### PR TITLE
Iterative chapter generation

### DIFF
--- a/story_modules.py
+++ b/story_modules.py
@@ -100,12 +100,13 @@ class GenerateEnhancersSignature(dspy.Signature):
     chapter_plan: str = dspy.InputField(desc="Level 2: Chapter Plan (Each arc broken into chapters).")
     enhancers_guide: str = dspy.OutputField(desc="A guide evaluating which story enhancers (e.g., Tension, Mystery, Twists) are needed for specific scenes or chapters and how to apply them.")
 
-class GenerateStorySignature(dspy.Signature):
-    """Generates the final Story."""
-    world_bible: str = dspy.InputField(desc="The comprehensive World Bible.")
-    chapter_plan: str = dspy.InputField(desc="Level 2: Chapter Plan (Each arc broken into chapters).")
-    enhancers_guide: str = dspy.InputField(desc="Guide on how to apply story enhancers to specific scenes.")
-    story: str = dspy.OutputField(desc="The final generated story.")
+class GenerateSingleChapterSignature(dspy.Signature):
+    """Writes a full, detailed chapter based on the world bible and the specific chapter goal."""
+    world_bible: str = dspy.InputField()
+    chapter_plan: str = dspy.InputField(desc="The full plan for context.")
+    current_chapter_description: str = dspy.InputField(desc="The specific event to write now.")
+    previous_chapters_summary: str = dspy.InputField(desc="Brief summary of what happened so far.")
+    chapter_text: str = dspy.OutputField(desc="A long, immersive chapter with dialogue and description.")
 
 class StoryGenerator(dspy.Module):
     def __init__(self):
@@ -113,7 +114,7 @@ class StoryGenerator(dspy.Module):
         self.generate_arc_outline = dspy.Predict(GenerateArcOutlineSignature)
         self.generate_chapter_plan = dspy.Predict(GenerateChapterPlanSignature)
         self.generate_enhancers = dspy.Predict(GenerateEnhancersSignature)
-        self.generate_story = dspy.Predict(GenerateStorySignature)
+        self.write_chapter = dspy.ChainOfThought(GenerateSingleChapterSignature)
 
     def forward(self, core_premise: str, spine_template: str, world_bible: str):
         arc_outline_result = self.generate_arc_outline(
@@ -130,15 +131,27 @@ class StoryGenerator(dspy.Module):
             world_bible=world_bible,
             chapter_plan=chapter_plan_result.chapter_plan
         )
-        story_result = self.generate_story(
-            world_bible=world_bible,
-            chapter_plan=chapter_plan_result.chapter_plan,
-            enhancers_guide=enhancers_result.enhancers_guide
-        )
+
+        chapters_to_write = [line.strip() for line in chapter_plan_result.chapter_plan.split('\n') if line.strip()]
+
+        full_story = ""
+        previous_chapters_summary = ""
+
+        for i, chapter_desc in enumerate(chapters_to_write):
+            result = self.write_chapter(
+                world_bible=world_bible,
+                chapter_plan=chapter_plan_result.chapter_plan,
+                current_chapter_description=chapter_desc,
+                previous_chapters_summary=previous_chapters_summary
+            )
+
+            chapter_text = result.chapter_text
+            full_story += f"\n\n### Chapter {i+1}\n\n" + chapter_text
+            previous_chapters_summary += f"Chapter {i+1}: {chapter_desc}\n"
 
         return dspy.Prediction(
             arc_outline=arc_outline_result.arc_outline,
             chapter_plan=chapter_plan_result.chapter_plan,
             enhancers_guide=enhancers_result.enhancers_guide,
-            story=story_result.story
+            story=full_story.strip()
         )

--- a/test_story.py
+++ b/test_story.py
@@ -31,6 +31,8 @@ class MockLM(dspy.LM):
         # e.g., "This JSON object must only contain the following keys: chapter_plan."
 
         # We can also just look at the last fields being asked for
+        if "[[ ## chapter_text ## ]]" in content or ('"chapter_text"' in content and "immersive chapter" in content):
+            return ['```json\n{"reasoning": "Mock reasoning", "chapter_text": "Mock chapter text"}\n```']
         if "[[ ## story ## ]]" in content or ('"story"' in content and "The final generated story" in content):
             return ['```json\n{"story": "Mock final story"}\n```']
         if "[[ ## enhancers_guide ## ]]" in content or ('"enhancers_guide"' in content and "evaluating which story enhancers" in content):
@@ -59,8 +61,10 @@ class MockLM(dspy.LM):
             return ['```json\n{"arc_outline": "Mock arc outline"}\n```']
         elif "chapter_plan" in content and "enhancers_guide" not in content and "story" not in content:
             return ['```json\n{"chapter_plan": "Mock chapter plan"}\n```']
-        elif "enhancers_guide" in content and "story" not in content:
+        elif "enhancers_guide" in content and "story" not in content and "chapter_text" not in content:
             return ['```json\n{"enhancers_guide": "Mock enhancers guide"}\n```']
+        elif "chapter_text" in content:
+            return ['```json\n{"reasoning": "Mock reasoning", "chapter_text": "Mock chapter text"}\n```']
         elif "story" in content:
             return ['```json\n{"story": "Mock final story"}\n```']
         return ["Mock response"]


### PR DESCRIPTION
Refactored the story generation pipeline to generate the story iteratively, chapter over chapter, based on the provided chapter plan. This allows for more detailed, focused chapter writing by providing context of previous chapters and the specific current chapter goal, instead of generating the entire story at once. Included an update to the testing module (`test_story.py`) to correctly mock the new `ChainOfThought` structure.

---
*PR created automatically by Jules for task [17457969125052917636](https://jules.google.com/task/17457969125052917636) started by @ironharvy*