### PR TITLE
Add Story Enhancers evaluation step

### DIFF
--- a/main.py
+++ b/main.py
@@ -139,6 +139,9 @@ def main():
     console.print("\n[bold red]--- Level 2: Chapter Plan ---[/bold red]")
     console.print(story_result.chapter_plan)
 
+    console.print("\n[bold red]--- Enhancers Guide ---[/bold red]")
+    console.print(story_result.enhancers_guide)
+
     console.print("\n[bold red]--- Final Story ---[/bold red]")
     console.print(story_result.story)
 
@@ -157,6 +160,8 @@ def main():
         f.write(f"{story_result.arc_outline}\n\n")
         f.write("## Chapter Plan\n")
         f.write(f"{story_result.chapter_plan}\n\n")
+        f.write("## Enhancers Guide\n")
+        f.write(f"{story_result.enhancers_guide}\n\n")
         f.write("## Final Story\n")
         f.write(f"{story_result.story}\n")
 

--- a/story_modules.py
+++ b/story_modules.py
@@ -93,10 +93,18 @@ class GenerateChapterPlanSignature(dspy.Signature):
     arc_outline: str = dspy.InputField(desc="Level 1: Arc Outline (5-10 major events).")
     chapter_plan: str = dspy.OutputField(desc="Level 2: Chapter Plan (Each arc broken into chapters).")
 
+class GenerateEnhancersSignature(dspy.Signature):
+    """Evaluates the chapter plan and determines which story enhancers are needed for specific scenes/chapters.
+    Story Enhancers include: Tension Module, Mystery Module, Theme Alignment, Setup/Payoff Tracker, Emotional Curve, Twist Generator, Easter Egg Injector."""
+    world_bible: str = dspy.InputField(desc="The comprehensive World Bible.")
+    chapter_plan: str = dspy.InputField(desc="Level 2: Chapter Plan (Each arc broken into chapters).")
+    enhancers_guide: str = dspy.OutputField(desc="A guide evaluating which story enhancers (e.g., Tension, Mystery, Twists) are needed for specific scenes or chapters and how to apply them.")
+
 class GenerateStorySignature(dspy.Signature):
     """Generates the final Story."""
     world_bible: str = dspy.InputField(desc="The comprehensive World Bible.")
     chapter_plan: str = dspy.InputField(desc="Level 2: Chapter Plan (Each arc broken into chapters).")
+    enhancers_guide: str = dspy.InputField(desc="Guide on how to apply story enhancers to specific scenes.")
     story: str = dspy.OutputField(desc="The final generated story.")
 
 class StoryGenerator(dspy.Module):
@@ -104,6 +112,7 @@ class StoryGenerator(dspy.Module):
         super().__init__()
         self.generate_arc_outline = dspy.Predict(GenerateArcOutlineSignature)
         self.generate_chapter_plan = dspy.Predict(GenerateChapterPlanSignature)
+        self.generate_enhancers = dspy.Predict(GenerateEnhancersSignature)
         self.generate_story = dspy.Predict(GenerateStorySignature)
 
     def forward(self, core_premise: str, spine_template: str, world_bible: str):
@@ -117,13 +126,19 @@ class StoryGenerator(dspy.Module):
             world_bible=world_bible,
             arc_outline=arc_outline_result.arc_outline
         )
-        story_result = self.generate_story(
+        enhancers_result = self.generate_enhancers(
             world_bible=world_bible,
             chapter_plan=chapter_plan_result.chapter_plan
+        )
+        story_result = self.generate_story(
+            world_bible=world_bible,
+            chapter_plan=chapter_plan_result.chapter_plan,
+            enhancers_guide=enhancers_result.enhancers_guide
         )
 
         return dspy.Prediction(
             arc_outline=arc_outline_result.arc_outline,
             chapter_plan=chapter_plan_result.chapter_plan,
+            enhancers_guide=enhancers_result.enhancers_guide,
             story=story_result.story
         )

--- a/test_story.py
+++ b/test_story.py
@@ -33,6 +33,8 @@ class MockLM(dspy.LM):
         # We can also just look at the last fields being asked for
         if "[[ ## story ## ]]" in content or ('"story"' in content and "The final generated story" in content):
             return ['```json\n{"story": "Mock final story"}\n```']
+        if "[[ ## enhancers_guide ## ]]" in content or ('"enhancers_guide"' in content and "evaluating which story enhancers" in content):
+            return ['```json\n{"enhancers_guide": "Mock enhancers guide"}\n```']
         if "[[ ## chapter_plan ## ]]" in content or ('"chapter_plan"' in content and "Each arc broken into chapters" in content):
             return ['```json\n{"chapter_plan": "Mock chapter plan"}\n```']
         if "[[ ## arc_outline ## ]]" in content or ('"arc_outline"' in content and "5-10 major events" in content):
@@ -55,8 +57,10 @@ class MockLM(dspy.LM):
             return ['```json\n{"world_bible": "Mock world bible"}\n```']
         elif "arc_outline" in content and "chapter_plan" not in content:
             return ['```json\n{"arc_outline": "Mock arc outline"}\n```']
-        elif "chapter_plan" in content and "story" not in content:
+        elif "chapter_plan" in content and "enhancers_guide" not in content and "story" not in content:
             return ['```json\n{"chapter_plan": "Mock chapter plan"}\n```']
+        elif "enhancers_guide" in content and "story" not in content:
+            return ['```json\n{"enhancers_guide": "Mock enhancers guide"}\n```']
         elif "story" in content:
             return ['```json\n{"story": "Mock final story"}\n```']
         return ["Mock response"]


### PR DESCRIPTION
Resolves issue where LLM was not dynamically adding "Story Enhancers" (like tension modules, emotional curves, and mystery modules) to the generated story. Added a new step in the DSPy pipeline to generate an `enhancers_guide` before generating the final story, allowing the LLM to plan where to apply these enhancers.

---
*PR created automatically by Jules for task [15158756127936088176](https://jules.google.com/task/15158756127936088176) started by @ironharvy*