### PR TITLE
Fix litellm APIConnectionError for Ollama models

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ def configure_dspy(model_name: str, api_base: str = None, api_key: str = None):
         else:
             kwargs["api_key"] = env_key
     elif "ollama" in model_name.lower():
-        kwargs["api_key"] = "" # Ollama typically doesn't need an API key
+        pass # Ollama typically doesn't need an API key
 
     console.print(f"[italic]Configuring DSPy to use model '{model_name}'...[/italic]")
     lm = dspy.LM(model_name, **kwargs)

--- a/test_dspy_ollama.py
+++ b/test_dspy_ollama.py
@@ -1,0 +1,13 @@
+import litellm
+import traceback
+
+try:
+    response = litellm.completion(
+        model="ollama/qwen3",
+        messages=[{"role": "user", "content": "Hello"}],
+        api_base="http://localhost:11434",
+        api_key=""
+    )
+    print(response)
+except Exception as e:
+    traceback.print_exc()

--- a/test_story.py
+++ b/test_story.py
@@ -14,8 +14,19 @@ class MockLM(dspy.LM):
     def __init__(self):
         super().__init__(model="mock")
 
-    def __call__(self, prompt, **kwargs):
-        return ["Mock response"]
+    def __call__(self, prompt=None, messages=None, **kwargs):
+        # We need to return JSON since dspy expects it
+        return ["""```json
+{
+  "questions_with_answers": [{"question": "q", "proposed_answer": "a"}],
+  "core_premise": "core",
+  "spine_template": "spine",
+  "world_bible": "world",
+  "arc_outline": "arc",
+  "chapter_plan": "chapter",
+  "scenes": "scenes"
+}
+```"""]
 
 def test_pipeline(model_name="ollama_chat/llama3", api_base="http://localhost:11434", api_key=None):
     kwargs = {"max_tokens": 1000}
@@ -29,7 +40,8 @@ def test_pipeline(model_name="ollama_chat/llama3", api_base="http://localhost:11
         if env_key:
             kwargs["api_key"] = env_key
     elif "ollama" in model_name.lower():
-        kwargs["api_key"] = ""
+        # litellm requires api_key to not be empty string or None for some providers, but actually for ollama we can just pass none but without api_key=""
+        pass
 
     print(f"Testing pipeline with model: {model_name}...")
 
@@ -38,7 +50,10 @@ def test_pipeline(model_name="ollama_chat/llama3", api_base="http://localhost:11
         print("OPENAI_API_KEY not found. Skipping full integration test to avoid errors.")
         return
 
-    lm = dspy.LM(model_name, **kwargs)
+    if model_name == "mock":
+        lm = MockLM()
+    else:
+        lm = dspy.LM(model_name, **kwargs)
     dspy.configure(lm=lm)
 
     idea = "A story about a space pirate who finds a map to the center of the universe."


### PR DESCRIPTION
When running `test_story.py` or `main.py` with an Ollama model, setting `api_key=""` caused `litellm` (via DSPy) to construct an invalid `Authorization: Bearer ` HTTP header, leading to an `httpx` `Illegal header value` exception. This PR simply removes the empty string assignment for the `api_key` argument when configuring the Ollama model, resolving the crash. Additionally, `MockLM` was updated to return valid JSON so that `dspy` serialization checks pass when running mock tests.

---
*PR created automatically by Jules for task [18169167721054185267](https://jules.google.com/task/18169167721054185267) started by @ironharvy*