### PR TITLE
Separate image generation into a standalone script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,11 +42,25 @@ ruff format --check .                 # Check formatting without changes
 ### Running the Application
 ```bash
 python main.py                        # Basic run with default model
-python main.py --enable-images       # With image generation
+python main.py --enable-images       # With inline image generation
 python main.py -v                    # Verbose (INFO)
 python main.py -vv                   # LLM debug logging
 python main.py -vvv                  # Full HTTP+LLM firehose
 ```
+
+Every run writes `story_output.md` plus a `story_output.json` sidecar in
+`--output-dir` (default `.tmp`). The JSON is consumed by the standalone
+image script below.
+
+### Generating Images After the Fact
+```bash
+python scripts/generate_images.py \
+  --story-json .tmp/story_output.json \
+  --output-markdown .tmp/story_output.with_images.md
+```
+Flags: `--skip-portraits`, `--skip-scenes`, `--regenerate-portraits`,
+`--regenerate-scenes`, `--images-dir`, plus the usual DSPy model args
+(`--model`, `--api-key`, `--llm-url`).
 
 ### DSPy Pipeline Optimization
 ```bash
@@ -196,7 +210,10 @@ def test_specific_function():
 - `world_bible_modules.py` - World bible generation
 - `alternate_story_modules.py` - 3-phase alternative pipeline
 - `postprocessing.py` - Post-generation utilities
-- `image_gen.py` - Replicate image generation
+- `image_gen.py` - Replicate image backend (portraits + scenes)
+- `image_pipeline.py` - Shared image pipeline consuming `StoryArtifacts`
+- `story_artifacts.py` - Artifacts dataclass, JSON sidecar I/O, markdown renderer
+- `scripts/generate_images.py` - Standalone CLI to add images to an existing run
 - `logging_config.py` - Centralized logging setup
 - `dspy_optimization.py` - Module loading/optimization
 - `test_*.py` - Test files (mirror module structure)

--- a/README.md
+++ b/README.md
@@ -14,17 +14,20 @@ python main.py
 
 - Guides you through an interactive ideation flow (questions, premise refinement, spine, world bible).
 - Generates structured story artifacts (arc outline, chapter plan, enhancers guide, full story).
-- Optionally generates character portraits and per-chapter scene illustrations via Replicate.
-- Writes all outputs to a markdown file in your chosen output directory.
+- Optionally generates character portraits and per-chapter scene illustrations via Replicate, either inline during a run or after the fact via `scripts/generate_images.py`.
+- Writes outputs as a human-readable markdown file plus a structured JSON sidecar.
 
 ## Project Layout
 
 - `main.py` — primary interactive CLI for story generation.
 - `story_modules.py` — core story generation modules/signatures.
 - `world_bible_modules.py` — world bible question + generation modules.
-- `image_gen.py` — Replicate-based image generation helpers.
+- `image_gen.py` — Replicate-based image backend (portraits + scenes).
+- `image_pipeline.py` — shared image pipeline (describe characters, generate portraits/scenes) consumed by both `main.py` and the standalone script.
+- `story_artifacts.py` — `StoryArtifacts` dataclass + JSON sidecar I/O + markdown rendering.
 - `logging_config.py` — centralized logging configuration.
 - `alternate_story_modules.py` — alternate Architect→Director→Scripter→Writer pipeline modules.
+- `scripts/generate_images.py` — standalone CLI that adds/refreshes images on an existing story JSON.
 - `scripts/fetch_langfuse_traces.py` — utility to fetch/summarize Langfuse traces.
 - `test_story.py`, `test_alternate.py` — pytest coverage for main and alternate pipelines.
 
@@ -146,9 +149,10 @@ python scripts/optimize_text_pipeline.py \
 
 ## Output
 
-By default, output is written to:
+By default, every run writes two files to the output directory (default `.tmp`):
 
-- `.tmp/story_output.md`
+- `story_output.md` — human-readable markdown view.
+- `story_output.json` — structured sidecar with all text artifacts plus any image paths. This is the input format consumed by `scripts/generate_images.py`.
 
 The markdown includes:
 
@@ -160,6 +164,26 @@ The markdown includes:
 - Enhancers Guide
 - Final Story
 - Optional character portraits / scene image embeds when images are enabled
+
+## Generating Images After the Fact
+
+If you generated a story without `--enable-images` and want images later, feed the saved JSON to the standalone script:
+
+```bash
+python scripts/generate_images.py \
+  --story-json .tmp/story_output.json \
+  --output-markdown .tmp/story_output.with_images.md
+```
+
+By default it writes updated image paths back into the same JSON. Useful flags:
+
+- `--skip-portraits`, `--skip-scenes` — do only one kind of image.
+- `--regenerate-portraits`, `--regenerate-scenes` — replace images already recorded in the JSON.
+- `--output-json`, `--output-markdown` — write to new files instead of mutating in place.
+- `--images-dir` — where to save image files (default `images/`).
+- `--model` / `--api-key` / `--llm-url` — the text LLM used to derive image prompts from the world bible and chapters.
+
+You still need `REPLICATE_API_TOKEN` (or `--replicate-api-token`).
 
 ## Logging Behavior
 

--- a/image_pipeline.py
+++ b/image_pipeline.py
@@ -1,0 +1,186 @@
+"""Image generation pipeline shared by the interactive run and the standalone
+script.
+
+The functions here consume/produce :class:`story_artifacts.StoryArtifacts`
+objects so images can be generated either inline during a fresh story run or
+after the fact from a saved JSON sidecar.  The concrete image backend is
+injected (currently :class:`image_gen.ImageGenerator`), so a future
+diffusers-based backend just needs to implement the same two methods:
+``generate_character_portrait`` and ``generate_scene_illustration``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, Protocol
+
+from story_artifacts import CharacterVisualData, StoryArtifacts
+
+logger = logging.getLogger(__name__)
+
+
+class ImageBackend(Protocol):
+    """Duck-typed interface any image backend must satisfy."""
+
+    def generate_character_portrait(self, prompt: str, character_name: str) -> str: ...
+
+    def generate_scene_illustration(
+        self,
+        prompt: str,
+        reference_image_paths: list[str],
+        chapter_index: int,
+    ) -> str: ...
+
+
+def describe_characters(world_bible: str) -> list[CharacterVisualData]:
+    """Run the DSPy ``CharacterVisualDescriber`` over a world bible."""
+    from story_modules import CharacterVisualDescriber
+
+    describer = CharacterVisualDescriber()
+    result = describer(world_bible=world_bible)
+    return [
+        CharacterVisualData(
+            name=cv.name,
+            reference_mix=cv.reference_mix,
+            distinguishing_features=cv.distinguishing_features,
+            full_prompt=cv.full_prompt,
+        )
+        for cv in result.character_visuals
+    ]
+
+
+def build_character_visuals_summary(
+    character_visuals: Iterable[CharacterVisualData],
+) -> str:
+    """One-line-per-character summary fed to the scene prompt generator."""
+    return "\n".join(
+        f"- {cv.name}: {cv.reference_mix}. {cv.distinguishing_features}"
+        for cv in character_visuals
+    )
+
+
+def split_story_chapters(final_story: str) -> list[str]:
+    """Split the final story text by ``### Chapter `` markers.
+
+    Each returned string still begins with the chapter's number/title payload
+    (the literal marker prefix is stripped), matching the convention used by
+    the main pipeline and the markdown renderer.
+    """
+    chapters = final_story.split("### Chapter ")
+    return [c for c in chapters if c.strip()]
+
+
+def generate_character_portraits(
+    character_visuals: Iterable[CharacterVisualData],
+    image_backend: ImageBackend,
+    *,
+    existing_paths: dict[str, str] | None = None,
+    skip_existing: bool = True,
+) -> dict[str, str]:
+    """Generate portraits for each character, returning name->path."""
+    paths: dict[str, str] = dict(existing_paths or {})
+    for cv in character_visuals:
+        if skip_existing and cv.name in paths:
+            logger.debug(
+                "Skipping portrait for %s (already present: %s)",
+                cv.name,
+                paths[cv.name],
+            )
+            continue
+        try:
+            path = image_backend.generate_character_portrait(
+                prompt=cv.full_prompt, character_name=cv.name
+            )
+            paths[cv.name] = path
+            logger.info("Generated portrait for %s -> %s", cv.name, path)
+        except Exception as exc:
+            logger.error("Failed to generate portrait for %s: %s", cv.name, exc)
+    return paths
+
+
+def generate_scene_illustrations(
+    final_story: str,
+    character_visuals_summary: str,
+    reference_image_paths: list[str],
+    image_backend: ImageBackend,
+    *,
+    scene_prompt_gen=None,
+    existing_paths: dict[int, str] | None = None,
+    skip_existing: bool = True,
+) -> dict[int, str]:
+    """Generate a scene illustration per chapter, returning index->path."""
+    if scene_prompt_gen is None:
+        from story_modules import SceneImagePromptGenerator
+
+        scene_prompt_gen = SceneImagePromptGenerator()
+
+    paths: dict[int, str] = dict(existing_paths or {})
+    chapters = split_story_chapters(final_story)
+    for i, chapter_text in enumerate(chapters, start=1):
+        if skip_existing and i in paths:
+            logger.debug(
+                "Skipping scene for chapter %d (already present: %s)",
+                i,
+                paths[i],
+            )
+            continue
+        try:
+            prompt_result = scene_prompt_gen(
+                chapter_text=chapter_text,
+                character_visuals_summary=character_visuals_summary,
+            )
+            path = image_backend.generate_scene_illustration(
+                prompt=prompt_result.image_prompt,
+                reference_image_paths=reference_image_paths,
+                chapter_index=i,
+            )
+            paths[i] = path
+            logger.info("Generated scene for chapter %d -> %s", i, path)
+        except Exception as exc:
+            logger.error("Failed to generate scene for chapter %d: %s", i, exc)
+    return paths
+
+
+def generate_images_for_story(
+    artifacts: StoryArtifacts,
+    image_backend: ImageBackend,
+    *,
+    describe_missing: bool = True,
+    skip_portraits: bool = False,
+    skip_scenes: bool = False,
+    skip_existing: bool = True,
+) -> StoryArtifacts:
+    """Fill in character visuals, portraits, and scene images on ``artifacts``.
+
+    Mutates ``artifacts`` in place and returns it for chaining.  If
+    ``describe_missing`` is True and the artifact has no character visuals
+    yet, DSPy is called to derive them from the world bible.
+    """
+    if describe_missing and not artifacts.character_visuals:
+        if not artifacts.world_bible:
+            logger.warning("Cannot describe characters: world bible is empty.")
+        else:
+            logger.info("Describing character visuals from world bible...")
+            artifacts.character_visuals = describe_characters(artifacts.world_bible)
+
+    if not skip_portraits and artifacts.character_visuals:
+        artifacts.character_portrait_paths = generate_character_portraits(
+            artifacts.character_visuals,
+            image_backend,
+            existing_paths=artifacts.character_portrait_paths,
+            skip_existing=skip_existing,
+        )
+
+    if not skip_scenes and artifacts.final_story:
+        summary = build_character_visuals_summary(artifacts.character_visuals)
+        reference_paths = list(artifacts.character_portrait_paths.values())
+        artifacts.scene_image_paths = generate_scene_illustrations(
+            artifacts.final_story,
+            summary,
+            reference_paths,
+            image_backend,
+            existing_paths=artifacts.scene_image_paths,
+            skip_existing=skip_existing,
+        )
+
+    return artifacts

--- a/main.py
+++ b/main.py
@@ -7,8 +7,6 @@ from story_modules import (
     SpineTemplateGenerator,
     StoryGenerator,
     ChapterInpaintingGenerator,
-    CharacterVisualDescriber,
-    SceneImagePromptGenerator,
 )
 from world_bible_modules import (
     WorldBibleGenerator,
@@ -21,6 +19,13 @@ from dotenv import load_dotenv
 from logging_config import setup_logging
 from dspy_optimization import try_load_optimized_module
 from postprocessing import find_similar_sentences, format_report
+from story_artifacts import StoryArtifacts, save_artifacts, save_markdown
+from image_pipeline import (
+    describe_characters,
+    build_character_visuals_summary,
+    generate_character_portraits,
+    generate_scene_illustrations,
+)
 
 load_dotenv()
 
@@ -286,29 +291,18 @@ def main():
         image_gen = ImageGenerator(api_token=args.replicate_api_token)
 
         console.print("\n[italic]Generating character visual descriptions...[/italic]")
-        cv_describer = CharacterVisualDescriber()
-        cv_result = cv_describer(world_bible=world_bible)
-        character_visuals = cv_result.character_visuals
-
-        lines = []
+        character_visuals = describe_characters(world_bible)
         for cv in character_visuals:
             console.print(f"\n[bold cyan]{cv.name}:[/bold cyan] {cv.reference_mix}")
             console.print(f"  [dim]{cv.distinguishing_features}[/dim]")
-            lines.append(
-                f"- {cv.name}: {cv.reference_mix}. {cv.distinguishing_features}"
-            )
-        character_visuals_summary = "\n".join(lines)
+        character_visuals_summary = build_character_visuals_summary(character_visuals)
 
         console.print("\n[italic]Generating character portraits...[/italic]")
-        for cv in character_visuals:
-            try:
-                path = image_gen.generate_character_portrait(
-                    prompt=cv.full_prompt, character_name=cv.name
-                )
-                character_portrait_paths[cv.name] = path
-                console.print(f"  [green]Saved portrait:[/green] {path}")
-            except Exception as e:
-                console.print(f"  [red]Failed to generate portrait for {cv.name}: {e}[/red]")
+        character_portrait_paths = generate_character_portraits(
+            character_visuals, image_gen
+        )
+        for name, path in character_portrait_paths.items():
+            console.print(f"  [green]Saved portrait for {name}:[/green] {path}")
 
     Confirm.ask("Press Enter to continue to Story generation...", default=True, show_default=False)
 
@@ -353,28 +347,14 @@ def main():
     scene_image_paths = {}
     if args.enable_images and image_gen:
         console.print("\n[italic]Generating scene illustrations for each chapter...[/italic]")
-        scene_prompt_gen = SceneImagePromptGenerator()
-
-        chapters = final_story_text.split("### Chapter ")
-        chapters = [c for c in chapters if c.strip()]
-
-        reference_paths = list(character_portrait_paths.values())
-
-        for i, chapter_text in enumerate(chapters, start=1):
-            try:
-                prompt_result = scene_prompt_gen(
-                    chapter_text=chapter_text,
-                    character_visuals_summary=character_visuals_summary,
-                )
-                path = image_gen.generate_scene_illustration(
-                    prompt=prompt_result.image_prompt,
-                    reference_image_paths=reference_paths,
-                    chapter_index=i,
-                )
-                scene_image_paths[i] = path
-                console.print(f"  [green]Chapter {i} scene:[/green] {path}")
-            except Exception as e:
-                console.print(f"  [red]Failed to generate scene for chapter {i}: {e}[/red]")
+        scene_image_paths = generate_scene_illustrations(
+            final_story_text,
+            character_visuals_summary,
+            list(character_portrait_paths.values()),
+            image_gen,
+        )
+        for i, path in sorted(scene_image_paths.items()):
+            console.print(f"  [green]Chapter {i} scene:[/green] {path}")
 
     # 10. Post-processing: detect similar sentences
     if args.check_similar:
@@ -390,49 +370,30 @@ def main():
                 len(similar_pairs),
             )
 
-    # 11. Save output to markdown
+    # 11. Save output (JSON sidecar + human-readable markdown)
     os.makedirs(args.output_dir, exist_ok=True)
-    output_filename = os.path.join(args.output_dir, "story_output.md")
-    logger.info(f"Saving story output to {output_filename}...")
-    with open(output_filename, "w", encoding="utf-8") as f:
-        f.write("# Story Output\n\n")
-        f.write("## Core Premise\n")
-        f.write(f"{core_premise}\n\n")
-        f.write("## Spine Template\n")
-        f.write(f"{spine_template}\n\n")
-        f.write("## World Bible\n")
-        f.write(f"{world_bible}\n\n")
+    artifacts = StoryArtifacts(
+        core_premise=core_premise,
+        spine_template=spine_template,
+        world_bible=world_bible,
+        arc_outline=story_result.arc_outline,
+        chapter_plan=story_result.chapter_plan,
+        enhancers_guide=story_result.enhancers_guide,
+        final_story=final_story_text,
+        character_visuals=character_visuals,
+        character_portrait_paths=character_portrait_paths,
+        scene_image_paths=scene_image_paths,
+    )
+    markdown_path = os.path.join(args.output_dir, "story_output.md")
+    json_path = os.path.join(args.output_dir, "story_output.json")
+    save_markdown(markdown_path, artifacts)
+    save_artifacts(json_path, artifacts)
 
-        if character_visuals:
-            f.write("## Character Visuals\n\n")
-            for cv in character_visuals:
-                f.write(f"### {cv.name}\n")
-                f.write(f"**Reference:** {cv.reference_mix}\n\n")
-                f.write(f"**Features:** {cv.distinguishing_features}\n\n")
-                portrait = character_portrait_paths.get(cv.name)
-                if portrait:
-                    f.write(f"![{cv.name} portrait]({portrait})\n\n")
-
-        f.write("## Arc Outline\n")
-        f.write(f"{story_result.arc_outline}\n\n")
-        f.write("## Chapter Plan\n")
-        f.write(f"{story_result.chapter_plan}\n\n")
-        f.write("## Enhancers Guide\n")
-        f.write(f"{story_result.enhancers_guide}\n\n")
-        f.write("## Final Story\n")
-
-        if scene_image_paths:
-            chapters = final_story_text.split("### Chapter ")
-            chapters = [c for c in chapters if c.strip()]
-            for i, chapter_text in enumerate(chapters, start=1):
-                f.write(f"\n\n### Chapter {chapter_text}")
-                scene = scene_image_paths.get(i)
-                if scene:
-                    f.write(f"\n\n![Chapter {i} scene]({scene})\n")
-        else:
-            f.write(f"{final_story_text}\n")
-
-    console.print(f"\n[bold magenta]Story generation complete! Results saved to {output_filename}[/bold magenta]")
+    console.print(
+        f"\n[bold magenta]Story generation complete! Results saved to "
+        f"{markdown_path} (markdown) and {json_path} (artifacts)."
+        "[/bold magenta]"
+    )
 
 if __name__ == "__main__":
     main()

--- a/scripts/generate_images.py
+++ b/scripts/generate_images.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Standalone CLI that adds (or refreshes) images for an existing story run.
+
+Consumes a ``story_output.json`` artifact produced by ``main.py`` and runs the
+shared image pipeline against it.  Useful when you generated a story without
+``--enable-images`` and want to add portraits and scene illustrations later
+without regenerating the text.
+
+Examples:
+    # Generate both portraits and scenes, overwriting the JSON in place.
+    python scripts/generate_images.py --story-json .tmp/story_output.json
+
+    # Portraits only, writing a fresh JSON and refreshed markdown elsewhere.
+    python scripts/generate_images.py \\
+        --story-json .tmp/story_output.json \\
+        --skip-scenes \\
+        --output-json .tmp/story_output.with_images.json \\
+        --output-markdown .tmp/story_output.with_images.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+# Make the project root importable when running as ``scripts/...``.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from image_gen import ImageGenerator  # noqa: E402
+from image_pipeline import generate_images_for_story  # noqa: E402
+from logging_config import setup_logging  # noqa: E402
+from main import configure_dspy  # noqa: E402
+from story_artifacts import load_artifacts, save_artifacts, save_markdown  # noqa: E402
+
+
+logger = logging.getLogger(__name__)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate images for an existing story output.",
+    )
+    parser.add_argument(
+        "--story-json",
+        type=str,
+        required=True,
+        help="Path to the story artifacts JSON (produced by main.py).",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=str,
+        default=None,
+        help="Where to write the updated artifacts JSON (default: overwrite input).",
+    )
+    parser.add_argument(
+        "--output-markdown",
+        type=str,
+        default=None,
+        help="If set, (re)render and write the markdown view to this path.",
+    )
+    parser.add_argument(
+        "--images-dir",
+        type=str,
+        default="images",
+        help="Directory to save generated images. Defaults to 'images'.",
+    )
+    parser.add_argument(
+        "--replicate-api-token",
+        type=str,
+        default=os.environ.get("REPLICATE_API_TOKEN"),
+        help="Replicate API token. Defaults to REPLICATE_API_TOKEN env var.",
+    )
+    parser.add_argument(
+        "--skip-portraits",
+        action="store_true",
+        help="Do not generate character portraits.",
+    )
+    parser.add_argument(
+        "--skip-scenes",
+        action="store_true",
+        help="Do not generate per-chapter scene illustrations.",
+    )
+    parser.add_argument(
+        "--regenerate-portraits",
+        action="store_true",
+        help="Regenerate portraits even if they already exist in the JSON.",
+    )
+    parser.add_argument(
+        "--regenerate-scenes",
+        action="store_true",
+        help="Regenerate scene images even if they already exist in the JSON.",
+    )
+
+    # LLM config (needed for CharacterVisualDescriber / SceneImagePromptGenerator).
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=os.environ.get("MODEL", "openai/gpt-4o-mini"),
+        help="The language model used for prompt derivation.",
+    )
+    parser.add_argument(
+        "--llm-url",
+        type=str,
+        default=os.environ.get("LLM_URL"),
+        help="Custom API base URL.",
+    )
+    parser.add_argument(
+        "--api-key",
+        type=str,
+        default=os.environ.get("API_KEY"),
+        help="API key for the model.",
+    )
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=4000,
+        help="Max tokens for prompt-derivation LLM calls.",
+    )
+    parser.add_argument(
+        "--cache",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable/disable DSPy disk cache.",
+    )
+    parser.add_argument(
+        "--memory-cache",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable/disable DSPy in-memory cache.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=str,
+        default=os.environ.get("DSPY_CACHE_DIR"),
+        help="Override DSPy disk cache directory.",
+    )
+
+    parser.add_argument(
+        "--log-file",
+        type=str,
+        default=os.environ.get("LOG_FILE", ".tmp/generate_images.log"),
+        help="Path for detailed logs.",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Logging verbosity: -v INFO, -vv LLM debug, -vvv full firehose.",
+    )
+    return parser
+
+
+def main() -> int:
+    load_dotenv()
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    setup_logging(verbosity=args.verbose, log_file=args.log_file)
+
+    if not args.replicate_api_token:
+        logger.error(
+            "Missing Replicate API token. Set REPLICATE_API_TOKEN "
+            "or pass --replicate-api-token.",
+        )
+        return 1
+
+    if args.skip_portraits and args.skip_scenes:
+        logger.error("Both --skip-portraits and --skip-scenes given; nothing to do.")
+        return 1
+
+    configure_dspy(
+        model_name=args.model,
+        api_base=args.llm_url,
+        api_key=args.api_key,
+        max_tokens=args.max_tokens,
+        cache=args.cache,
+        memory_cache=args.memory_cache,
+        cache_dir=args.cache_dir,
+    )
+
+    artifacts = load_artifacts(args.story_json)
+    logger.info(
+        "Loaded artifacts: %d character visuals, %d portraits, %d scenes.",
+        len(artifacts.character_visuals),
+        len(artifacts.character_portrait_paths),
+        len(artifacts.scene_image_paths),
+    )
+
+    if args.regenerate_portraits:
+        artifacts.character_portrait_paths = {}
+    if args.regenerate_scenes:
+        artifacts.scene_image_paths = {}
+
+    image_backend = ImageGenerator(
+        api_token=args.replicate_api_token,
+        output_dir=args.images_dir,
+    )
+
+    generate_images_for_story(
+        artifacts,
+        image_backend,
+        skip_portraits=args.skip_portraits,
+        skip_scenes=args.skip_scenes,
+    )
+
+    output_json = args.output_json or args.story_json
+    save_artifacts(output_json, artifacts)
+
+    if args.output_markdown:
+        save_markdown(args.output_markdown, artifacts)
+
+    logger.info(
+        "Done. Portraits: %d, scenes: %d.",
+        len(artifacts.character_portrait_paths),
+        len(artifacts.scene_image_paths),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/story_artifacts.py
+++ b/story_artifacts.py
@@ -1,0 +1,146 @@
+"""Structured story artifacts: JSON sidecar I/O and markdown rendering.
+
+A story run produces text (world bible, chapters, etc.) plus optional image
+paths.  This module is the single source of truth for how those pieces are
+persisted as JSON and re-rendered as the user-facing markdown, so the main
+interactive pipeline and the standalone image-generation script can share it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+ARTIFACT_VERSION = 1
+
+
+@dataclass
+class CharacterVisualData:
+    """Plain-data view of a character's visual descriptor, decoupled from DSPy."""
+
+    name: str
+    reference_mix: str
+    distinguishing_features: str
+    full_prompt: str
+
+
+@dataclass
+class StoryArtifacts:
+    """All text + image references produced by a single story run."""
+
+    core_premise: str = ""
+    spine_template: str = ""
+    world_bible: str = ""
+    arc_outline: str = ""
+    chapter_plan: str = ""
+    enhancers_guide: str = ""
+    final_story: str = ""
+    character_visuals: list[CharacterVisualData] = field(default_factory=list)
+    character_portrait_paths: dict[str, str] = field(default_factory=dict)
+    scene_image_paths: dict[int, str] = field(default_factory=dict)
+    version: int = ARTIFACT_VERSION
+
+    def to_dict(self) -> dict:
+        data = asdict(self)
+        # JSON object keys must be strings; chapter indices are ints.
+        data["scene_image_paths"] = {
+            str(k): v for k, v in self.scene_image_paths.items()
+        }
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "StoryArtifacts":
+        character_visuals = [
+            CharacterVisualData(**cv) for cv in data.get("character_visuals", [])
+        ]
+        scene_image_paths = {
+            int(k): v for k, v in (data.get("scene_image_paths") or {}).items()
+        }
+        return cls(
+            core_premise=data.get("core_premise", ""),
+            spine_template=data.get("spine_template", ""),
+            world_bible=data.get("world_bible", ""),
+            arc_outline=data.get("arc_outline", ""),
+            chapter_plan=data.get("chapter_plan", ""),
+            enhancers_guide=data.get("enhancers_guide", ""),
+            final_story=data.get("final_story", ""),
+            character_visuals=character_visuals,
+            character_portrait_paths=dict(data.get("character_portrait_paths") or {}),
+            scene_image_paths=scene_image_paths,
+            version=data.get("version", ARTIFACT_VERSION),
+        )
+
+
+def save_artifacts(path: str | Path, artifacts: StoryArtifacts) -> Path:
+    """Serialize artifacts to a JSON file, creating parent dirs as needed."""
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("w", encoding="utf-8") as fh:
+        json.dump(artifacts.to_dict(), fh, indent=2, ensure_ascii=False)
+    logger.info("Saved story artifacts to %s", out)
+    return out
+
+
+def load_artifacts(path: str | Path) -> StoryArtifacts:
+    """Load artifacts from a JSON file produced by ``save_artifacts``."""
+    src = Path(path)
+    with src.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    return StoryArtifacts.from_dict(data)
+
+
+def render_markdown(artifacts: StoryArtifacts) -> str:
+    """Render the human-readable markdown view of a story run."""
+    parts: list[str] = []
+    parts.append("# Story Output\n\n")
+    parts.append("## Core Premise\n")
+    parts.append(f"{artifacts.core_premise}\n\n")
+    parts.append("## Spine Template\n")
+    parts.append(f"{artifacts.spine_template}\n\n")
+    parts.append("## World Bible\n")
+    parts.append(f"{artifacts.world_bible}\n\n")
+
+    if artifacts.character_visuals:
+        parts.append("## Character Visuals\n\n")
+        for cv in artifacts.character_visuals:
+            parts.append(f"### {cv.name}\n")
+            parts.append(f"**Reference:** {cv.reference_mix}\n\n")
+            parts.append(f"**Features:** {cv.distinguishing_features}\n\n")
+            portrait = artifacts.character_portrait_paths.get(cv.name)
+            if portrait:
+                parts.append(f"![{cv.name} portrait]({portrait})\n\n")
+
+    parts.append("## Arc Outline\n")
+    parts.append(f"{artifacts.arc_outline}\n\n")
+    parts.append("## Chapter Plan\n")
+    parts.append(f"{artifacts.chapter_plan}\n\n")
+    parts.append("## Enhancers Guide\n")
+    parts.append(f"{artifacts.enhancers_guide}\n\n")
+    parts.append("## Final Story\n")
+
+    if artifacts.scene_image_paths:
+        chapters = artifacts.final_story.split("### Chapter ")
+        chapters = [c for c in chapters if c.strip()]
+        for i, chapter_text in enumerate(chapters, start=1):
+            parts.append(f"\n\n### Chapter {chapter_text}")
+            scene = artifacts.scene_image_paths.get(i)
+            if scene:
+                parts.append(f"\n\n![Chapter {i} scene]({scene})\n")
+    else:
+        parts.append(f"{artifacts.final_story}\n")
+
+    return "".join(parts)
+
+
+def save_markdown(path: str | Path, artifacts: StoryArtifacts) -> Path:
+    """Write the markdown rendering of artifacts to disk."""
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("w", encoding="utf-8") as fh:
+        fh.write(render_markdown(artifacts))
+    logger.info("Saved story markdown to %s", out)
+    return out


### PR DESCRIPTION
Split image generation out of the interactive story run so images can be
added after the fact against an existing story's artifacts, instead of
having to rerun the whole pipeline with --enable-images.

- Add story_artifacts.py: StoryArtifacts dataclass + JSON save/load +
  shared markdown renderer. Story runs now emit a story_output.json
  sidecar alongside story_output.md.
- Add image_pipeline.py: extract character-visual description, portrait
  generation, and per-chapter scene illustration into reusable functions
  that consume/produce StoryArtifacts. The image backend is duck-typed
  via an ImageBackend protocol so a diffusers backend can be dropped in
  later.
- Refactor main.py to call the shared pipeline and persist artifacts
  through the new module, removing the duplicated inline markdown
  writing.
- Add scripts/generate_images.py: standalone CLI that loads a saved
  story_output.json and (re)generates portraits and/or scene images,
  with flags to skip or force regeneration of each and to re-render
  the markdown.

https://claude.ai/code/session_016qQAx1GadhS3FwYnB5rKaf