### PR TITLE
Add comprehensive logging and improve chapter title handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 .env
 .gitignore
 images/
+.logs/

--- a/main.py
+++ b/main.py
@@ -26,6 +26,30 @@ coloredlogs.install(level='INFO')
 
 console = Console()
 
+
+def setup_logging():
+    """Configure file logging for DSPy and application into .logs/ folder."""
+    log_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".logs")
+    os.makedirs(log_dir, exist_ok=True)
+
+    log_file = os.path.join(log_dir, "story_writer.log")
+    file_handler = logging.FileHandler(log_file, mode="a", encoding="utf-8")
+    file_handler.setLevel(logging.DEBUG)
+    file_handler.setFormatter(
+        logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
+    )
+
+    # Root logger so we capture DSPy internals too
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG)
+    root.addHandler(file_handler)
+
+    # Also capture dspy specifically at DEBUG
+    for name in ("dspy", "dspy.adapters", "dspy.clients"):
+        logging.getLogger(name).setLevel(logging.DEBUG)
+
+    logger.info("Logging initialised – file: %s", log_file)
+
 def configure_dspy(model_name: str, api_base: str = None, api_key: str = None, max_tokens: int = 2000):
     kwargs = {}
     if api_base:
@@ -74,6 +98,7 @@ def main():
 
     args = parser.parse_args()
 
+    setup_logging()
     configure_dspy(model_name=args.model, api_base=args.llm_url, api_key=args.api_key, max_tokens=args.max_tokens)
 
     console.print("[bold magenta]Welcome to the AI DSPy Story Writer![/bold magenta]")

--- a/story_modules.py
+++ b/story_modules.py
@@ -1,10 +1,17 @@
 import dspy
 import logging
+import re
 from typing import List
 from pydantic import BaseModel, Field, model_validator
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+# Regex to strip leading "Chapter <number>:" / "Chapter <number> -" from LLM-generated titles
+_chapter_prefix_re = re.compile(
+    r'^(chapter\s+\d+\s*[:\-\.]\s*)',
+    re.IGNORECASE,
+)
 
 class QuestionWithAnswer(BaseModel):
     question: str = Field(description="The interrogative question.")
@@ -217,7 +224,6 @@ class StoryGenerator(dspy.Module):
         # we only write actual chapter entries.  Arc headers are structural
         # groupings in the chapter plan and should not be expanded into their
         # own chapters—doing so produces semi-duplicate content.
-        import re
         _arc_header_re = re.compile(
             r'^[\s\*\#]*(arc)\s*\d*\s*[:\-\.]',
             re.IGNORECASE,
@@ -242,11 +248,21 @@ class StoryGenerator(dspy.Module):
                 )
 
                 chapter_text = result.chapter_text
-                full_story += f"\n\n### Chapter {i+1}: {result.title}\n\n" + chapter_text
+                # Strip redundant "Chapter N:" prefix the LLM sometimes adds
+                clean_title = _chapter_prefix_re.sub('', result.title).strip()
+                full_story += f"\n\n### Chapter {i+1}: {clean_title}\n\n" + chapter_text
                 previous_chapters_summary += f"Chapter {i+1}: {chapter_desc}\n"
             except Exception as e:
-                logger.error(f"Error writing chapter {i+1}: {e}")
-                break
+                logger.error(f"Error writing chapter {i+1}: {e}", exc_info=True)
+                continue
+
+        if not full_story.strip():
+            logger.warning(
+                "Story generation produced no chapter content. "
+                "chapters_to_write=%d, chapter_plan excerpt=%.500s",
+                len(chapters_to_write),
+                chapter_plan_result.chapter_plan,
+            )
 
         return dspy.Prediction(
             arc_outline=arc_outline_result.arc_outline,

--- a/test_story.py
+++ b/test_story.py
@@ -235,6 +235,23 @@ def test_question_with_answer_key_normalization(payload, expected):
     assert result.model_dump() == expected
 
 
+@pytest.mark.parametrize(
+    "raw_title,expected_clean",
+    [
+        ("Chapter 1: The Awakening", "The Awakening"),
+        ("Chapter 12 - Descent", "Descent"),
+        ("chapter 3: rising dawn", "rising dawn"),
+        ("Chapter 1. First Light", "First Light"),
+        ("The Awakening", "The Awakening"),           # no prefix – unchanged
+        ("Chapter One: Narrative", "Chapter One: Narrative"),  # spelled-out number – unchanged
+    ],
+)
+def test_chapter_title_prefix_stripping(raw_title, expected_clean):
+    from story_modules import _chapter_prefix_re
+    clean = _chapter_prefix_re.sub('', raw_title).strip()
+    assert clean == expected_clean
+
+
 def test_question_with_answer_does_not_promote_unrelated_fields():
     with pytest.raises(Exception):
         QuestionWithAnswer.model_validate({"question": "Why?", "confidence": 0.92})


### PR DESCRIPTION
## Summary
This PR enhances the application with file-based logging capabilities and improves the robustness of chapter title processing by stripping redundant prefixes that the LLM sometimes generates.

## Key Changes

- **Logging Infrastructure**: Added `setup_logging()` function that configures file-based logging to `.logs/story_writer.log` with DEBUG level, capturing both application and DSPy internal logs
  - Logging is initialized at application startup in `main()`
  - Root logger and DSPy-specific loggers are configured to capture detailed debug information

- **Chapter Title Cleaning**: Implemented regex-based prefix stripping to handle LLM-generated chapter titles
  - Added `_chapter_prefix_re` regex pattern to match and remove "Chapter N:" / "Chapter N -" / "Chapter N." prefixes (case-insensitive)
  - Applied cleaning in `StoryWriter.forward()` when constructing the final story output
  - Prevents duplicate chapter numbering in the output (e.g., "### Chapter 1: Chapter 1: The Awakening" → "### Chapter 1: The Awakening")

- **Error Handling Improvements**: Enhanced error handling in chapter generation
  - Changed exception handling from `break` to `continue` to allow partial story generation if individual chapters fail
  - Added `exc_info=True` to error logging for better debugging
  - Added warning log when story generation produces no chapter content, including diagnostic information

- **Testing**: Added comprehensive test cases for chapter title prefix stripping with various formats and edge cases

- **Gitignore**: Added `.logs/` directory to gitignore to prevent logging artifacts from being committed

## Implementation Details

The chapter title regex pattern handles numeric chapter numbers followed by colons, hyphens, or periods, making the solution robust to different LLM output formats while preserving intentional chapter titles that don't follow the standard prefix pattern.

https://claude.ai/code/session_01Au8n6Z6mKiyN1eu5GA8rie