### PR TITLE
Extract headless engine from CLI with data contracts and prompter abstraction

### DIFF
--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -3,26 +3,33 @@
 This package decouples the story generation pipeline from the interactive CLI
 so that it can run inside web workers, tests, or other non-TTY contexts.
 
-Initial scope (step 1-3 of the extraction plan):
-- ``engine.types``      — data contracts (StoryState, QAPair, PipelineOptions).
-- ``engine.prompter``   — Prompter protocol for human-input abstraction.
-- ``engine.config``     — DSPy model configuration and generator wiring.
-
-Later steps will add ``engine.stages`` and ``engine.pipeline``.
+Public API:
+- :mod:`engine.types`     — data contracts (StoryState, QAPair, ...).
+- :mod:`engine.prompter`  — Prompter protocol for human-input abstraction.
+- :mod:`engine.config`    — DSPy model configuration and generator wiring.
+- :mod:`engine.stages`    — per-stage pipeline functions.
+- :mod:`engine.pipeline`  — stage ordering + ``run_all`` orchestration.
+- :mod:`engine.writers`   — presentation-layer output (markdown today).
 """
 
+from engine.pipeline import default_stage_order, run_all, run_stage
+from engine.prompter import Prompter
 from engine.types import (
+    CharacterVisualState,
     PipelineOptions,
     QAPair,
     StageName,
     StoryState,
 )
-from engine.prompter import Prompter
 
 __all__ = [
+    "CharacterVisualState",
     "PipelineOptions",
     "Prompter",
     "QAPair",
     "StageName",
     "StoryState",
+    "default_stage_order",
+    "run_all",
+    "run_stage",
 ]

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,0 +1,28 @@
+"""Headless story generation engine.
+
+This package decouples the story generation pipeline from the interactive CLI
+so that it can run inside web workers, tests, or other non-TTY contexts.
+
+Initial scope (step 1-3 of the extraction plan):
+- ``engine.types``      — data contracts (StoryState, QAPair, PipelineOptions).
+- ``engine.prompter``   — Prompter protocol for human-input abstraction.
+- ``engine.config``     — DSPy model configuration and generator wiring.
+
+Later steps will add ``engine.stages`` and ``engine.pipeline``.
+"""
+
+from engine.types import (
+    PipelineOptions,
+    QAPair,
+    StageName,
+    StoryState,
+)
+from engine.prompter import Prompter
+
+__all__ = [
+    "PipelineOptions",
+    "Prompter",
+    "QAPair",
+    "StageName",
+    "StoryState",
+]

--- a/engine/config.py
+++ b/engine/config.py
@@ -1,0 +1,134 @@
+"""DSPy runtime configuration and generator wiring.
+
+Extracted from ``main.py`` without behavior changes so the CLI and future
+headless workers share the same setup path.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+import dspy
+
+from dspy_optimization import try_load_optimized_module
+from story_modules import (
+    ChapterInpaintingGenerator,
+    CorePremiseGenerator,
+    QuestionGenerator,
+    SpineTemplateGenerator,
+    StoryGenerator,
+)
+from world_bible_modules import (
+    WorldBibleGenerator,
+    WorldBibleQuestionGenerator,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+# Module-level guard so long-lived worker processes don't re-instrument DSPy
+# for every job. Instrumentation hooks are global; re-attaching them leaks
+# callbacks and can distort traces.
+_LANGFUSE_INSTRUMENTED = False
+
+
+def configure_dspy(
+    model_name: str,
+    api_base: Optional[str] = None,
+    api_key: Optional[str] = None,
+    max_tokens: int = 2000,
+    cache: bool = True,
+    memory_cache: bool = True,
+    cache_dir: Optional[str] = None,
+) -> None:
+    """Configure the global DSPy language model and cache.
+
+    This mirrors the pre-refactor behavior of ``main.configure_dspy`` exactly.
+    DSPy's configuration is process-global (see ``dspy.configure``), so this
+    should be called once per worker process, not per request.
+    """
+    kwargs: dict = {}
+    if api_base:
+        kwargs["api_base"] = api_base
+    if api_key is not None:
+        kwargs["api_key"] = api_key
+    elif "openai" in model_name.lower():
+        env_key = os.environ.get("OPENAI_API_KEY")
+        if not env_key:
+            logger.warning(
+                "OPENAI_API_KEY not found in environment variables. "
+                "Assuming mock or alternative setup."
+            )
+        else:
+            kwargs["api_key"] = env_key
+    elif "ollama" in model_name.lower():
+        # Ollama typically doesn't need an API key; leave ``kwargs`` untouched.
+        pass
+
+    dspy.configure_cache(
+        enable_disk_cache=cache,
+        enable_memory_cache=memory_cache,
+        disk_cache_dir=cache_dir,
+    )
+
+    logger.info(
+        "Configuring DSPy model=%r max_tokens=%s cache=%s memory_cache=%s cache_dir=%r",
+        model_name,
+        max_tokens,
+        cache,
+        memory_cache,
+        cache_dir,
+    )
+    lm = dspy.LM(model_name, max_tokens=max_tokens, cache=cache, **kwargs)
+
+    global _LANGFUSE_INSTRUMENTED
+    if os.environ.get("LANGFUSE_PUBLIC_KEY") and not _LANGFUSE_INSTRUMENTED:
+        try:
+            from openinference.instrumentation.dspy import DSPyInstrumentor
+
+            DSPyInstrumentor().instrument()
+            _LANGFUSE_INSTRUMENTED = True
+        except Exception as exc:
+            logger.warning("Langfuse DSPy callback handler unavailable: %s", exc)
+
+    dspy.configure(lm=lm)
+
+
+def initialize_text_generators(
+    *,
+    use_optimized: bool = False,
+    optimized_manifest: Optional[str] = None,
+) -> dict:
+    """Instantiate and (optionally) load optimized artifacts for the text
+    generation modules used by the pipeline.
+
+    Returns a dict keyed by module name, matching ``main.py``'s prior
+    contract so the CLI refactor is a drop-in replacement.
+    """
+    generators = {
+        "QuestionGenerator": QuestionGenerator(),
+        "CorePremiseGenerator": CorePremiseGenerator(),
+        "SpineTemplateGenerator": SpineTemplateGenerator(),
+        "WorldBibleQuestionGenerator": WorldBibleQuestionGenerator(),
+        "WorldBibleGenerator": WorldBibleGenerator(),
+        "StoryGenerator": StoryGenerator(),
+        "ChapterInpaintingGenerator": ChapterInpaintingGenerator(),
+    }
+
+    if use_optimized:
+        logger.info(
+            "Optimized text modules enabled (manifest=%r)",
+            optimized_manifest,
+        )
+        for module_name, module in generators.items():
+            try_load_optimized_module(
+                module,
+                module_name=module_name,
+                manifest_path=optimized_manifest,
+                logger=logger,
+            )
+
+    return generators

--- a/engine/pipeline.py
+++ b/engine/pipeline.py
@@ -1,0 +1,112 @@
+"""End-to-end pipeline runner.
+
+Composes the functions in :mod:`engine.stages` into the default ordering
+used by both the CLI and the (future) web worker. Callers can also invoke
+individual stages via :func:`run_stage` when driving the pipeline
+interactively (e.g. pausing between stages to persist state).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, Mapping, Optional, Sequence
+
+from engine.prompter import Prompter
+from engine.stages import (
+    run_character_portraits,
+    run_character_visuals,
+    run_ideate,
+    run_inpaint,
+    run_premise,
+    run_scene_images,
+    run_similarity_check,
+    run_spine,
+    run_story,
+    run_world_bible,
+    run_world_bible_questions,
+)
+from engine.types import PipelineOptions, StageName, StoryState
+
+
+logger = logging.getLogger(__name__)
+
+
+STAGE_FUNCS: dict[StageName, Callable] = {
+    StageName.IDEATE: run_ideate,
+    StageName.PREMISE: run_premise,
+    StageName.SPINE: run_spine,
+    StageName.WORLD_BIBLE_QUESTIONS: run_world_bible_questions,
+    StageName.WORLD_BIBLE: run_world_bible,
+    StageName.CHARACTER_VISUALS: run_character_visuals,
+    StageName.CHARACTER_PORTRAITS: run_character_portraits,
+    StageName.STORY: run_story,
+    StageName.INPAINT: run_inpaint,
+    StageName.SCENE_IMAGES: run_scene_images,
+    StageName.SIMILARITY_CHECK: run_similarity_check,
+}
+
+
+def default_stage_order(options: PipelineOptions) -> list[StageName]:
+    """Return the stages to run given the current options.
+
+    The ordering mirrors the legacy CLI flow. Optional stages are appended
+    based on :class:`PipelineOptions` flags so the worker and CLI share a
+    single source of truth about what a "full run" includes.
+    """
+    order: list[StageName] = [
+        StageName.IDEATE,
+        StageName.PREMISE,
+        StageName.SPINE,
+        StageName.WORLD_BIBLE_QUESTIONS,
+        StageName.WORLD_BIBLE,
+    ]
+    if options.enable_images:
+        order += [StageName.CHARACTER_VISUALS, StageName.CHARACTER_PORTRAITS]
+    order.append(StageName.STORY)
+    if options.inpaint_chapters:
+        order.append(StageName.INPAINT)
+    if options.enable_images:
+        order.append(StageName.SCENE_IMAGES)
+    if options.check_similar:
+        order.append(StageName.SIMILARITY_CHECK)
+    return order
+
+
+def run_stage(
+    stage: StageName,
+    state: StoryState,
+    generators: Mapping[str, object],
+    prompter: Prompter,
+    options: PipelineOptions,
+) -> StoryState:
+    """Run a single stage by name. Useful for workers that persist state
+    between stages (so a crash doesn't lose completed work)."""
+    func = STAGE_FUNCS[stage]
+    logger.debug("Running stage %s", stage.value)
+    return func(state, generators, prompter, options)
+
+
+def run_all(
+    state: StoryState,
+    generators: Mapping[str, object],
+    prompter: Prompter,
+    options: PipelineOptions,
+    *,
+    stages: Optional[Sequence[StageName]] = None,
+    on_stage_complete: Optional[Callable[[StageName, StoryState], None]] = None,
+) -> StoryState:
+    """Run every stage in ``stages`` (or :func:`default_stage_order`) in order.
+
+    ``on_stage_complete`` fires after each stage with the updated state. The
+    eventual web worker will hook this to emit SSE progress events and
+    persist state to Postgres.
+    """
+    options.validate()
+    plan = list(stages) if stages is not None else default_stage_order(options)
+
+    for stage in plan:
+        state = run_stage(stage, state, generators, prompter, options)
+        if on_stage_complete is not None:
+            on_stage_complete(stage, state)
+
+    return state

--- a/engine/prompter.py
+++ b/engine/prompter.py
@@ -1,0 +1,71 @@
+"""Human-input abstraction for the story generation pipeline.
+
+The pipeline must work both interactively (a person at a TTY answering
+questions) and headlessly (a web worker replaying pre-collected answers from a
+database). Both modes implement the same :class:`Prompter` protocol; pipeline
+code never branches on transport.
+
+Concrete implementations live alongside this module:
+- ``engine.prompter_cli``      — rich/terminal prompts (replacing the
+  ``rich.Prompt`` / ``Confirm`` calls in ``main.py``).
+- ``engine.prompter_scripted`` — deterministic, in-memory answers for workers
+  and tests.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, Sequence, runtime_checkable
+
+from engine.types import QAPair
+
+
+@runtime_checkable
+class Prompter(Protocol):
+    """Contract for supplying human input to pipeline stages.
+
+    Pipeline code calls methods on a ``Prompter`` wherever it needs a decision
+    from the user. Implementations decide whether that means blocking on a TTY,
+    looking up a stored answer, or returning a canned value in a test.
+    """
+
+    def ask_idea(self) -> str:
+        """Return the user's initial story idea/prompt."""
+        ...
+
+    def answer_questions(self, qa: Sequence[QAPair]) -> list[QAPair]:
+        """Given a list of questions with proposed answers, return the list
+        with ``user_answer`` populated on each entry.
+
+        Implementations may mutate the inputs or return new instances — callers
+        should use the returned list.
+        """
+        ...
+
+    def confirm_premise(self, premise: str) -> tuple[bool, str]:
+        """Show the user the generated core premise and ask whether to accept.
+
+        Returns:
+            ``(accept, refinement_details)``. When ``accept`` is ``True`` the
+            ``refinement_details`` value is ignored. When ``False``, the
+            details are folded back into the idea and the premise is
+            regenerated.
+        """
+        ...
+
+    def wait_continue(self, label: str) -> None:
+        """Optional checkpoint between stages.
+
+        CLI implementations typically block on "Press Enter to continue";
+        scripted implementations no-op.
+        """
+        ...
+
+    def notify(self, level: str, message: str) -> None:
+        """Surface a progress / status message.
+
+        ``level`` is a free-form hint (e.g. ``"info"``, ``"warning"``,
+        ``"error"``, ``"success"``). Implementations map it to whatever is
+        appropriate — rich color for CLI, an SSE event for web workers, a log
+        line for tests.
+        """
+        ...

--- a/engine/prompter_cli.py
+++ b/engine/prompter_cli.py
@@ -1,0 +1,93 @@
+"""Terminal/``rich``-based :class:`Prompter` implementation.
+
+This wraps the exact interaction pattern used by ``main.py`` today so the CLI
+behavior is unchanged after the refactor.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from rich.console import Console
+from rich.prompt import Confirm, Prompt
+
+from engine.prompter import Prompter
+from engine.types import QAPair
+
+
+_LEVEL_STYLES = {
+    "info": "italic",
+    "success": "bold green",
+    "warning": "bold yellow",
+    "error": "bold red",
+    "header": "bold magenta",
+}
+
+
+class CLIPrompter(Prompter):
+    """Interactive prompter backed by a ``rich.Console``.
+
+    A single console instance is used for all output so the CLI looks
+    consistent with prior behavior.
+    """
+
+    def __init__(self, console: Console | None = None) -> None:
+        self.console = console or Console()
+
+    def ask_idea(self) -> str:
+        return Prompt.ask(
+            "\n[bold yellow]What is your initial story idea/prompt?[/bold yellow]"
+        )
+
+    def answer_questions(self, qa: Sequence[QAPair]) -> list[QAPair]:
+        answered: list[QAPair] = []
+        for i, pair in enumerate(qa):
+            self.console.print(
+                f"\n[bold cyan]Question {i + 1}:[/bold cyan] {pair.question}"
+            )
+            self.console.print(
+                f"[bold green]Proposed Answer:[/bold green] {pair.proposed_answer}"
+            )
+
+            accept = Confirm.ask("Accept this proposed answer?")
+            if accept:
+                # ``None`` means "use the proposed answer"; we keep it explicit
+                # via ``effective_answer`` on downstream reads.
+                user_answer = None
+            else:
+                user_answer = Prompt.ask("Enter your answer")
+
+            answered.append(
+                QAPair(
+                    question=pair.question,
+                    proposed_answer=pair.proposed_answer,
+                    user_answer=user_answer,
+                )
+            )
+        return answered
+
+    def confirm_premise(self, premise: str) -> tuple[bool, str]:
+        self.console.print("\n[bold magenta]--- Core Premise ---[/bold magenta]")
+        self.console.print(premise)
+        self.console.print("[bold magenta]--------------------[/bold magenta]")
+
+        refine = Confirm.ask(
+            "Do you want to refine this premise? "
+            "(Choosing 'Yes' will let you provide more details and regenerate, "
+            "'No' proceeds)",
+            default=False,
+        )
+        if not refine:
+            return True, ""
+
+        details = Prompt.ask("Provide more details or changes")
+        return False, details
+
+    def wait_continue(self, label: str) -> None:
+        # Matches the legacy ``Confirm.ask("Press Enter to continue ...", default=True)``
+        # calls in ``main.py``.
+        Confirm.ask(label, default=True, show_default=False)
+
+    def notify(self, level: str, message: str) -> None:
+        style = _LEVEL_STYLES.get(level.lower(), "italic")
+        self.console.print(f"[{style}]{message}[/{style}]")

--- a/engine/prompter_scripted.py
+++ b/engine/prompter_scripted.py
@@ -36,41 +36,37 @@ class PremiseDecision:
 class ScriptedPrompter(Prompter):
     """Replay a pre-collected script of answers.
 
+    The pipeline may call :meth:`answer_questions` an arbitrary number of
+    times (one per ideation round triggered by :meth:`confirm_premise`, plus
+    once for the world-bible questions). We model this as an ordered queue
+    of "answer batches" — each call pops the next batch.
+
     Attributes:
-        idea: the initial story idea supplied up-front.
-        ideation_answers: answers for :meth:`answer_questions` during the
-            ideation step, in call order. Each entry is the full replacement
-            ``user_answer`` string, or ``None`` to accept the proposed answer.
-        world_bible_answers: same shape, used for the world-bible question
-            batch.
+        idea: the initial story idea returned by :meth:`ask_idea`.
+        answer_batches: one list per expected ``answer_questions`` call, in
+            call order. Each inner list must be long enough for the question
+            batch the pipeline hands in; entries are either the full
+            replacement ``user_answer`` string, or ``None`` to accept the
+            proposed answer.
         premise_decisions: iterable of :class:`PremiseDecision` values. The
-            pipeline may loop over premise refinement; the final decision
-            must be ``accept=True`` or the script will raise.
+            final decision must be ``accept=True`` or the script will raise.
         notify_sink: optional callback receiving ``(level, message)`` — lets
             the web worker forward messages as SSE events. Defaults to a
             logger.
     """
 
     idea: str = ""
-    ideation_answers: Sequence[Optional[str]] = field(default_factory=list)
-    world_bible_answers: Sequence[Optional[str]] = field(default_factory=list)
+    answer_batches: Sequence[Sequence[Optional[str]]] = field(default_factory=list)
     premise_decisions: Sequence[PremiseDecision] = field(default_factory=list)
     notify_sink: Optional[Callable[[str, str], None]] = None
 
-    # Private iterators are populated lazily so the dataclass remains
-    # trivially constructible/serializable.
-    _ideation_iter: Optional[Iterator[Optional[str]]] = field(
-        default=None, init=False, repr=False
-    )
-    _wb_iter: Optional[Iterator[Optional[str]]] = field(
+    # Lazy iterators keep the dataclass trivially constructible.
+    _answer_iter: Optional[Iterator[Sequence[Optional[str]]]] = field(
         default=None, init=False, repr=False
     )
     _premise_iter: Optional[Iterator[PremiseDecision]] = field(
         default=None, init=False, repr=False
     )
-    # Toggles between the two batches. The pipeline calls ``answer_questions``
-    # exactly twice (ideation, then world bible), so we route by call order.
-    _questions_call_count: int = field(default=0, init=False, repr=False)
 
     def ask_idea(self) -> str:
         if not self.idea:
@@ -80,37 +76,31 @@ class ScriptedPrompter(Prompter):
         return self.idea
 
     def answer_questions(self, qa: Sequence[QAPair]) -> list[QAPair]:
-        # First call = ideation questions; second = world bible questions.
-        if self._questions_call_count == 0:
-            answers = list(self.ideation_answers)
-            label = "ideation"
-        elif self._questions_call_count == 1:
-            answers = list(self.world_bible_answers)
-            label = "world_bible"
-        else:
+        if self._answer_iter is None:
+            self._answer_iter = iter(self.answer_batches)
+
+        try:
+            answers = list(next(self._answer_iter))
+        except StopIteration as exc:
             raise RuntimeError(
-                "ScriptedPrompter.answer_questions called more than twice; "
-                "the pipeline contract only includes ideation and world-bible "
-                "question batches."
-            )
-        self._questions_call_count += 1
+                "ScriptedPrompter.answer_questions called more times than "
+                "the number of answer_batches provided."
+            ) from exc
 
         if len(answers) < len(qa):
             raise RuntimeError(
-                f"ScriptedPrompter has {len(answers)} {label} answers but was "
+                f"ScriptedPrompter batch has {len(answers)} answers but was "
                 f"asked for {len(qa)}."
             )
 
-        answered: list[QAPair] = []
-        for pair, user_answer in zip(qa, answers):
-            answered.append(
-                QAPair(
-                    question=pair.question,
-                    proposed_answer=pair.proposed_answer,
-                    user_answer=user_answer,
-                )
+        return [
+            QAPair(
+                question=pair.question,
+                proposed_answer=pair.proposed_answer,
+                user_answer=user_answer,
             )
-        return answered
+            for pair, user_answer in zip(qa, answers)
+        ]
 
     def confirm_premise(self, premise: str) -> tuple[bool, str]:
         if self._premise_iter is None:

--- a/engine/prompter_scripted.py
+++ b/engine/prompter_scripted.py
@@ -1,0 +1,140 @@
+"""Deterministic :class:`Prompter` backed by pre-collected answers.
+
+This is the implementation used by web workers (where the user filled out a
+form up-front and the pipeline replays their answers) and by tests.
+
+The scripted prompter never blocks and never reads from stdin.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Callable, Iterator, Optional, Sequence
+
+from engine.prompter import Prompter
+from engine.types import QAPair
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PremiseDecision:
+    """One user decision on a generated core premise.
+
+    If ``accept`` is ``True`` the pipeline moves on. Otherwise
+    ``refinement_details`` is folded back into the idea and the premise is
+    regenerated.
+    """
+
+    accept: bool
+    refinement_details: str = ""
+
+
+@dataclass
+class ScriptedPrompter(Prompter):
+    """Replay a pre-collected script of answers.
+
+    Attributes:
+        idea: the initial story idea supplied up-front.
+        ideation_answers: answers for :meth:`answer_questions` during the
+            ideation step, in call order. Each entry is the full replacement
+            ``user_answer`` string, or ``None`` to accept the proposed answer.
+        world_bible_answers: same shape, used for the world-bible question
+            batch.
+        premise_decisions: iterable of :class:`PremiseDecision` values. The
+            pipeline may loop over premise refinement; the final decision
+            must be ``accept=True`` or the script will raise.
+        notify_sink: optional callback receiving ``(level, message)`` — lets
+            the web worker forward messages as SSE events. Defaults to a
+            logger.
+    """
+
+    idea: str = ""
+    ideation_answers: Sequence[Optional[str]] = field(default_factory=list)
+    world_bible_answers: Sequence[Optional[str]] = field(default_factory=list)
+    premise_decisions: Sequence[PremiseDecision] = field(default_factory=list)
+    notify_sink: Optional[Callable[[str, str], None]] = None
+
+    # Private iterators are populated lazily so the dataclass remains
+    # trivially constructible/serializable.
+    _ideation_iter: Optional[Iterator[Optional[str]]] = field(
+        default=None, init=False, repr=False
+    )
+    _wb_iter: Optional[Iterator[Optional[str]]] = field(
+        default=None, init=False, repr=False
+    )
+    _premise_iter: Optional[Iterator[PremiseDecision]] = field(
+        default=None, init=False, repr=False
+    )
+    # Toggles between the two batches. The pipeline calls ``answer_questions``
+    # exactly twice (ideation, then world bible), so we route by call order.
+    _questions_call_count: int = field(default=0, init=False, repr=False)
+
+    def ask_idea(self) -> str:
+        if not self.idea:
+            raise RuntimeError(
+                "ScriptedPrompter.ask_idea called but no idea was provided."
+            )
+        return self.idea
+
+    def answer_questions(self, qa: Sequence[QAPair]) -> list[QAPair]:
+        # First call = ideation questions; second = world bible questions.
+        if self._questions_call_count == 0:
+            answers = list(self.ideation_answers)
+            label = "ideation"
+        elif self._questions_call_count == 1:
+            answers = list(self.world_bible_answers)
+            label = "world_bible"
+        else:
+            raise RuntimeError(
+                "ScriptedPrompter.answer_questions called more than twice; "
+                "the pipeline contract only includes ideation and world-bible "
+                "question batches."
+            )
+        self._questions_call_count += 1
+
+        if len(answers) < len(qa):
+            raise RuntimeError(
+                f"ScriptedPrompter has {len(answers)} {label} answers but was "
+                f"asked for {len(qa)}."
+            )
+
+        answered: list[QAPair] = []
+        for pair, user_answer in zip(qa, answers):
+            answered.append(
+                QAPair(
+                    question=pair.question,
+                    proposed_answer=pair.proposed_answer,
+                    user_answer=user_answer,
+                )
+            )
+        return answered
+
+    def confirm_premise(self, premise: str) -> tuple[bool, str]:
+        if self._premise_iter is None:
+            self._premise_iter = iter(self.premise_decisions)
+        try:
+            decision = next(self._premise_iter)
+        except StopIteration as exc:
+            raise RuntimeError(
+                "ScriptedPrompter exhausted premise_decisions; the final "
+                "entry must be accept=True."
+            ) from exc
+        return decision.accept, decision.refinement_details
+
+    def wait_continue(self, label: str) -> None:
+        # No-op: scripted runs never block.
+        logger.debug("ScriptedPrompter.wait_continue skipped: %s", label)
+
+    def notify(self, level: str, message: str) -> None:
+        if self.notify_sink is not None:
+            self.notify_sink(level, message)
+            return
+        # Default: downgrade to a log record so the worker stays quiet.
+        log_method = getattr(logger, level.lower(), None)
+        if callable(log_method):
+            log_method(message)
+        else:
+            logger.info("[%s] %s", level, message)

--- a/engine/stages.py
+++ b/engine/stages.py
@@ -1,0 +1,390 @@
+"""Pipeline stages.
+
+Each stage is a pure function:
+
+    def run_<stage>(state, generators, prompter, options) -> StoryState
+
+Stages read what they need from ``state``, write their slice, and return the
+(possibly mutated) state. They never call ``print`` directly; status goes
+through :meth:`Prompter.notify`, and any blocking waits go through
+:meth:`Prompter.wait_continue` (no-op under the scripted prompter).
+
+Optional stages (character visuals, portraits, inpainting, scene images,
+similarity check) are invoked by the pipeline runner when the corresponding
+:class:`PipelineOptions` flag is set. They are written to be safe to call
+without that flag, but the pipeline won't by default.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, Mapping
+
+from engine.prompter import Prompter
+from engine.types import (
+    CharacterVisualState,
+    PipelineOptions,
+    QAPair,
+    StoryState,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _qa_pairs_from_dspy(dspy_qa: Iterable) -> list[QAPair]:
+    """Adapt ``story_modules.QuestionWithAnswer`` instances (or anything with
+    ``.question`` / ``.proposed_answer``) to our persistence-friendly
+    :class:`QAPair`."""
+    return [
+        QAPair(question=item.question, proposed_answer=item.proposed_answer)
+        for item in dspy_qa
+    ]
+
+
+def _format_qa_text(answered: Iterable[QAPair]) -> str:
+    """Render answered QAPairs back into the ``Q: ...\\nA: ...`` string that
+    the DSPy premise/world-bible modules expect."""
+    return "\n\n".join(
+        f"Q: {qa.question}\nA: {qa.effective_answer}" for qa in answered
+    )
+
+
+def _split_story_chapters(story_text: str) -> list[str]:
+    """Split a story by ``### Chapter `` headings, preserving prior behavior
+    from ``main.py`` (drop empty fragments)."""
+    return [c for c in story_text.split("### Chapter ") if c.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Text stages
+# ---------------------------------------------------------------------------
+
+
+def run_ideate(
+    state: StoryState,
+    generators: Mapping[str, object],
+    prompter: Prompter,
+    options: PipelineOptions,
+) -> StoryState:
+    """Ask the user for the initial story idea."""
+    if not state.idea:
+        state.idea = prompter.ask_idea()
+    return state
+
+
+def run_premise(
+    state: StoryState,
+    generators: Mapping[str, object],
+    prompter: Prompter,
+    options: PipelineOptions,
+) -> StoryState:
+    """Ideation-question loop + core-premise generation + refinement loop.
+
+    Matches the legacy ``while True:`` flow in ``main.py``: questions →
+    premise → accept/refine. When refining, the user's details are folded
+    back into the idea string (stacking across iterations, same as before).
+    """
+    q_gen = generators["QuestionGenerator"]
+    cp_gen = generators["CorePremiseGenerator"]
+
+    idea = state.idea
+    while True:
+        prompter.notify("info", "Generating questions to interrogate your idea...")
+        q_result = q_gen(idea=idea)
+
+        proposed = _qa_pairs_from_dspy(q_result.questions_with_answers)
+        answered = prompter.answer_questions(proposed)
+        # Only the most recent round is kept — prior rounds fed the refined
+        # idea string so their info is already captured in ``idea``.
+        state.ideation_qa = list(answered)
+
+        prompter.notify("info", "Generating Core Premise...")
+        cp_result = cp_gen(idea=idea, qa_pairs=_format_qa_text(answered))
+        state.core_premise = cp_result.core_premise
+
+        accept, refinement_details = prompter.confirm_premise(state.core_premise)
+        if accept:
+            break
+
+        idea = (
+            f"Original idea: {idea}\n"
+            f"Refinements: {refinement_details}\n"
+            f"Current Core Premise: {state.core_premise}"
+        )
+
+    return state
+
+
+def run_spine(
+    state: StoryState,
+    generators: Mapping[str, object],
+    prompter: Prompter,
+    options: PipelineOptions,
+) -> StoryState:
+    """Generate the narrative spine template from the core premise."""
+    prompter.notify("info", "Generating Spine Template...")
+    st_gen = generators["SpineTemplateGenerator"]
+    result = st_gen(core_premise=state.core_premise)
+    state.spine_template = result.spine_template
+
+    prompter.wait_continue("Press Enter to continue to World Bible generation...")
+    return state
+
+
+def run_world_bible_questions(
+    state: StoryState,
+    generators: Mapping[str, object],
+    prompter: Prompter,
+    options: PipelineOptions,
+) -> StoryState:
+    """Generate and answer follow-up questions that flesh out the world bible."""
+    prompter.notify(
+        "info",
+        "Generating follow-up questions to help flesh out the World Bible...",
+    )
+    wb_q_gen = generators["WorldBibleQuestionGenerator"]
+    result = wb_q_gen(
+        core_premise=state.core_premise, spine_template=state.spine_template
+    )
+    proposed = _qa_pairs_from_dspy(result.questions_with_answers)
+    state.world_bible_qa = list(prompter.answer_questions(proposed))
+    return state
+
+
+def run_world_bible(
+    state: StoryState,
+    generators: Mapping[str, object],
+    prompter: Prompter,
+    options: PipelineOptions,
+) -> StoryState:
+    """Generate the world bible from premise + spine + answered WB questions."""
+    prompter.notify("info", "Generating World Bible...")
+    wb_gen = generators["WorldBibleGenerator"]
+    result = wb_gen(
+        core_premise=state.core_premise,
+        spine_template=state.spine_template,
+        user_additions=_format_qa_text(state.world_bible_qa),
+    )
+    state.world_bible = result.world_bible
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Image pipeline stages (optional)
+# ---------------------------------------------------------------------------
+
+
+def run_character_visuals(
+    state: StoryState,
+    generators: Mapping[str, object],
+    prompter: Prompter,
+    options: PipelineOptions,
+) -> StoryState:
+    """Describe the main characters visually (text-only, no Replicate call).
+
+    Split from :func:`run_character_portraits` so the text half can run even
+    without a Replicate token — useful for tests and for future UI preview.
+    """
+    # Late import: ``story_modules`` pulls in dspy; keeping the import here
+    # matches the lazy pattern in the legacy CLI.
+    from story_modules import CharacterVisualDescriber
+
+    prompter.notify("info", "Generating character visual descriptions...")
+    describer = CharacterVisualDescriber()
+    result = describer(world_bible=state.world_bible)
+
+    visuals: list[CharacterVisualState] = []
+    for cv in result.character_visuals:
+        visuals.append(
+            CharacterVisualState(
+                name=cv.name,
+                reference_mix=cv.reference_mix,
+                distinguishing_features=cv.distinguishing_features,
+                full_prompt=cv.full_prompt,
+            )
+        )
+        prompter.notify("info", f"{cv.name}: {cv.reference_mix}")
+    state.character_visuals = visuals
+    return state
+
+
+def run_character_portraits(
+    state: StoryState,
+    generators: Mapping[str, object],
+    prompter: Prompter,
+    options: PipelineOptions,
+) -> StoryState:
+    """Render a portrait per character via Replicate.
+
+    Requires ``options.replicate_api_token``. If the token is missing, this
+    stage raises — :meth:`PipelineOptions.validate` should catch that earlier.
+    """
+    if not options.replicate_api_token:
+        raise RuntimeError(
+            "run_character_portraits requires options.replicate_api_token"
+        )
+    if not state.character_visuals:
+        prompter.notify(
+            "warning",
+            "No character visuals available; skipping portrait generation.",
+        )
+        return state
+
+    # Late import so unit tests that don't touch images don't need Replicate.
+    from image_gen import ImageGenerator
+
+    image_gen = ImageGenerator(api_token=options.replicate_api_token)
+    prompter.notify("info", "Generating character portraits...")
+    for cv in state.character_visuals:
+        try:
+            path = image_gen.generate_character_portrait(
+                prompt=cv.full_prompt, character_name=cv.name
+            )
+            state.character_portrait_paths[cv.name] = path
+            prompter.notify("success", f"Saved portrait: {path}")
+        except Exception as exc:
+            prompter.notify(
+                "error",
+                f"Failed to generate portrait for {cv.name}: {exc}",
+            )
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Story + post-processing stages
+# ---------------------------------------------------------------------------
+
+
+def run_story(
+    state: StoryState,
+    generators: Mapping[str, object],
+    prompter: Prompter,
+    options: PipelineOptions,
+) -> StoryState:
+    """Generate the arc outline, chapter plan, enhancers guide, and story."""
+    prompter.wait_continue("Press Enter to continue to Story generation...")
+    prompter.notify(
+        "info", "Generating Story (Arc Outline, Chapter Plan, Final Story)..."
+    )
+
+    story_gen = generators["StoryGenerator"]
+    result = story_gen(
+        core_premise=state.core_premise,
+        spine_template=state.spine_template,
+        world_bible=state.world_bible,
+    )
+
+    state.arc_outline = result.arc_outline
+    state.chapter_plan = result.chapter_plan
+    state.enhancers_guide = result.enhancers_guide
+    state.story_text = result.story
+    # Keep ``final_story_text`` in sync so downstream stages work even when
+    # inpainting is disabled.
+    state.final_story_text = result.story
+    return state
+
+
+def run_inpaint(
+    state: StoryState,
+    generators: Mapping[str, object],
+    prompter: Prompter,
+    options: PipelineOptions,
+) -> StoryState:
+    """Run the chapter-expansion pass and replace the final story text."""
+    if options.inpaint_ratio <= 1.0:
+        raise ValueError(
+            f"inpaint_ratio must be > 1.0, got {options.inpaint_ratio}"
+        )
+
+    prompter.notify("info", "Running chapter inpainting pass...")
+    inpaint_gen = generators["ChapterInpaintingGenerator"]
+    result = inpaint_gen(
+        story=state.story_text,
+        world_bible=state.world_bible,
+        chapter_plan=state.chapter_plan,
+        expansion_ratio=options.inpaint_ratio,
+    )
+    state.final_story_text = result.story
+    prompter.notify(
+        "info",
+        f"Chapter inpainting complete "
+        f"({result.expanded_chapters}/{result.total_chapters} chapters expanded).",
+    )
+    return state
+
+
+def run_scene_images(
+    state: StoryState,
+    generators: Mapping[str, object],
+    prompter: Prompter,
+    options: PipelineOptions,
+) -> StoryState:
+    """Render a scene illustration per chapter, referencing character portraits."""
+    if not options.replicate_api_token:
+        raise RuntimeError(
+            "run_scene_images requires options.replicate_api_token"
+        )
+
+    from image_gen import ImageGenerator
+    from story_modules import SceneImagePromptGenerator
+
+    prompter.notify("info", "Generating scene illustrations for each chapter...")
+    image_gen = ImageGenerator(api_token=options.replicate_api_token)
+    scene_prompt_gen = SceneImagePromptGenerator()
+
+    character_visuals_summary = "\n".join(
+        f"- {cv.name}: {cv.reference_mix}. {cv.distinguishing_features}"
+        for cv in state.character_visuals
+    )
+    reference_paths = list(state.character_portrait_paths.values())
+
+    chapters = _split_story_chapters(state.final_story_text)
+    for i, chapter_text in enumerate(chapters, start=1):
+        try:
+            prompt_result = scene_prompt_gen(
+                chapter_text=chapter_text,
+                character_visuals_summary=character_visuals_summary,
+            )
+            path = image_gen.generate_scene_illustration(
+                prompt=prompt_result.image_prompt,
+                reference_image_paths=reference_paths,
+                chapter_index=i,
+            )
+            state.scene_image_paths[i] = path
+            prompter.notify("success", f"Chapter {i} scene: {path}")
+        except Exception as exc:
+            prompter.notify(
+                "error", f"Failed to generate scene for chapter {i}: {exc}"
+            )
+    return state
+
+
+def run_similarity_check(
+    state: StoryState,
+    generators: Mapping[str, object],
+    prompter: Prompter,
+    options: PipelineOptions,
+) -> StoryState:
+    """Scan the final story for near-duplicate sentences."""
+    # Imported lazily so the engine package doesn't hard-require numpy/etc.
+    from postprocessing import find_similar_sentences, format_report
+
+    prompter.notify("header", "--- Similar Sentence Check ---")
+    similar_pairs = find_similar_sentences(
+        state.final_story_text, threshold=options.similar_threshold
+    )
+    report = format_report(similar_pairs)
+    state.similarity_report = report
+    prompter.notify("info", report)
+    if similar_pairs:
+        logger.warning(
+            "Detected %d similar sentence pair(s) in generated story",
+            len(similar_pairs),
+        )
+    return state

--- a/engine/types.py
+++ b/engine/types.py
@@ -1,0 +1,228 @@
+"""Data contracts for the headless story generation pipeline.
+
+These types replace the ad-hoc locals scattered across ``main.py`` with one
+serializable state object that can live in a DB row / Redis job payload.
+
+Design notes:
+- ``StoryState`` accumulates outputs across stages. Each stage reads what it
+  needs and writes its own slice.
+- ``QAPair`` mirrors ``story_modules.QuestionWithAnswer`` but adds the user's
+  accepted answer (or ``None`` meaning "accept the proposed answer").
+- ``PipelineOptions`` captures the per-run toggles that used to live on the
+  argparse ``Namespace``.
+- ``StageName`` is the stable identifier used for persistence and routing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+
+class StageName(str, Enum):
+    """Canonical stage identifiers.
+
+    These are persisted (in DB rows, job queues, logs) so the string values
+    are part of the public contract — do not rename without a migration.
+    """
+
+    IDEATE = "ideate"
+    PREMISE = "premise"
+    SPINE = "spine"
+    WORLD_BIBLE_QUESTIONS = "world_bible_questions"
+    WORLD_BIBLE = "world_bible"
+    CHARACTER_VISUALS = "character_visuals"
+    CHARACTER_PORTRAITS = "character_portraits"
+    STORY = "story"
+    INPAINT = "inpaint"
+    SCENE_IMAGES = "scene_images"
+    SIMILARITY_CHECK = "similarity_check"
+
+
+@dataclass
+class QAPair:
+    """One interrogative question + a proposed answer + the user's choice.
+
+    ``user_answer`` is the authoritative answer. When ``None``, the caller
+    should treat ``proposed_answer`` as accepted.
+    """
+
+    question: str
+    proposed_answer: str
+    user_answer: Optional[str] = None
+
+    @property
+    def effective_answer(self) -> str:
+        """The answer to feed downstream stages."""
+        return self.user_answer if self.user_answer is not None else self.proposed_answer
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "QAPair":
+        return cls(
+            question=data["question"],
+            proposed_answer=data["proposed_answer"],
+            user_answer=data.get("user_answer"),
+        )
+
+
+@dataclass
+class CharacterVisualState:
+    """Serializable mirror of ``story_modules.CharacterVisual`` for persistence.
+
+    We avoid depending on the Pydantic model directly so ``StoryState`` stays
+    free of DSPy / Pydantic imports and remains trivially JSON-roundtrippable.
+    """
+
+    name: str
+    reference_mix: str
+    distinguishing_features: str
+    full_prompt: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "CharacterVisualState":
+        return cls(
+            name=data["name"],
+            reference_mix=data.get("reference_mix", ""),
+            distinguishing_features=data.get("distinguishing_features", ""),
+            full_prompt=data.get("full_prompt", ""),
+        )
+
+
+@dataclass
+class StoryState:
+    """Accumulating pipeline state.
+
+    Every stage reads what it needs, writes its slice, and returns the mutated
+    state. The whole struct is JSON-serializable via :meth:`to_dict`.
+    """
+
+    idea: str = ""
+    ideation_qa: list[QAPair] = field(default_factory=list)
+    core_premise: str = ""
+    spine_template: str = ""
+    world_bible_qa: list[QAPair] = field(default_factory=list)
+    world_bible: str = ""
+
+    # Image pipeline (optional)
+    character_visuals: list[CharacterVisualState] = field(default_factory=list)
+    character_portrait_paths: dict[str, str] = field(default_factory=dict)
+
+    # Story pipeline outputs
+    arc_outline: str = ""
+    chapter_plan: str = ""
+    enhancers_guide: str = ""
+    story_text: str = ""
+    # ``final_story_text`` mirrors ``story_text`` unless inpainting ran.
+    final_story_text: str = ""
+
+    # Scene illustrations keyed by 1-based chapter index.
+    scene_image_paths: dict[int, str] = field(default_factory=dict)
+
+    # Post-processing
+    similarity_report: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-serializable representation of the state."""
+        return {
+            "idea": self.idea,
+            "ideation_qa": [qa.to_dict() for qa in self.ideation_qa],
+            "core_premise": self.core_premise,
+            "spine_template": self.spine_template,
+            "world_bible_qa": [qa.to_dict() for qa in self.world_bible_qa],
+            "world_bible": self.world_bible,
+            "character_visuals": [cv.to_dict() for cv in self.character_visuals],
+            "character_portrait_paths": dict(self.character_portrait_paths),
+            "arc_outline": self.arc_outline,
+            "chapter_plan": self.chapter_plan,
+            "enhancers_guide": self.enhancers_guide,
+            "story_text": self.story_text,
+            "final_story_text": self.final_story_text,
+            # Serialize int keys as strings for JSON compatibility.
+            "scene_image_paths": {str(k): v for k, v in self.scene_image_paths.items()},
+            "similarity_report": self.similarity_report,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "StoryState":
+        scene_images_raw = data.get("scene_image_paths", {}) or {}
+        scene_images: dict[int, str] = {}
+        for key, value in scene_images_raw.items():
+            try:
+                scene_images[int(key)] = value
+            except (TypeError, ValueError):
+                # Tolerate non-integer keys by skipping; data that round-trips
+                # through ``to_dict`` will always be coercible.
+                continue
+
+        return cls(
+            idea=data.get("idea", ""),
+            ideation_qa=[QAPair.from_dict(x) for x in data.get("ideation_qa", [])],
+            core_premise=data.get("core_premise", ""),
+            spine_template=data.get("spine_template", ""),
+            world_bible_qa=[QAPair.from_dict(x) for x in data.get("world_bible_qa", [])],
+            world_bible=data.get("world_bible", ""),
+            character_visuals=[
+                CharacterVisualState.from_dict(x)
+                for x in data.get("character_visuals", [])
+            ],
+            character_portrait_paths=dict(data.get("character_portrait_paths", {})),
+            arc_outline=data.get("arc_outline", ""),
+            chapter_plan=data.get("chapter_plan", ""),
+            enhancers_guide=data.get("enhancers_guide", ""),
+            story_text=data.get("story_text", ""),
+            final_story_text=data.get("final_story_text", ""),
+            scene_image_paths=scene_images,
+            similarity_report=data.get("similarity_report"),
+        )
+
+
+@dataclass
+class PipelineOptions:
+    """Per-run toggles. Mirrors the subset of CLI flags that drives pipeline
+    behavior (not cosmetic concerns like logging verbosity)."""
+
+    enable_images: bool = False
+    replicate_api_token: Optional[str] = None
+
+    inpaint_chapters: bool = False
+    inpaint_ratio: float = 1.35
+
+    check_similar: bool = True
+    similar_threshold: float = 0.65
+
+    use_optimized: bool = False
+    optimized_manifest: Optional[str] = None
+
+    def validate(self) -> None:
+        """Raise ``ValueError`` for invalid combinations.
+
+        Callers should run this before kicking off a pipeline so that the
+        failure surfaces at job-submission time rather than mid-generation.
+        """
+        if self.inpaint_chapters and self.inpaint_ratio <= 1.0:
+            raise ValueError(
+                f"inpaint_ratio must be > 1.0 when inpaint_chapters=True, "
+                f"got {self.inpaint_ratio}"
+            )
+        if self.enable_images and not self.replicate_api_token:
+            raise ValueError(
+                "enable_images=True requires replicate_api_token to be set."
+            )
+        if not (0.0 <= self.similar_threshold <= 1.0):
+            raise ValueError(
+                f"similar_threshold must be in [0.0, 1.0], got {self.similar_threshold}"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "PipelineOptions":
+        return cls(**data)

--- a/engine/writers/__init__.py
+++ b/engine/writers/__init__.py
@@ -1,0 +1,8 @@
+"""Presentation-layer writers that serialize :class:`StoryState` to formats
+suitable for end users (markdown, JSON, HTML, ...). Writers are intentionally
+separate from pipeline stages so the web app can render ``StoryState``
+directly without going through a file on disk."""
+
+from engine.writers.markdown import write_markdown
+
+__all__ = ["write_markdown"]

--- a/engine/writers/markdown.py
+++ b/engine/writers/markdown.py
@@ -1,0 +1,82 @@
+"""Render a :class:`StoryState` to the legacy ``story_output.md`` format.
+
+Extracted verbatim from ``main.py``'s step-11 block so the CLI produces
+byte-identical output after the refactor. The web app will not use this
+writer — it renders :class:`StoryState` directly in React — but the CLI and
+scripts still do.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+from engine.stages import _split_story_chapters
+from engine.types import StoryState
+
+
+logger = logging.getLogger(__name__)
+
+
+def render_markdown(state: StoryState) -> str:
+    """Return the markdown representation of the story as a string.
+
+    Pure function of ``state`` — no filesystem side effects. Callers that
+    want to write to disk should use :func:`write_markdown`.
+    """
+    parts: list[str] = ["# Story Output\n\n"]
+
+    parts.append("## Core Premise\n")
+    parts.append(f"{state.core_premise}\n\n")
+    parts.append("## Spine Template\n")
+    parts.append(f"{state.spine_template}\n\n")
+    parts.append("## World Bible\n")
+    parts.append(f"{state.world_bible}\n\n")
+
+    if state.character_visuals:
+        parts.append("## Character Visuals\n\n")
+        for cv in state.character_visuals:
+            parts.append(f"### {cv.name}\n")
+            parts.append(f"**Reference:** {cv.reference_mix}\n\n")
+            parts.append(f"**Features:** {cv.distinguishing_features}\n\n")
+            portrait = state.character_portrait_paths.get(cv.name)
+            if portrait:
+                parts.append(f"![{cv.name} portrait]({portrait})\n\n")
+
+    parts.append("## Arc Outline\n")
+    parts.append(f"{state.arc_outline}\n\n")
+    parts.append("## Chapter Plan\n")
+    parts.append(f"{state.chapter_plan}\n\n")
+    parts.append("## Enhancers Guide\n")
+    parts.append(f"{state.enhancers_guide}\n\n")
+    parts.append("## Final Story\n")
+
+    if state.scene_image_paths:
+        # Match the legacy chapter-interleaved format: each chapter followed
+        # by its scene illustration.
+        chapters = _split_story_chapters(state.final_story_text)
+        for i, chapter_text in enumerate(chapters, start=1):
+            parts.append(f"\n\n### Chapter {chapter_text}")
+            scene = state.scene_image_paths.get(i)
+            if scene:
+                parts.append(f"\n\n![Chapter {i} scene]({scene})\n")
+    else:
+        parts.append(f"{state.final_story_text}\n")
+
+    return "".join(parts)
+
+
+def write_markdown(state: StoryState, path: str) -> str:
+    """Write the state's markdown representation to ``path``.
+
+    Creates parent directories as needed. Returns the final path written.
+    """
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    logger.info("Saving story output to %s...", path)
+    content = render_markdown(state)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+    return path

--- a/main.py
+++ b/main.py
@@ -1,25 +1,15 @@
-import dspy
 from rich.console import Console
 from rich.prompt import Prompt, Confirm
 from story_modules import (
-    QuestionGenerator,
-    CorePremiseGenerator,
-    SpineTemplateGenerator,
-    StoryGenerator,
-    ChapterInpaintingGenerator,
     CharacterVisualDescriber,
     SceneImagePromptGenerator,
-)
-from world_bible_modules import (
-    WorldBibleGenerator,
-    WorldBibleQuestionGenerator,
 )
 import os
 import argparse
 import logging
 from dotenv import load_dotenv
+from engine.config import configure_dspy, initialize_text_generators
 from logging_config import setup_logging
-from dspy_optimization import try_load_optimized_module
 from postprocessing import find_similar_sentences, format_report
 
 load_dotenv()
@@ -34,87 +24,6 @@ def _env_flag_true(name: str, default: bool = False) -> bool:
     if raw_value is None:
         return default
     return raw_value.strip().lower() in {"1", "true", "yes", "on"}
-
-
-def configure_dspy(
-    model_name: str,
-    api_base: str = None,
-    api_key: str = None,
-    max_tokens: int = 2000,
-    cache: bool = True,
-    memory_cache: bool = True,
-    cache_dir: str | None = None,
-):
-    kwargs = {}
-    if api_base:
-        kwargs["api_base"] = api_base
-    if api_key is not None:
-        kwargs["api_key"] = api_key
-    elif "openai" in model_name.lower():
-        env_key = os.environ.get("OPENAI_API_KEY")
-        if not env_key:
-            logger.warning("OPENAI_API_KEY not found in environment variables. Assuming mock or alternative setup.")
-        else:
-            kwargs["api_key"] = env_key
-    elif "ollama" in model_name.lower():
-        pass
-        #kwargs["api_key"] = "" # Ollama typically doesn't need an API key
-
-    dspy.configure_cache(
-        enable_disk_cache=cache,
-        enable_memory_cache=memory_cache,
-        disk_cache_dir=cache_dir,
-    )
-
-    logger.info(
-        "Configuring DSPy model=%r max_tokens=%s cache=%s memory_cache=%s cache_dir=%r",
-        model_name,
-        max_tokens,
-        cache,
-        memory_cache,
-        cache_dir,
-    )
-    lm = dspy.LM(model_name, max_tokens=max_tokens, cache=cache, **kwargs)
-
-    if os.environ.get("LANGFUSE_PUBLIC_KEY"):
-        try:
-            from openinference.instrumentation.dspy import DSPyInstrumentor
-            DSPyInstrumentor().instrument()
-        except Exception as exc:
-            logger.warning("Langfuse DSPy callback handler unavailable: %s", exc)
-
-    dspy.configure(lm=lm)
-
-
-def initialize_text_generators(
-    *,
-    use_optimized: bool = False,
-    optimized_manifest: str | None = None,
-):
-    generators = {
-        "QuestionGenerator": QuestionGenerator(),
-        "CorePremiseGenerator": CorePremiseGenerator(),
-        "SpineTemplateGenerator": SpineTemplateGenerator(),
-        "WorldBibleQuestionGenerator": WorldBibleQuestionGenerator(),
-        "WorldBibleGenerator": WorldBibleGenerator(),
-        "StoryGenerator": StoryGenerator(),
-        "ChapterInpaintingGenerator": ChapterInpaintingGenerator(),
-    }
-
-    if use_optimized:
-        logger.info(
-            "Optimized text modules enabled (manifest=%r)",
-            optimized_manifest,
-        )
-        for module_name, module in generators.items():
-            try_load_optimized_module(
-                module,
-                module_name=module_name,
-                manifest_path=optimized_manifest,
-                logger=logger,
-            )
-
-    return generators
 
 def get_answers_for_questions(questions_with_answers) -> str:
     qa_pairs = []

--- a/main.py
+++ b/main.py
@@ -1,22 +1,31 @@
-from rich.console import Console
-from rich.prompt import Prompt, Confirm
-from story_modules import (
-    CharacterVisualDescriber,
-    SceneImagePromptGenerator,
-)
-import os
+"""Interactive CLI entrypoint.
+
+This is intentionally thin: it parses command-line flags, wires up a
+:class:`CLIPrompter`, configures DSPy, and hands off to the headless pipeline
+runner in :mod:`engine.pipeline`. All generation logic lives in
+:mod:`engine.stages`.
+"""
+
+from __future__ import annotations
+
 import argparse
 import logging
+import os
+import sys
+
 from dotenv import load_dotenv
+from rich.console import Console
+
+from engine import PipelineOptions, StoryState, run_all
 from engine.config import configure_dspy, initialize_text_generators
+from engine.prompter_cli import CLIPrompter
+from engine.writers import write_markdown
 from logging_config import setup_logging
-from postprocessing import find_similar_sentences, format_report
+
 
 load_dotenv()
 
 logger = logging.getLogger(__name__)
-
-console = Console()
 
 
 def _env_flag_true(name: str, default: bool = False) -> bool:
@@ -25,23 +34,8 @@ def _env_flag_true(name: str, default: bool = False) -> bool:
         return default
     return raw_value.strip().lower() in {"1", "true", "yes", "on"}
 
-def get_answers_for_questions(questions_with_answers) -> str:
-    qa_pairs = []
-    for i, qa in enumerate(questions_with_answers):
-        console.print(f"\n[bold cyan]Question {i+1}:[/bold cyan] {qa.question}")
-        console.print(f"[bold green]Proposed Answer:[/bold green] {qa.proposed_answer}")
 
-        accept = Confirm.ask("Accept this proposed answer?")
-        if accept:
-            user_answer = qa.proposed_answer
-        else:
-            user_answer = Prompt.ask("Enter your answer")
-
-        qa_pairs.append(f"Q: {qa.question}\nA: {user_answer}")
-
-    return "\n\n".join(qa_pairs)
-
-def main():
+def _build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="AI DSPy Story Writer")
     parser.add_argument("--model", type=str, default=os.environ.get("MODEL", "openai/gpt-4o-mini"), help="The language model to use (e.g., openai/gpt-4o-mini, ollama_chat/llama3). Defaults to MODEL env var.")
     parser.add_argument("--llm-url", type=str, default=os.environ.get("LLM_URL"), help="The custom API base URL (e.g., http://localhost:11434 for Ollama). Defaults to LLM_URL env var.")
@@ -97,10 +91,36 @@ def main():
         default=1.35,
         help="Target chapter expansion ratio for inpainting (must be > 1.0, default: 1.35).",
     )
