### PR TITLE
Add optional chapter inpainting post-pass

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from story_modules import (
     CorePremiseGenerator,
     SpineTemplateGenerator,
     StoryGenerator,
+    ChapterInpaintingGenerator,
     CharacterVisualDescriber,
     SceneImagePromptGenerator,
 )
@@ -97,6 +98,7 @@ def initialize_text_generators(
         "WorldBibleQuestionGenerator": WorldBibleQuestionGenerator(),
         "WorldBibleGenerator": WorldBibleGenerator(),
         "StoryGenerator": StoryGenerator(),
+        "ChapterInpaintingGenerator": ChapterInpaintingGenerator(),
     }
 
     if use_optimized:
@@ -174,6 +176,18 @@ def main():
         default=0.65,
         help="Similarity threshold (0-1) for flagging sentence pairs (default: 0.65).",
     )
+    parser.add_argument(
+        "--inpaint-chapters",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Run a post-generation chapter expansion pass for richer detail (default: disabled).",
+    )
+    parser.add_argument(
+        "--inpaint-ratio",
+        type=float,
+        default=1.35,
+        help="Target chapter expansion ratio for inpainting (must be > 1.0, default: 1.35).",
+    )
 
     args = parser.parse_args()
 
@@ -203,6 +217,7 @@ def main():
     st_gen = generators["SpineTemplateGenerator"]
     wb_gen = generators["WorldBibleGenerator"]
     story_gen = generators["StoryGenerator"]
+    chapter_inpainting_gen = generators["ChapterInpaintingGenerator"]
 
     core_premise = ""
     while True:
@@ -313,13 +328,34 @@ def main():
     console.print("\n[bold red]--- Final Story ---[/bold red]")
     console.print(story_result.story)
 
+    final_story_text = story_result.story
+    if args.inpaint_chapters:
+        if args.inpaint_ratio <= 1.0:
+            parser.error("--inpaint-ratio must be greater than 1.0")
+
+        console.print("\n[italic]Running chapter inpainting pass...[/italic]")
+        inpaint_result = chapter_inpainting_gen(
+            story=story_result.story,
+            world_bible=world_bible,
+            chapter_plan=story_result.chapter_plan,
+            expansion_ratio=args.inpaint_ratio,
+        )
+        final_story_text = inpaint_result.story
+
+        console.print(
+            "[italic]Chapter inpainting complete "
+            f"({inpaint_result.expanded_chapters}/{inpaint_result.total_chapters} chapters expanded).[/italic]"
+        )
+        console.print("\n[bold red]--- Inpainted Story ---[/bold red]")
+        console.print(final_story_text)
+
     # 9. Generate scene illustrations for each chapter (if images enabled)
     scene_image_paths = {}
     if args.enable_images and image_gen:
         console.print("\n[italic]Generating scene illustrations for each chapter...[/italic]")
         scene_prompt_gen = SceneImagePromptGenerator()
 
-        chapters = story_result.story.split("### Chapter ")
+        chapters = final_story_text.split("### Chapter ")
         chapters = [c for c in chapters if c.strip()]
 
         reference_paths = list(character_portrait_paths.values())
@@ -344,7 +380,7 @@ def main():
     if args.check_similar:
         console.print("\n[bold yellow]--- Similar Sentence Check ---[/bold yellow]")
         similar_pairs = find_similar_sentences(
-            story_result.story, threshold=args.similar_threshold,
+            final_story_text, threshold=args.similar_threshold,
         )
         report = format_report(similar_pairs)
         console.print(report)
@@ -386,7 +422,7 @@ def main():
         f.write("## Final Story\n")
 
         if scene_image_paths:
-            chapters = story_result.story.split("### Chapter ")
+            chapters = final_story_text.split("### Chapter ")
             chapters = [c for c in chapters if c.strip()]
             for i, chapter_text in enumerate(chapters, start=1):
                 f.write(f"\n\n### Chapter {chapter_text}")
@@ -394,7 +430,7 @@ def main():
                 if scene:
                     f.write(f"\n\n![Chapter {i} scene]({scene})\n")
         else:
-            f.write(f"{story_result.story}\n")
+            f.write(f"{final_story_text}\n")
 
     console.print(f"\n[bold magenta]Story generation complete! Results saved to {output_filename}[/bold magenta]")
 

--- a/story_modules.py
+++ b/story_modules.py
@@ -2,9 +2,8 @@ import dspy
 import logging
 import random
 import re
-from typing import List
+from typing import Any, List
 from pydantic import BaseModel, Field, model_validator
-from typing import Any
 from _compat import observe
 
 # Probability that a chapter receives a random creative flourish (0.0 – 1.0).
@@ -18,6 +17,8 @@ _RANDOM_DETAIL_TYPES = [
     "an unusual yet revealing character habit, nervous tic, or physical detail",
     "a brief, surprising background element that enriches the world without derailing the plot",
 ]
+
+_chapter_heading_re = re.compile(r"^###\s+Chapter\s+\d+:.*$", re.MULTILINE)
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +56,34 @@ def _normalize_chapter_plan_entries(chapters: list[str]) -> list[str]:
 
     logger.debug("Normalized chapter plan entries: %s", normalized)
     return normalized
