### PR TITLE
Add GitHub Actions CI workflow to run Ruff and pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run Ruff lint
+        run: ruff check .
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run tests
+        run: pytest -q

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest
+ruff


### PR DESCRIPTION
### Motivation
- Add a CI workflow to run linting and tests automatically on pushes and pull requests using Python 3.11.

### Description
- Add `.github/workflows/ci.yml` to run `ruff check .` and `pytest -q` on `push` to `main` and `pull_request`, using `actions/checkout@v4` and `actions/setup-python@v5` with pip caching and dependency installation from `requirements-dev.txt`.
- Add `requirements-dev.txt` that references `-r requirements.txt` and includes `pytest` and `ruff`.

### Testing
- No automated tests were executed as part of this change, but the CI is configured to run `ruff check .` and `pytest -q` when workflows are triggered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd7d0ef13c83289f7abad875ce5572)