+    return parser
 
+
+def _options_from_args(args: argparse.Namespace) -> PipelineOptions:
+    return PipelineOptions(
+        enable_images=args.enable_images,
+        replicate_api_token=args.replicate_api_token,
+        inpaint_chapters=args.inpaint_chapters,
+        inpaint_ratio=args.inpaint_ratio,
+        check_similar=args.check_similar,
+        similar_threshold=args.similar_threshold,
+        use_optimized=args.use_optimized,
+        optimized_manifest=args.optimized_manifest,
+    )
+
+
+def main() -> int:
+    parser = _build_arg_parser()
     args = parser.parse_args()
 
     setup_logging(verbosity=args.verbose, log_file=args.log_file)
+
+    options = _options_from_args(args)
+    try:
+        options.validate()
+    except ValueError as exc:
+        # Surface the same CLI-friendly error the old code raised for bad
+        # --inpaint-ratio / missing --replicate-api-token combinations.
+        parser.error(str(exc))
+
     configure_dspy(
         model_name=args.model,
         api_base=args.llm_url,
@@ -111,237 +131,26 @@ def main():
         cache_dir=args.cache_dir,
     )
 
+    console = Console()
     console.print("[bold magenta]Welcome to the AI DSPy Story Writer![/bold magenta]")
 
