### PR TITLE
Normalize QuestionWithAnswer keys and add unit tests for key handling

### DIFF
--- a/story_modules.py
+++ b/story_modules.py
@@ -10,25 +10,38 @@ class QuestionWithAnswer(BaseModel):
     @model_validator(mode='before')
     @classmethod
     def fix_keys(cls, data: Any) -> Any:
-        if isinstance(data, dict):
-            # If the model gives something like {'': 'Question text'}
-            if 'question' not in data:
-                # First try to find a key that is likely the question
-                if '' in data:
-                    data['question'] = data.pop('')
-                else:
-                    # just take the first key that isn't proposed_answer
-                    for k in list(data.keys()):
-                        if k != 'proposed_answer' and k != 'question':
-                            data['question'] = data.pop(k)
-                            break
+        if not isinstance(data, dict):
+            return data
 
-            if 'proposed_answer' not in data:
-                for k in list(data.keys()):
-                    if k != 'question' and k != 'proposed_answer':
-                        data['proposed_answer'] = data.pop(k)
+        normalized = dict(data)
+
+        def normalize_key(key: str) -> str:
+            return ''.join(ch for ch in key.lower() if ch.isalnum())
+
+        question_aliases = {"question", "q", "prompt", "query"}
+        answer_aliases = {"proposedanswer", "answer", "response", "a"}
+
+        # Preserve already-correct keys first.
+        if "question" not in normalized:
+            if "" in normalized and isinstance(normalized[""], str):
+                normalized["question"] = normalized.pop("")
+            else:
+                for key in list(normalized.keys()):
+                    if key in {"question", "proposed_answer"}:
+                        continue
+                    if normalize_key(key) in question_aliases and isinstance(normalized[key], str):
+                        normalized["question"] = normalized.pop(key)
                         break
-        return data
+
+        if "proposed_answer" not in normalized:
+            for key in list(normalized.keys()):
+                if key in {"question", "proposed_answer"}:
+                    continue
+                if normalize_key(key) in answer_aliases and isinstance(normalized[key], str):
+                    normalized["proposed_answer"] = normalized.pop(key)
+                    break
+
+        return normalized
 
 class GenerateQuestionsSignature(dspy.Signature):
     """Generates 5 interrogative questions to interrogate the user's idea to generate a 'Core Premise'. Each question must include a proposed answer."""

--- a/test_story.py
+++ b/test_story.py
@@ -3,11 +3,13 @@ import os
 import argparse
 from story_modules import (
     QuestionGenerator,
+    QuestionWithAnswer,
     CorePremiseGenerator,
     SpineTemplateGenerator,
     WorldBibleGenerator,
     StoryGenerator
 )
+import pytest
 
 # A mock LM to avoid needing an API key for automated testing
 class MockLM(dspy.LM):
@@ -69,7 +71,7 @@ class MockLM(dspy.LM):
             return ['```json\n{"story": "Mock final story"}\n```']
         return ["Mock response"]
 
-def test_pipeline(model_name="ollama_chat/llama3", api_base="http://localhost:11434", api_key=None):
+def test_pipeline(model_name="mock", api_base="http://localhost:11434", api_key=None):
     kwargs = {"max_tokens": 1000}
     if api_base:
         kwargs["api_base"] = api_base
@@ -132,6 +134,24 @@ def test_pipeline(model_name="ollama_chat/llama3", api_base="http://localhost:11
     story_result = story_gen(core_premise=cp_result.core_premise, spine_template=st_result.spine_template, world_bible=wb_result.world_bible)
     print("Story generated.")
     print("Test passed successfully!")
+
+
+@pytest.mark.parametrize(
+    "payload,expected",
+    [
+        ({"": "Who is the hero?", "proposed_answer": "Kai"}, {"question": "Who is the hero?", "proposed_answer": "Kai"}),
+        ({"question": "Where?", "answer": "Mars"}, {"question": "Where?", "proposed_answer": "Mars"}),
+        ({"query": "When?", "response": "At dawn"}, {"question": "When?", "proposed_answer": "At dawn"}),
+    ],
+)
+def test_question_with_answer_key_normalization(payload, expected):
+    result = QuestionWithAnswer.model_validate(payload)
+    assert result.model_dump() == expected
+
+
+def test_question_with_answer_does_not_promote_unrelated_fields():
+    with pytest.raises(Exception):
+        QuestionWithAnswer.model_validate({"question": "Why?", "confidence": 0.92})
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Test AI DSPy Story Writer")


### PR DESCRIPTION
### Motivation
- Accept varied key names produced by LMs and adapters (e.g., `q`, `prompt`, `answer`, empty-string keys) and reliably map them into the `QuestionWithAnswer` model fields. 
- Avoid inadvertently promoting unrelated fields into `question`/`proposed_answer` when normalizing input data. 
- Make the test suite deterministic in CI by defaulting to a `mock` LM and adding unit tests for normalization behavior.

### Description
- Rewrote the `QuestionWithAnswer.fix_keys` validator to return early for non-dict input, operate on a copy, and normalize keys using `normalize_key`, plus alias sets for question and answer fields. 
- The new logic preserves already-correct keys, accepts empty-string keyed questions, and maps common aliases (`q`, `prompt`, `query`, `answer`, `response`, `a`) to `question` and `proposed_answer`. 
- Updated `test_story.py` to import `QuestionWithAnswer` and `pytest`, set the default `test_pipeline` model to `mock`, and added `test_question_with_answer_key_normalization` and `test_question_with_answer_does_not_promote_unrelated_fields` unit tests.

### Testing
- Ran the test suite with `pytest`, including the new `test_question_with_answer_key_normalization` parameterized cases, and they passed. 
- Ran the negative test `test_question_with_answer_does_not_promote_unrelated_fields` which asserted that unrelated fields are not promoted, and it passed. 
- Executed the end-to-end `test_pipeline` with the `mock` LM to ensure downstream generators still run under the mock environment, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd672282948328b0313d9350eeae6c)