+
+
+def _split_story_into_chapters(story_text: str) -> list[tuple[str, str]]:
+    chapter_matches = list(_chapter_heading_re.finditer(story_text or ""))
+    if not chapter_matches:
+        return []
+
+    chapters: list[tuple[str, str]] = []
+    for index, match in enumerate(chapter_matches):
+        body_start = match.end()
+        body_end = (
+            chapter_matches[index + 1].start()
+            if index + 1 < len(chapter_matches)
+            else len(story_text)
+        )
+        header = match.group(0).strip()
+        body = story_text[body_start:body_end].strip()
+        chapters.append((header, body))
+
+    return chapters
+
+
+def _compose_story_from_chapters(chapters: list[tuple[str, str]]) -> str:
+    chapter_blocks = [
+        f"{chapter_header}\n\n{chapter_body}".strip()
+        for chapter_header, chapter_body in chapters
+    ]
+    return "\n\n".join(chapter_blocks).strip()
 
 class QuestionWithAnswer(BaseModel):
     question: str = Field(description="The interrogative question.")
@@ -274,6 +303,89 @@ class GenerateSingleChapterSignature(dspy.Signature):
     random_detail: str = dspy.InputField(desc="An optional creative flourish to weave naturally into the chapter. Empty string means no special detail is required.")
     title: str = dspy.OutputField(desc="The title of the chapter.")
     chapter_text: str = dspy.OutputField(desc="A long, immersive chapter with dialogue and description.")
+
+
+class GenerateChapterInpaintingSignature(dspy.Signature):
+    """Expands an existing chapter with richer detail while preserving plot facts."""
+
+    world_bible: str = dspy.InputField(
+        desc="The comprehensive World Bible describing setting, rules, and characters.",
+    )
+    chapter_plan: str = dspy.InputField(
+        desc="The full chapter plan for continuity and pacing context.",
+    )
+    chapter_header: str = dspy.InputField(
+        desc="The chapter markdown header (e.g., '### Chapter 4: ...').",
+    )
+    chapter_text: str = dspy.InputField(
+        desc="The already-written chapter text to be expanded.",
+    )
+    expansion_ratio: float = dspy.InputField(
+        desc="Target expansion ratio. Add detail to approach this length multiplier without bloat.",
+    )
+    expanded_chapter_text: str = dspy.OutputField(
+        desc=(
+            "A more detailed chapter that preserves all major events, outcomes, and continuity. "
+            "Do not introduce major new plot points."
+        ),
+    )
+
+
+class ChapterInpaintingGenerator(dspy.Module):
+    def __init__(self):
+        super().__init__()
+        self.expand_chapter = dspy.ChainOfThought(GenerateChapterInpaintingSignature)
+
+    @observe()
+    def forward(
+        self,
+        story: str,
+        world_bible: str,
+        chapter_plan: str,
+        expansion_ratio: float = 1.35,
+    ):
+        if expansion_ratio <= 1.0:
+            raise ValueError(f"expansion_ratio must be > 1.0, got {expansion_ratio}")
+
+        chapters = _split_story_into_chapters(story)
+        if not chapters:
+            logger.warning("Chapter inpainting skipped: no chapter headings detected.")
+            return dspy.Prediction(
+                story=story,
+                expanded_chapters=0,
+                total_chapters=0,
+            )
+
+        expanded_chapters: list[tuple[str, str]] = []
+        expanded_count = 0
+        for chapter_header, chapter_text in chapters:
+            try:
+                result = self.expand_chapter(
+                    world_bible=world_bible,
+                    chapter_plan=chapter_plan,
+                    chapter_header=chapter_header,
+                    chapter_text=chapter_text,
+                    expansion_ratio=expansion_ratio,
+                )
+                expanded_chapter_text = result.expanded_chapter_text.strip()
+                if expanded_chapter_text:
+                    expanded_count += 1
+                    expanded_chapters.append((chapter_header, expanded_chapter_text))
+                else:
+                    expanded_chapters.append((chapter_header, chapter_text))
+            except Exception as exc:
+                logger.warning(
+                    "Chapter inpainting failed for %s: %s",
+                    chapter_header,
+                    exc,
+                )
+                expanded_chapters.append((chapter_header, chapter_text))
+
+        return dspy.Prediction(
+            story=_compose_story_from_chapters(expanded_chapters),
+            expanded_chapters=expanded_count,
+            total_chapters=len(chapters),
+        )
 
 class StoryGenerator(dspy.Module):
     def __init__(self, random_detail_probability: float = RANDOM_DETAIL_PROBABILITY):

--- a/test_story.py
+++ b/test_story.py
@@ -13,6 +13,7 @@ from story_modules import (
     CorePremiseGenerator,
     SpineTemplateGenerator,
     StoryGenerator,
+    ChapterInpaintingGenerator,
     CharacterVisualDescriber,
     SceneImagePromptGenerator,
 )