-    # 1. Prompt for initial idea
-    idea = Prompt.ask("\n[bold yellow]What is your initial story idea/prompt?[/bold yellow]")
-
-    # Initialize generators
+    prompter = CLIPrompter(console=console)
     generators = initialize_text_generators(
         use_optimized=args.use_optimized,
         optimized_manifest=args.optimized_manifest,
     )
-    q_gen = generators["QuestionGenerator"]
-    cp_gen = generators["CorePremiseGenerator"]
-    st_gen = generators["SpineTemplateGenerator"]
-    wb_gen = generators["WorldBibleGenerator"]
-    story_gen = generators["StoryGenerator"]
-    chapter_inpainting_gen = generators["ChapterInpaintingGenerator"]
 
-    core_premise = ""
-    while True:
-        # 2. Ask questions
-        console.print("\n[italic]Generating questions to interrogate your idea...[/italic]")
-        q_result = q_gen(idea=idea)
+    state = StoryState()
+    state = run_all(state, generators, prompter, options)
 
-        qa_text = get_answers_for_questions(q_result.questions_with_answers)
+    output_path = os.path.join(args.output_dir, "story_output.md")
+    write_markdown(state, output_path)
+    console.print(
+        f"\n[bold magenta]Story generation complete! "
+        f"Results saved to {output_path}[/bold magenta]"
+    )
+    return 0
 
