### PR TITLE
Fix #33: postprocessing: preserve leading punctuation in normalized sentences

### DIFF
--- a/postprocessing.py
+++ b/postprocessing.py
@@ -13,13 +13,28 @@ logger = logging.getLogger(__name__)
 # Sentence-ending punctuation pattern
 _SENTENCE_SPLIT_RE = re.compile(r'(?<=[.!?])\s+')
 
-# Markdown artifacts to strip before comparison
-_MARKDOWN_NOISE_RE = re.compile(r'^[\s#*_>\-\d.]+')
+# Markdown/list artifacts to strip before comparison.
+# Each pattern targets a specific construct so that meaningful opening
+# punctuation (quotes, parentheses, etc.) is never consumed.
+_MARKDOWN_NOISE_RES = [
+    re.compile(r'^\s*#{1,6}\s+'),   # headings:  ## Foo
+    re.compile(r'^\s*[-*]\s+'),     # unordered list markers:  - Foo / * Foo
+    re.compile(r'^\s*\d+\.\s+'),    # ordered list markers:  1. Foo
+    re.compile(r'^\s*>\s*'),        # blockquotes:  > Foo
+    re.compile(r'^\s*[_*]{1,3}(?=[A-Za-z"\'])'),  # leading emphasis: _Foo / **Foo
+]
 
 
 def _normalize(sentence: str) -> str:
-    """Lowercase, strip markdown noise and extra whitespace for comparison."""
-    s = _MARKDOWN_NOISE_RE.sub('', sentence)
+    """Lowercase, strip markdown noise and extra whitespace for comparison.
+
+    Meaningful leading punctuation (opening quotes, parentheses, etc.) is
+    preserved so that similarity matching remains faithful to the prose.
+    """
+    s = sentence
+    for pat in _MARKDOWN_NOISE_RES:
+        s = pat.sub('', s)
+    s = s.strip()
     return ' '.join(s.lower().split())
 
 

--- a/test_postprocessing.py
+++ b/test_postprocessing.py
@@ -1,4 +1,4 @@
-from postprocessing import extract_sentences, find_similar_sentences, format_report
+from postprocessing import _normalize, extract_sentences, find_similar_sentences, format_report
 
 
 SAMPLE_STORY = (
@@ -7,6 +7,31 @@ SAMPLE_STORY = (
     "She drew her sword and advanced carefully. The air smelled of pine and damp earth. "
     "She drew her sword and moved forward carefully. Nothing stirred in the underbrush."
 )
+
+
+def test_normalize_preserves_leading_quote():
+    assert _normalize('"Hello there," she said warmly') == '"hello there," she said warmly'
+
+
+def test_normalize_preserves_leading_parenthesis():
+    assert _normalize("(Whispering) she crept forward") == "(whispering) she crept forward"
+
+
+def test_normalize_strips_markdown_heading():
+    assert _normalize("## The Grand Adventure") == "the grand adventure"
+
+
+def test_normalize_strips_unordered_list_marker():
+    assert _normalize("- item one goes here") == "item one goes here"
+    assert _normalize("* item two goes here") == "item two goes here"
+
+
+def test_normalize_strips_ordered_list_marker():
+    assert _normalize("1. first ordered item") == "first ordered item"
+
+
+def test_normalize_strips_blockquote():
+    assert _normalize("> quoted text here") == "quoted text here"
 
 
 def test_extract_sentences_filters_short_fragments():


### PR DESCRIPTION
Automated implementation for #33.

## Issue description

In postprocessing._normalize, the regex currently strips leading punctuation and list/markdown markers.
That accidentally removes opening quotes/parentheses from sentences, which can reduce matching quality and make reports less faithful.

Requested change
Update normalization so markdown/list artifacts are removed, but meaningful opening punctuation in prose is preserved.
Keep behavior for headings/list markers intact.
Add/adjust tests in test_postprocessing.py to cover:
leading quote sentence ("Hello there...")
leading parenthesis sentence ((Whispering) ...)
markdown heading/list noise still handled as before.
Acceptance criteria
pytest -q test_postprocessing.py passes.
Existing duplicate/similarity detection tests continue to pass.
No changes outside postprocessing.py and test_postprocessing.py unless necessary.

## Changes

```
postprocessing.py      | 23 +++++++++++++++++++----
 test_postprocessing.py | 27 ++++++++++++++++++++++++++-
 2 files changed, 45 insertions(+), 5 deletions(-)
```

**Labels:** `codex`, `aiorchestra`

Closes #33