@@ -49,8 +50,13 @@ class MockLM(dspy.LM):
             return ['```json\n{"image_prompt": "anime scene, a warrior with short black hair and amber eyes standing in a dark cathedral, dramatic lighting"}\n```']
         if "[[ ## random_detail ## ]]" in content or ('"random_detail"' in content and "naturally woven" in content):
             return ['```json\n{"random_detail": "A small paper unicorn sat perched on the corner of the desk, its horn casting a faint shadow in the candlelight."}\n```']
-        if "[[ ## chapter_text ## ]]" in content or ('"chapter_text"' in content and "immersive chapter" in content):
+        if (
+            "[[ ## chapter_text ## ]]" in content
+            or ('"chapter_text"' in content and "immersive chapter" in content)
+        ) and '"expanded_chapter_text"' not in content:
             return ['```json\n{"reasoning": "Mock reasoning", "title": "Mock Title", "chapter_text": "Mock chapter text"}\n```']
+        if "[[ ## expanded_chapter_text ## ]]" in content or '"expanded_chapter_text"' in content:
+            return ['```json\n{"reasoning": "Mock reasoning", "expanded_chapter_text": "Mock expanded chapter text with richer detail and slower pacing."}\n```']
         if "[[ ## story ## ]]" in content or ('"story"' in content and "The final generated story" in content):
             return ['```json\n{"story": "Mock final story"}\n```']
         if "[[ ## enhancers_guide ## ]]" in content or ('"enhancers_guide"' in content and "evaluating which story enhancers" in content):
@@ -94,8 +100,10 @@ class MockLM(dspy.LM):
             return ['```json\n{"reasoning": "Mock reasoning", "chapter_plan": ["Chapter 1: Discovery", "Chapter 2: Training", "Chapter 3: Revelation", "Chapter 4: Escape"]}\n```']
         elif "enhancers_guide" in content and "story" not in content and "chapter_text" not in content:
             return ['```json\n{"reasoning": "Mock reasoning", "enhancers_guide": "Mock enhancers guide"}\n```']
-        elif "chapter_text" in content:
+        elif "chapter_text" in content and "expanded_chapter_text" not in content:
             return ['```json\n{"reasoning": "Mock reasoning", "title": "Mock Title", "chapter_text": "Mock chapter text"}\n```']
+        elif "expanded_chapter_text" in content:
+            return ['```json\n{"reasoning": "Mock reasoning", "expanded_chapter_text": "Mock expanded chapter text with richer detail and slower pacing."}\n```']
         elif "story" in content:
             return ['```json\n{"story": "Mock final story"}\n```']
         return ["Mock response"]
@@ -426,6 +434,7 @@ def test_initialize_text_generators_uses_loader_when_enabled():
         "WorldBibleQuestionGenerator",
         "WorldBibleGenerator",
         "StoryGenerator",
+        "ChapterInpaintingGenerator",
     }
     assert set(generators.keys()) == expected_module_names
     assert mocked_loader.call_count == len(expected_module_names)
@@ -436,7 +445,43 @@ def test_initialize_text_generators_skips_loader_when_disabled():
         generators = initialize_text_generators(use_optimized=False)
 
     assert "StoryGenerator" in generators
+    assert "ChapterInpaintingGenerator" in generators
     mocked_loader.assert_not_called()
+
+
+def test_chapter_inpainting_generator_expands_detected_chapters():
+    dspy.configure(lm=MockLM())
+    inpainting = ChapterInpaintingGenerator()
+    story = (
+        "### Chapter 1: Arrival\n\nThe caravan reached the city gates at dusk.\n\n"
+        "### Chapter 2: The Oath\n\nShe swore to protect the archive."
+    )
+
+    result = inpainting(
+        story=story,
+        world_bible="Mock world bible",
+        chapter_plan="Chapter 1: Arrival\nChapter 2: The Oath",
+        expansion_ratio=1.3,
+    )
+
+    assert result.total_chapters == 2
+    assert result.expanded_chapters == 2
+    assert "### Chapter 1: Arrival" in result.story
+    assert "### Chapter 2: The Oath" in result.story
+    assert "Mock expanded chapter text" in result.story
+
+
+def test_chapter_inpainting_generator_rejects_invalid_ratio():
+    dspy.configure(lm=MockLM())
+    inpainting = ChapterInpaintingGenerator()
+
+    with pytest.raises(ValueError, match="expansion_ratio must be > 1.0"):
+        inpainting(
+            story="### Chapter 1: Start\n\nShort text.",
+            world_bible="Mock world bible",
+            chapter_plan="Chapter 1: Start",
+            expansion_ratio=1.0,
+        )
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Test AI DSPy Story Writer")


### PR DESCRIPTION
## Summary
- add ChapterInpaintingGenerator to run a post-generation chapter expansion pass
- add chapter split/recompose helpers and inpainting signature in story_modules.py
- add CLI flags --inpaint-chapters and --inpaint-ratio in main.py
- run inpainting after initial story generation and use inpainted text for downstream image/similarity/output steps
- update tests for generator initialization and chapter inpainting behavior

## Testing
- .venv/bin/pytest -q test_story.py -k 'inpainting or initialize_text_generators'
- .venv/bin/python -m py_compile main.py story_modules.py test_story.py