-        # 3. Generate Core Premise
-        console.print("\n[italic]Generating Core Premise...[/italic]")
-        cp_result = cp_gen(idea=idea, qa_pairs=qa_text)
-        core_premise = cp_result.core_premise
-
-        console.print("\n[bold magenta]--- Core Premise ---[/bold magenta]")
-        console.print(core_premise)
-        console.print("[bold magenta]--------------------[/bold magenta]")
-
-        refine = Confirm.ask("Do you want to refine this premise? (Choosing 'Yes' will let you provide more details and regenerate, 'No' proceeds)", default=False)
-        if refine:
-            refinement_details = Prompt.ask("Provide more details or changes")
-            idea = f"Original idea: {idea}\nRefinements: {refinement_details}\nCurrent Core Premise: {core_premise}"
-        else:
-            break
-
-    # 4. Generate Spine Template
-    console.print("\n[italic]Generating Spine Template...[/italic]")
-    st_result = st_gen(core_premise=core_premise)
-    spine_template = st_result.spine_template
-
-    console.print("\n[bold blue]--- Spine Template ---[/bold blue]")
-    console.print(spine_template)
-    console.print("[bold blue]--------------------[/bold blue]")
-
-    Confirm.ask("Press Enter to continue to World Bible generation...", default=True, show_default=False)
-
-    # 5. Ask World Bible Questions
-    console.print("\n[italic]Generating follow-up questions to help flesh out the World Bible...[/italic]")
-    wb_q_gen = generators["WorldBibleQuestionGenerator"]
-    wb_q_result = wb_q_gen(core_premise=core_premise, spine_template=spine_template)
-
-    wb_qa_text = get_answers_for_questions(wb_q_result.questions_with_answers)
-
-    # 6. Generate World Bible
-    console.print("\n[italic]Generating World Bible...[/italic]")
-    wb_result = wb_gen(core_premise=core_premise, spine_template=spine_template, user_additions=wb_qa_text)
-    world_bible = wb_result.world_bible
-
-    console.print("\n[bold green]--- World Bible ---[/bold green]")
-    console.print(world_bible)
-    console.print("[bold green]-------------------[/bold green]")
-
-    # 7. Character visuals & portrait generation (if images enabled)
-    character_visuals = []
-    character_portrait_paths = {}
-    character_visuals_summary = ""
-    image_gen = None
-
-    if args.enable_images:
-        if not args.replicate_api_token:
-            console.print("[bold red]Error: --enable-images requires a Replicate API token. "
-                          "Set REPLICATE_API_TOKEN env var or pass --replicate-api-token.[/bold red]")
-            return
-
-        from image_gen import ImageGenerator
-        image_gen = ImageGenerator(api_token=args.replicate_api_token)
-
-        console.print("\n[italic]Generating character visual descriptions...[/italic]")
-        cv_describer = CharacterVisualDescriber()
-        cv_result = cv_describer(world_bible=world_bible)
-        character_visuals = cv_result.character_visuals
-
-        lines = []
-        for cv in character_visuals:
-            console.print(f"\n[bold cyan]{cv.name}:[/bold cyan] {cv.reference_mix}")
-            console.print(f"  [dim]{cv.distinguishing_features}[/dim]")
-            lines.append(
-                f"- {cv.name}: {cv.reference_mix}. {cv.distinguishing_features}"
-            )
-        character_visuals_summary = "\n".join(lines)
-
-        console.print("\n[italic]Generating character portraits...[/italic]")
-        for cv in character_visuals:
-            try:
-                path = image_gen.generate_character_portrait(
-                    prompt=cv.full_prompt, character_name=cv.name
-                )
-                character_portrait_paths[cv.name] = path
-                console.print(f"  [green]Saved portrait:[/green] {path}")
-            except Exception as e:
-                console.print(f"  [red]Failed to generate portrait for {cv.name}: {e}[/red]")
-
-    Confirm.ask("Press Enter to continue to Story generation...", default=True, show_default=False)
-
-    # 8. Generate Story
-    console.print("\n[italic]Generating Story (Arc Outline, Chapter Plan, Final Story)...[/italic]")
-    story_result = story_gen(core_premise=core_premise, spine_template=spine_template, world_bible=world_bible)
-
-    console.print("\n[bold red]--- Level 1: Arc Outline ---[/bold red]")
-    console.print(story_result.arc_outline)
-
-    console.print("\n[bold red]--- Level 2: Chapter Plan ---[/bold red]")
-    console.print(story_result.chapter_plan)
-
-    console.print("\n[bold red]--- Enhancers Guide ---[/bold red]")
-    console.print(story_result.enhancers_guide)
-
-    console.print("\n[bold red]--- Final Story ---[/bold red]")
-    console.print(story_result.story)
-
-    final_story_text = story_result.story
-    if args.inpaint_chapters:
-        if args.inpaint_ratio <= 1.0:
-            parser.error("--inpaint-ratio must be greater than 1.0")
-
-        console.print("\n[italic]Running chapter inpainting pass...[/italic]")
-        inpaint_result = chapter_inpainting_gen(
-            story=story_result.story,
-            world_bible=world_bible,
-            chapter_plan=story_result.chapter_plan,
-            expansion_ratio=args.inpaint_ratio,
-        )
-        final_story_text = inpaint_result.story
-
-        console.print(
-            "[italic]Chapter inpainting complete "
-            f"({inpaint_result.expanded_chapters}/{inpaint_result.total_chapters} chapters expanded).[/italic]"
-        )
-        console.print("\n[bold red]--- Inpainted Story ---[/bold red]")
-        console.print(final_story_text)
-
-    # 9. Generate scene illustrations for each chapter (if images enabled)
-    scene_image_paths = {}
-    if args.enable_images and image_gen:
-        console.print("\n[italic]Generating scene illustrations for each chapter...[/italic]")
-        scene_prompt_gen = SceneImagePromptGenerator()
-
-        chapters = final_story_text.split("### Chapter ")
-        chapters = [c for c in chapters if c.strip()]
-
-        reference_paths = list(character_portrait_paths.values())
-
-        for i, chapter_text in enumerate(chapters, start=1):
-            try:
-                prompt_result = scene_prompt_gen(
-                    chapter_text=chapter_text,
-                    character_visuals_summary=character_visuals_summary,
-                )
-                path = image_gen.generate_scene_illustration(
-                    prompt=prompt_result.image_prompt,
-                    reference_image_paths=reference_paths,
-                    chapter_index=i,
-                )
-                scene_image_paths[i] = path
-                console.print(f"  [green]Chapter {i} scene:[/green] {path}")
-            except Exception as e:
-                console.print(f"  [red]Failed to generate scene for chapter {i}: {e}[/red]")
-
-    # 10. Post-processing: detect similar sentences
-    if args.check_similar:
-        console.print("\n[bold yellow]--- Similar Sentence Check ---[/bold yellow]")
-        similar_pairs = find_similar_sentences(
-            final_story_text, threshold=args.similar_threshold,
-        )
-        report = format_report(similar_pairs)
-        console.print(report)
-        if similar_pairs:
-            logger.warning(
-                "Detected %d similar sentence pair(s) in generated story",
-                len(similar_pairs),
-            )
-
-    # 11. Save output to markdown
-    os.makedirs(args.output_dir, exist_ok=True)
-    output_filename = os.path.join(args.output_dir, "story_output.md")
-    logger.info(f"Saving story output to {output_filename}...")
-    with open(output_filename, "w", encoding="utf-8") as f:
-        f.write("# Story Output\n\n")
-        f.write("## Core Premise\n")
-        f.write(f"{core_premise}\n\n")
-        f.write("## Spine Template\n")
-        f.write(f"{spine_template}\n\n")
-        f.write("## World Bible\n")
-        f.write(f"{world_bible}\n\n")
-
-        if character_visuals:
-            f.write("## Character Visuals\n\n")
-            for cv in character_visuals:
-                f.write(f"### {cv.name}\n")
-                f.write(f"**Reference:** {cv.reference_mix}\n\n")
-                f.write(f"**Features:** {cv.distinguishing_features}\n\n")
-                portrait = character_portrait_paths.get(cv.name)
-                if portrait:
-                    f.write(f"![{cv.name} portrait]({portrait})\n\n")
-
-        f.write("## Arc Outline\n")
-        f.write(f"{story_result.arc_outline}\n\n")
-        f.write("## Chapter Plan\n")
-        f.write(f"{story_result.chapter_plan}\n\n")
-        f.write("## Enhancers Guide\n")
-        f.write(f"{story_result.enhancers_guide}\n\n")
-        f.write("## Final Story\n")
-
-        if scene_image_paths:
-            chapters = final_story_text.split("### Chapter ")
-            chapters = [c for c in chapters if c.strip()]
-            for i, chapter_text in enumerate(chapters, start=1):
-                f.write(f"\n\n### Chapter {chapter_text}")
-                scene = scene_image_paths.get(i)
-                if scene:
-                    f.write(f"\n\n![Chapter {i} scene]({scene})\n")
-        else:
-            f.write(f"{final_story_text}\n")
-
-    console.print(f"\n[bold magenta]Story generation complete! Results saved to {output_filename}[/bold magenta]")
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/scripts/run_headless.py
+++ b/scripts/run_headless.py
@@ -1,0 +1,147 @@
+"""Headless story-generation driver.
+
+Reads a JSON file of pre-answered inputs and runs the full pipeline without
+touching stdin or rendering rich output. This is a thin stand-in for the
+future FastAPI worker — if this script works end-to-end for a given input,
+wrapping it in a job queue is mechanical.
+
+Input JSON schema (all fields required unless noted):
+
+    {
+      "idea": "A young wizard defends a floating city.",
+      "answer_batches": [
+        [null, "override answer 2"],   // first answer_questions call (ideation)
+        [null]                          // second call (world bible)
+      ],
+      "premise_decisions": [
+        {"accept": true}
+      ],
+      "options": {                      // optional; defaults match CLI
+        "enable_images": false,
+        "replicate_api_token": null,
+        "inpaint_chapters": false,
+        "inpaint_ratio": 1.35,
+        "check_similar": true,
+        "similar_threshold": 0.65,
+        "use_optimized": false,
+        "optimized_manifest": null
+      }
+    }
+
+Usage:
+    python scripts/run_headless.py --input script.json --output-dir .tmp
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+# Make the repo root importable when invoked as ``python scripts/run_headless.py``.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from dotenv import load_dotenv
+
+from engine import PipelineOptions, StoryState, run_all
+from engine.config import configure_dspy, initialize_text_generators
+from engine.prompter_scripted import PremiseDecision, ScriptedPrompter
+from engine.writers import write_markdown
+from logging_config import setup_logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def _load_script(path: str) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _build_prompter(script: dict) -> ScriptedPrompter:
+    decisions = [
+        PremiseDecision(
+            accept=bool(d.get("accept", False)),
+            refinement_details=str(d.get("refinement_details", "")),
+        )
+        for d in script.get("premise_decisions", [])
+    ]
+    return ScriptedPrompter(
+        idea=script["idea"],
+        answer_batches=script.get("answer_batches", []),
+        premise_decisions=decisions,
+        notify_sink=lambda level, msg: logger.info("[%s] %s", level, msg),
+    )
+
+
+def _build_options(script: dict) -> PipelineOptions:
+    raw = script.get("options", {}) or {}
+    return PipelineOptions(
+        enable_images=bool(raw.get("enable_images", False)),
+        replicate_api_token=raw.get("replicate_api_token")
+        or os.environ.get("REPLICATE_API_TOKEN"),
+        inpaint_chapters=bool(raw.get("inpaint_chapters", False)),
+        inpaint_ratio=float(raw.get("inpaint_ratio", 1.35)),
+        check_similar=bool(raw.get("check_similar", True)),
+        similar_threshold=float(raw.get("similar_threshold", 0.65)),
+        use_optimized=bool(raw.get("use_optimized", False)),
+        optimized_manifest=raw.get("optimized_manifest"),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, help="Path to script JSON.")
+    parser.add_argument(
+        "--output-dir", default=".tmp", help="Directory for markdown + state output."
+    )
+    parser.add_argument(
+        "--model",
+        default=os.environ.get("MODEL", "openai/gpt-4o-mini"),
+        help="LLM model identifier.",
+    )
+    parser.add_argument("--llm-url", default=os.environ.get("LLM_URL"))
+    parser.add_argument("--api-key", default=os.environ.get("API_KEY"))
+    parser.add_argument("--max-tokens", type=int, default=8000)
+    parser.add_argument("-v", "--verbose", action="count", default=1)
+    args = parser.parse_args(argv)
+
+    load_dotenv()
+    setup_logging(verbosity=args.verbose, log_file=None)
+
+    script = _load_script(args.input)
+    prompter = _build_prompter(script)
+    options = _build_options(script)
+    options.validate()
+
+    configure_dspy(
+        model_name=args.model,
+        api_base=args.llm_url,
+        api_key=args.api_key,
+        max_tokens=args.max_tokens,
+    )
+    generators = initialize_text_generators(
+        use_optimized=options.use_optimized,
+        optimized_manifest=options.optimized_manifest,
+    )
+
+    state = run_all(StoryState(), generators, prompter, options)
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    md_path = os.path.join(args.output_dir, "story_output.md")
+    write_markdown(state, md_path)
+
+    # Also dump the raw state JSON — this is what a worker would persist.
+    state_path = os.path.join(args.output_dir, "story_state.json")
+    with open(state_path, "w", encoding="utf-8") as f:
+        json.dump(state.to_dict(), f, indent=2, ensure_ascii=False)
+
+    logger.info("Wrote %s and %s", md_path, state_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test_engine_pipeline.py
+++ b/test_engine_pipeline.py
@@ -1,0 +1,286 @@
+"""End-to-end headless pipeline tests.
+
+Exercises :func:`engine.pipeline.run_all` with ``FakeGen`` stand-ins for the
+DSPy modules and a :class:`ScriptedPrompter` — no LLM calls, no rich/TTY.
+This is the contract the future FastAPI worker will rely on.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from engine import PipelineOptions, StageName, StoryState, run_all
+from engine.pipeline import default_stage_order
+from engine.prompter_scripted import PremiseDecision, ScriptedPrompter
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeGen:
+    """Canned-response stand-in for a dspy.Module.
+
+    Records every call for assertions.
+    """
+
+    def __init__(self, result: Any) -> None:
+        self.result = result
+        self.calls: list[dict] = []
+
+    def __call__(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        return self.result
+
+
+def _qa(question: str, proposed: str) -> SimpleNamespace:
+    return SimpleNamespace(question=question, proposed_answer=proposed)
+
+
+def _build_generators() -> dict[str, FakeGen]:
+    return {
+        "QuestionGenerator": FakeGen(
+            SimpleNamespace(
+                questions_with_answers=[
+                    _qa("Who is the protagonist?", "A young wizard"),
+                    _qa("Where?", "In a floating city"),
+                ]
+            )
+        ),
+        "CorePremiseGenerator": FakeGen(
+            SimpleNamespace(core_premise="A young wizard defends a floating city.")
+        ),
+        "SpineTemplateGenerator": FakeGen(
+            SimpleNamespace(spine_template="Once upon a time...")
+        ),
+        "WorldBibleQuestionGenerator": FakeGen(
+            SimpleNamespace(
+                questions_with_answers=[_qa("What is the magic system?", "Rune-based")]
+            )
+        ),
+        "WorldBibleGenerator": FakeGen(
+            SimpleNamespace(world_bible="Rune-based magic, floating city of Aethel.")
+        ),
+        "StoryGenerator": FakeGen(
+            SimpleNamespace(
+                arc_outline="Arc outline",
+                chapter_plan="Chapter 1: Arrival\nChapter 2: Oath",
+                enhancers_guide="Tension: high",
+                story=(
+                    "### Chapter 1: Arrival\n\n"
+                    "The caravan reached the gates at dusk.\n\n"
+                    "### Chapter 2: Oath\n\n"
+                    "She swore to protect the archive."
+                ),
+            )
+        ),
+        "ChapterInpaintingGenerator": FakeGen(
+            SimpleNamespace(
+                story=(
+                    "### Chapter 1: Arrival\n\n"
+                    "The weary caravan, laden with salt and silk, reached "
+                    "the gates at dusk.\n\n"
+                    "### Chapter 2: Oath\n\n"
+                    "Beneath the runed arches she swore to protect the archive."
+                ),
+                expanded_chapters=2,
+                total_chapters=2,
+            )
+        ),
+    }
+
+
+def _scripted_prompter(**overrides) -> ScriptedPrompter:
+    defaults = dict(
+        idea="A young wizard defends a floating city.",
+        # One ideation round (premise accepted on first try) + one WB round.
+        answer_batches=[[None, "A mountain city"], [None]],
+        premise_decisions=[PremiseDecision(accept=True)],
+    )
+    defaults.update(overrides)
+    return ScriptedPrompter(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Stage ordering
+# ---------------------------------------------------------------------------
+
+
+def test_default_stage_order_text_only():
+    order = default_stage_order(PipelineOptions(check_similar=False))
+    assert order == [
+        StageName.IDEATE,
+        StageName.PREMISE,
+        StageName.SPINE,
+        StageName.WORLD_BIBLE_QUESTIONS,
+        StageName.WORLD_BIBLE,
+        StageName.STORY,
+    ]
+
+
+def test_default_stage_order_with_all_optional():
+    order = default_stage_order(
+        PipelineOptions(
+            enable_images=True,
+            replicate_api_token="tok",
+            inpaint_chapters=True,
+            inpaint_ratio=1.35,
+            check_similar=True,
+        )
+    )
+    assert order == [
+        StageName.IDEATE,
+        StageName.PREMISE,
+        StageName.SPINE,
+        StageName.WORLD_BIBLE_QUESTIONS,
+        StageName.WORLD_BIBLE,
+        StageName.CHARACTER_VISUALS,
+        StageName.CHARACTER_PORTRAITS,
+        StageName.STORY,
+        StageName.INPAINT,
+        StageName.SCENE_IMAGES,
+        StageName.SIMILARITY_CHECK,
+    ]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end (text pipeline, no images)
+# ---------------------------------------------------------------------------
+
+
+def test_run_all_text_pipeline_populates_full_state():
+    generators = _build_generators()
+    prompter = _scripted_prompter()
+    options = PipelineOptions(check_similar=False)
+
+    state = run_all(StoryState(), generators, prompter, options)
+
+    assert state.idea == "A young wizard defends a floating city."
+    assert state.core_premise == "A young wizard defends a floating city."
+    assert state.spine_template == "Once upon a time..."
+    assert state.world_bible == "Rune-based magic, floating city of Aethel."
+    assert state.chapter_plan.startswith("Chapter 1: Arrival")
+    assert "### Chapter 1: Arrival" in state.final_story_text
+    # No inpaint → final matches story_text.
+    assert state.final_story_text == state.story_text
+
+
+def test_run_all_invokes_on_stage_complete_for_every_stage():
+    generators = _build_generators()
+    prompter = _scripted_prompter()
+    options = PipelineOptions(check_similar=False)
+
+    seen: list[StageName] = []
+    run_all(
+        StoryState(),
+        generators,
+        prompter,
+        options,
+        on_stage_complete=lambda stage, _state: seen.append(stage),
+    )
+    assert seen == default_stage_order(options)
+
+
+def test_run_all_answered_qa_feeds_downstream_generators():
+    generators = _build_generators()
+    prompter = _scripted_prompter(
+        answer_batches=[["overridden protagonist", None], [None]],
+    )
+    options = PipelineOptions(check_similar=False)
+
+    run_all(StoryState(), generators, prompter, options)
+
+    premise_call = generators["CorePremiseGenerator"].calls[0]
+    # First answer was overridden; second falls back to the proposed answer.
+    assert "overridden protagonist" in premise_call["qa_pairs"]
+    assert "In a floating city" in premise_call["qa_pairs"]
+
+
+def test_run_all_refine_loop_stacks_idea_across_iterations():
+    generators = _build_generators()
+    # Two generator rounds happen; the second run of ideation needs answers
+    # too. Pad the scripted answers accordingly.
+    prompter = ScriptedPrompter(
+        idea="seed idea",
+        # Two ideation rounds (one refine + one accept) + one WB round.
+        answer_batches=[[None, None], [None, None], [None]],
+        premise_decisions=[
+            PremiseDecision(accept=False, refinement_details="make it darker"),
+            PremiseDecision(accept=True),
+        ],
+    )
+    options = PipelineOptions(check_similar=False)
+
+    run_all(StoryState(), generators, prompter, options)
+
+    q_calls = generators["QuestionGenerator"].calls
+    assert len(q_calls) == 2, "expected one question generation per refine loop"
+    # Second iteration's idea should include the previous premise and
+    # the refinement text.
+    assert "Original idea: seed idea" in q_calls[1]["idea"]
+    assert "make it darker" in q_calls[1]["idea"]
+
+
+# ---------------------------------------------------------------------------
+# Inpainting + similarity check (post-processing stages)
+# ---------------------------------------------------------------------------
+
+
+def test_run_all_with_inpaint_replaces_final_story_text():
+    generators = _build_generators()
+    prompter = _scripted_prompter()
+    options = PipelineOptions(
+        inpaint_chapters=True, inpaint_ratio=1.35, check_similar=False
+    )
+
+    state = run_all(StoryState(), generators, prompter, options)
+
+    assert "laden with salt and silk" in state.final_story_text
+    # Pre-inpaint text stays on ``story_text`` for traceability.
+    assert "laden with salt and silk" not in state.story_text
+    assert state.story_text != state.final_story_text
+
+
+def test_run_all_similarity_check_records_report():
+    generators = _build_generators()
+    prompter = _scripted_prompter()
+    options = PipelineOptions(check_similar=True, similar_threshold=0.65)
+
+    state = run_all(StoryState(), generators, prompter, options)
+
+    assert state.similarity_report is not None
+    # Our fake story is too short to trigger duplicates, but the report
+    # must still be populated (even as an empty result).
+    assert isinstance(state.similarity_report, str)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_run_all_validates_options_upfront():
+    generators = _build_generators()
+    prompter = _scripted_prompter()
+    # enable_images without a token must fail fast, before any stage runs.
+    options = PipelineOptions(enable_images=True, replicate_api_token=None)
+
+    with pytest.raises(ValueError, match="replicate_api_token"):
+        run_all(StoryState(), generators, prompter, options)
+
+    # No generator should have been called.
+    assert generators["QuestionGenerator"].calls == []
+
+
+def test_state_survives_json_roundtrip_after_full_run():
+    generators = _build_generators()
+    prompter = _scripted_prompter()
+    options = PipelineOptions(check_similar=False)
+
+    state = run_all(StoryState(), generators, prompter, options)
+    restored = StoryState.from_dict(state.to_dict())
+    assert restored == state

--- a/test_engine_prompter.py
+++ b/test_engine_prompter.py
@@ -19,38 +19,36 @@ def test_ask_idea_without_idea_raises():
         ScriptedPrompter().ask_idea()
 
 
-def test_answer_questions_routes_first_call_to_ideation_and_second_to_world_bible():
+def test_answer_questions_pops_batches_in_order():
     prompter = ScriptedPrompter(
         idea="x",
-        ideation_answers=["iA", None, "iC"],
-        world_bible_answers=["wA"],
+        answer_batches=[["iA", None, "iC"], ["wA"]],
     )
 
-    ideation = prompter.answer_questions(_questions(3))
-    assert [qa.user_answer for qa in ideation] == ["iA", None, "iC"]
+    first = prompter.answer_questions(_questions(3))
+    assert [qa.user_answer for qa in first] == ["iA", None, "iC"]
     # Accepting the proposed answer is represented by user_answer=None;
     # effective_answer should fall back to the proposed value.
-    assert ideation[1].effective_answer == "p1"
+    assert first[1].effective_answer == "p1"
 
-    wb = prompter.answer_questions(_questions(1))
-    assert [qa.user_answer for qa in wb] == ["wA"]
+    second = prompter.answer_questions(_questions(1))
+    assert [qa.user_answer for qa in second] == ["wA"]
 
 
-def test_answer_questions_raises_if_script_exhausted():
-    prompter = ScriptedPrompter(idea="x", ideation_answers=["only one"])
-    with pytest.raises(RuntimeError, match="ideation answers"):
+def test_answer_questions_raises_when_batch_too_short():
+    prompter = ScriptedPrompter(idea="x", answer_batches=[["only one"]])
+    with pytest.raises(RuntimeError, match="batch has 1 answers"):
         prompter.answer_questions(_questions(2))
 
 
-def test_answer_questions_raises_on_third_call():
+def test_answer_questions_raises_when_batches_exhausted():
     prompter = ScriptedPrompter(
         idea="x",
-        ideation_answers=["a"],
-        world_bible_answers=["b"],
+        answer_batches=[["a"], ["b"]],
     )
     prompter.answer_questions(_questions(1))
     prompter.answer_questions(_questions(1))
-    with pytest.raises(RuntimeError, match="more than twice"):
+    with pytest.raises(RuntimeError, match="more times than"):
         prompter.answer_questions(_questions(1))
 
 

--- a/test_engine_prompter.py
+++ b/test_engine_prompter.py
@@ -1,0 +1,91 @@
+"""Unit tests for the :class:`ScriptedPrompter` contract."""
+
+import pytest
+
+from engine.prompter_scripted import PremiseDecision, ScriptedPrompter
+from engine.types import QAPair
+
+
+def _questions(n: int) -> list[QAPair]:
+    return [QAPair(f"q{i}", f"p{i}") for i in range(n)]
+
+
+def test_ask_idea_returns_provided_idea():
+    assert ScriptedPrompter(idea="a wizard").ask_idea() == "a wizard"
+
+
+def test_ask_idea_without_idea_raises():
+    with pytest.raises(RuntimeError, match="no idea"):
+        ScriptedPrompter().ask_idea()
+
+
+def test_answer_questions_routes_first_call_to_ideation_and_second_to_world_bible():
+    prompter = ScriptedPrompter(
+        idea="x",
+        ideation_answers=["iA", None, "iC"],
+        world_bible_answers=["wA"],
+    )
+
+    ideation = prompter.answer_questions(_questions(3))
+    assert [qa.user_answer for qa in ideation] == ["iA", None, "iC"]
+    # Accepting the proposed answer is represented by user_answer=None;
+    # effective_answer should fall back to the proposed value.
+    assert ideation[1].effective_answer == "p1"
+
+    wb = prompter.answer_questions(_questions(1))
+    assert [qa.user_answer for qa in wb] == ["wA"]
+
+
+def test_answer_questions_raises_if_script_exhausted():
+    prompter = ScriptedPrompter(idea="x", ideation_answers=["only one"])
+    with pytest.raises(RuntimeError, match="ideation answers"):
+        prompter.answer_questions(_questions(2))
+
+
+def test_answer_questions_raises_on_third_call():
+    prompter = ScriptedPrompter(
+        idea="x",
+        ideation_answers=["a"],
+        world_bible_answers=["b"],
+    )
+    prompter.answer_questions(_questions(1))
+    prompter.answer_questions(_questions(1))
+    with pytest.raises(RuntimeError, match="more than twice"):
+        prompter.answer_questions(_questions(1))
+
+
+def test_confirm_premise_walks_decisions_in_order():
+    prompter = ScriptedPrompter(
+        idea="x",
+        premise_decisions=[
+            PremiseDecision(accept=False, refinement_details="more noir"),
+            PremiseDecision(accept=True),
+        ],
+    )
+    accept, details = prompter.confirm_premise("v1")
+    assert not accept and details == "more noir"
+
+    accept, details = prompter.confirm_premise("v2")
+    assert accept and details == ""
+
+
+def test_confirm_premise_raises_when_exhausted():
+    prompter = ScriptedPrompter(idea="x", premise_decisions=[])
+    with pytest.raises(RuntimeError, match="exhausted"):
+        prompter.confirm_premise("v1")
+
+
+def test_notify_forwards_to_sink_when_provided():
+    received: list[tuple[str, str]] = []
+    prompter = ScriptedPrompter(
+        idea="x",
+        notify_sink=lambda level, msg: received.append((level, msg)),
+    )
+    prompter.notify("info", "hello")
+    prompter.notify("error", "boom")
+    assert received == [("info", "hello"), ("error", "boom")]
+
+
+def test_wait_continue_is_noop():
+    # Must not raise and must not block.
+    ScriptedPrompter(idea="x").wait_continue("press enter")

--- a/test_engine_types.py
+++ b/test_engine_types.py
@@ -1,0 +1,101 @@
+"""Unit tests for ``engine.types`` serialization and validation."""
+
+import pytest
+
+from engine.types import (
+    CharacterVisualState,
+    PipelineOptions,
+    QAPair,
+    StageName,
+    StoryState,
+)
+
+
+def test_qapair_effective_answer_prefers_user_answer():
+    assert QAPair("q", "prop", "override").effective_answer == "override"
+    assert QAPair("q", "prop", None).effective_answer == "prop"
+
+
+def test_qapair_roundtrip():
+    original = QAPair("q", "p", "u")
+    restored = QAPair.from_dict(original.to_dict())
+    assert restored == original
+
+
+def test_character_visual_state_roundtrip_tolerates_missing_fields():
+    cv = CharacterVisualState.from_dict({"name": "Alice"})
+    assert cv.name == "Alice"
+    assert cv.reference_mix == ""
+    assert cv.distinguishing_features == ""
+    assert cv.full_prompt == ""
+
+
+def test_story_state_roundtrip_preserves_nested_state():
+    original = StoryState(
+        idea="a wizard",
+        ideation_qa=[
+            QAPair("Q1?", "proposed", "user ans"),
+            QAPair("Q2?", "p2", None),
+        ],
+        core_premise="premise",
+        spine_template="spine",
+        world_bible_qa=[QAPair("wq?", "wp", None)],
+        world_bible="wb",
+        character_visuals=[
+            CharacterVisualState("Alice", "ref", "feat", "prompt"),
+        ],
+        character_portrait_paths={"Alice": "/tmp/a.png"},
+        arc_outline="arc",
+        chapter_plan="cp",
+        enhancers_guide="eg",
+        story_text="story",
+        final_story_text="final",
+        scene_image_paths={1: "/tmp/1.png", 2: "/tmp/2.png"},
+        similarity_report="similar",
+    )
+    restored = StoryState.from_dict(original.to_dict())
+    assert restored == original
+
+
+def test_story_state_scene_image_keys_roundtrip_as_ints():
+    # JSON serialization forces string keys; ensure we coerce back to int
+    # so downstream code can index by chapter number.
+    state = StoryState(scene_image_paths={3: "/x.png"})
+    as_dict = state.to_dict()
+    assert as_dict["scene_image_paths"] == {"3": "/x.png"}
+    restored = StoryState.from_dict(as_dict)
+    assert restored.scene_image_paths == {3: "/x.png"}
+
+
+def test_pipeline_options_rejects_bad_inpaint_ratio():
+    opts = PipelineOptions(inpaint_chapters=True, inpaint_ratio=1.0)
+    with pytest.raises(ValueError, match="inpaint_ratio"):
+        opts.validate()
+
+
+def test_pipeline_options_requires_replicate_token_when_images_enabled():
+    opts = PipelineOptions(enable_images=True, replicate_api_token=None)
+    with pytest.raises(ValueError, match="replicate_api_token"):
+        opts.validate()
+
+
+def test_pipeline_options_rejects_out_of_range_similarity():
+    with pytest.raises(ValueError, match="similar_threshold"):
+        PipelineOptions(similar_threshold=1.5).validate()
+
+
+def test_pipeline_options_accepts_valid_combination():
+    PipelineOptions(
+        enable_images=True,
+        replicate_api_token="tok",
+        inpaint_chapters=True,
+        inpaint_ratio=1.35,
+        similar_threshold=0.65,
+    ).validate()
+
+
+def test_stage_name_values_are_stable_strings():
+    # These values are persisted; if this test breaks, a migration is needed.
+    assert StageName.IDEATE.value == "ideate"
+    assert StageName.WORLD_BIBLE_QUESTIONS.value == "world_bible_questions"
+    assert StageName.SCENE_IMAGES.value == "scene_images"

--- a/test_engine_writers.py
+++ b/test_engine_writers.py
@@ -1,0 +1,87 @@
+"""Tests for :mod:`engine.writers.markdown`."""
+
+from __future__ import annotations
+
+import os
+
+from engine.types import CharacterVisualState, StoryState
+from engine.writers.markdown import render_markdown, write_markdown
+
+
+def _base_state() -> StoryState:
+    return StoryState(
+        core_premise="A young wizard defends a floating city.",
+        spine_template="Once upon a time...",
+        world_bible="Rune-based magic.",
+        arc_outline="Arc outline",
+        chapter_plan="Chapter 1: Arrival\nChapter 2: Oath",
+        enhancers_guide="Tension: high",
+        story_text=(
+            "### Chapter 1: Arrival\n\nThe caravan reached the gates.\n\n"
+            "### Chapter 2: Oath\n\nShe swore."
+        ),
+        final_story_text=(
+            "### Chapter 1: Arrival\n\nThe caravan reached the gates.\n\n"
+            "### Chapter 2: Oath\n\nShe swore."
+        ),
+    )
+
+
+def test_render_markdown_contains_all_sections():
+    md = render_markdown(_base_state())
+    for heading in [
+        "# Story Output",
+        "## Core Premise",
+        "## Spine Template",
+        "## World Bible",
+        "## Arc Outline",
+        "## Chapter Plan",
+        "## Enhancers Guide",
+        "## Final Story",
+    ]:
+        assert heading in md
+
+
+def test_render_markdown_omits_character_visuals_when_empty():
+    md = render_markdown(_base_state())
+    assert "## Character Visuals" not in md
+
+
+def test_render_markdown_includes_character_visuals_and_portraits():
+    state = _base_state()
+    state.character_visuals = [
+        CharacterVisualState("Alice", "mix", "blue hair", "prompt"),
+    ]
+    state.character_portrait_paths = {"Alice": "/tmp/alice.png"}
+    md = render_markdown(state)
+    assert "## Character Visuals" in md
+    assert "### Alice" in md
+    assert "**Reference:** mix" in md
+    assert "**Features:** blue hair" in md
+    assert "![Alice portrait](/tmp/alice.png)" in md
+
+
+def test_render_markdown_interleaves_scene_images_when_present():
+    state = _base_state()
+    state.scene_image_paths = {1: "/tmp/1.png", 2: "/tmp/2.png"}
+    md = render_markdown(state)
+    # Legacy format: the story section is reconstructed by splitting on
+    # "### Chapter " and re-inserting the scene after each chapter.
+    assert "![Chapter 1 scene](/tmp/1.png)" in md
+    assert "![Chapter 2 scene](/tmp/2.png)" in md
+
+
+def test_render_markdown_uses_final_story_text_when_no_scene_images():
+    state = _base_state()
+    state.final_story_text = "FINAL STORY BODY"
+    md = render_markdown(state)
+    assert "FINAL STORY BODY" in md
+
+
+def test_write_markdown_creates_parent_dirs(tmp_path):
+    nested = tmp_path / "deep" / "nested" / "dir" / "story.md"
+    path = write_markdown(_base_state(), str(nested))
+    assert os.path.isfile(path)
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+    assert "# Story Output" in content

--- a/test_story.py
+++ b/test_story.py
@@ -18,7 +18,7 @@ from story_modules import (
     SceneImagePromptGenerator,
 )
 from world_bible_modules import WorldBibleGenerator
-from main import initialize_text_generators
+from engine.config import initialize_text_generators
 
 load_dotenv()
 
@@ -421,7 +421,7 @@ def test_character_visual_normalizes_description_only_shape():
 
 
 def test_initialize_text_generators_uses_loader_when_enabled():
-    with patch("main.try_load_optimized_module", return_value=True) as mocked_loader:
+    with patch("engine.config.try_load_optimized_module", return_value=True) as mocked_loader:
         generators = initialize_text_generators(
             use_optimized=True,
             optimized_manifest=".tmp/dspy_optimized/text_pipeline_manifest.json",
@@ -441,7 +441,7 @@ def test_initialize_text_generators_uses_loader_when_enabled():
 
 
 def test_initialize_text_generators_skips_loader_when_disabled():
-    with patch("main.try_load_optimized_module") as mocked_loader:
+    with patch("engine.config.try_load_optimized_module") as mocked_loader:
         generators = initialize_text_generators(use_optimized=False)
 
     assert "StoryGenerator" in generators


### PR DESCRIPTION
## Summary

This PR extracts the story generation pipeline into a headless engine package that can run independently of the interactive CLI. The refactor introduces data contracts (`StoryState`, `QAPair`, `PipelineOptions`) and a `Prompter` protocol to decouple human input handling from pipeline logic, enabling the same code to work in web workers, tests, and interactive terminals.

## Key Changes

- **New `engine/` package** with core abstractions:
  - `engine.types`: Serializable data contracts (`StoryState`, `QAPair`, `CharacterVisualState`, `PipelineOptions`, `StageName`) that replace ad-hoc locals scattered across `main.py`. All types support JSON round-tripping via `to_dict()`/`from_dict()`.
  - `engine.prompter`: Protocol defining the human-input contract (`ask_idea`, `answer_questions`, `confirm_premise`, `wait_continue`, `notify`).
  - `engine.prompter_cli`: Rich/terminal implementation of `Prompter` (replaces inline `Prompt`/`Confirm` calls in `main.py`).
  - `engine.prompter_scripted`: Deterministic, in-memory `Prompter` for web workers and tests that replays pre-collected answers without blocking.
  - `engine.config`: Extracted DSPy configuration (`configure_dspy`, `initialize_text_generators`) from `main.py` so CLI and headless workers share setup.

- **Refactored `main.py`**:
  - Removed `configure_dspy()` and `initialize_text_generators()` functions (moved to `engine.config`).
  - Updated imports to use `engine.config` instead of local definitions.
  - Preserved all CLI behavior; this is a structural refactor with no functional changes to the interactive experience.

- **Updated `test_story.py`**:
  - Changed import of `initialize_text_generators` from `main` to `engine.config`.

- **New test files**:
  - `test_engine_types.py`: Unit tests for serialization, validation, and round-tripping of all data contracts.
  - `test_engine_prompter.py`: Unit tests for `ScriptedPrompter` behavior (routing, exhaustion, notifications).

## Notable Implementation Details

- `StoryState` accumulates outputs across pipeline stages; each stage reads what it needs and writes its slice.
- `QAPair.effective_answer` property provides a clean way to handle "accept proposed" (user_answer=None) vs. "override" semantics.
- `PipelineOptions.validate()` catches invalid configurations at job-submission time rather than mid-generation.
- `StageName` enum values are stable strings persisted in databases and job queues; renaming requires migration.
- Scene image paths use integer keys (chapter numbers) internally but serialize as strings for JSON compatibility, with automatic coercion on deserialization.
- Module-level `_LANGFUSE_INSTRUMENTED` guard in `engine.config` prevents re-instrumentation in long-lived worker processes.
- `ScriptedPrompter` routes the first `answer_questions()` call to ideation answers and the second to world-bible answers, matching the pipeline's two-batch contract.

https://claude.ai/code/session_01BQB86bQvRoFpxzi17msujB