### PR TITLE
Enhance Spine Template generation with full context and refinement loop

### DIFF
--- a/main.py
+++ b/main.py
@@ -244,15 +244,22 @@ def main():
             break
 
     # 4. Generate Spine Template
-    console.print("\n[italic]Generating Spine Template...[/italic]")
-    st_result = st_gen(core_premise=core_premise)
-    spine_template = st_result.spine_template
+    spine_template = ""
+    while True:
+        console.print("\n[italic]Generating Spine Template...[/italic]")
+        st_result = st_gen(idea=idea, qa_pairs=qa_text, core_premise=core_premise)
+        spine_template = st_result.spine_template
 
-    console.print("\n[bold blue]--- Spine Template ---[/bold blue]")
-    console.print(spine_template)
-    console.print("[bold blue]--------------------[/bold blue]")
+        console.print("\n[bold blue]--- Spine Template ---[/bold blue]")
+        console.print(spine_template)
+        console.print("[bold blue]--------------------[/bold blue]")
 
-    Confirm.ask("Press Enter to continue to World Bible generation...", default=True, show_default=False)
+        refine = Confirm.ask("Do you want to refine this spine template? (Choosing 'Yes' will let you provide more details and regenerate, 'No' proceeds)", default=False)
+        if refine:
+            refinement_details = Prompt.ask("Provide more details or changes")
+            idea = f"Original idea: {idea}\nRefinements for Spine Template: {refinement_details}\nCurrent Spine Template: {spine_template}"
+        else:
+            break
 
     # 5. Ask World Bible Questions
     console.print("\n[italic]Generating follow-up questions to help flesh out the World Bible...[/italic]")

--- a/story_modules.py
+++ b/story_modules.py
@@ -158,6 +158,8 @@ class CorePremiseGenerator(dspy.Module):
 
 class GenerateSpineTemplateSignature(dspy.Signature):
     """Creates a narrative spine template based on the Core Premise."""
+    idea: str = dspy.InputField(desc="The original story idea.")
+    qa_pairs: str = dspy.InputField(desc="Questions and answers to flesh out the story.")
     core_premise: str = dspy.InputField(desc="The Core Premise of the story.")
     spine_template: str = dspy.OutputField(desc="A narrative spine template (e.g., Once upon a time... Every day... One day... Because of that... Because of that... Until finally...).")
 
@@ -167,8 +169,8 @@ class SpineTemplateGenerator(dspy.Module):
         self.generate = dspy.Predict(GenerateSpineTemplateSignature)
 
     @observe()
-    def forward(self, core_premise: str):
-        return self.generate(core_premise=core_premise)
+    def forward(self, idea: str, qa_pairs: str, core_premise: str):
+        return self.generate(idea=idea, qa_pairs=qa_pairs, core_premise=core_premise)
 
 
 class CharacterVisual(BaseModel):

--- a/test_story.py
+++ b/test_story.py
@@ -48,13 +48,13 @@ class MockLM(dspy.LM):
             return ['```json\n{"character_visuals": [{"name": "Mock Hero", "reference_mix": "a mix of Guts from Berserk and Zuko from Avatar", "distinguishing_features": "short black hair, amber eyes, burn scar on left cheek, dark leather armor", "full_prompt": "anime portrait, a mix of Guts from Berserk and Zuko from Avatar, short black hair, amber eyes, burn scar on left cheek, dark leather armor"}]}\n```']
         if "[[ ## image_prompt ## ]]" in content or ('"image_prompt"' in content and "anime scene" in content):
             return ['```json\n{"image_prompt": "anime scene, a warrior with short black hair and amber eyes standing in a dark cathedral, dramatic lighting"}\n```']
-        if "[[ ## random_detail ## ]]" in content or ('"random_detail"' in content and "naturally woven" in content):
-            return ['```json\n{"random_detail": "A small paper unicorn sat perched on the corner of the desk, its horn casting a faint shadow in the candlelight."}\n```']
         if (
             "[[ ## chapter_text ## ]]" in content
             or ('"chapter_text"' in content and "immersive chapter" in content)
         ) and '"expanded_chapter_text"' not in content:
             return ['```json\n{"reasoning": "Mock reasoning", "title": "Mock Title", "chapter_text": "Mock chapter text"}\n```']
+        if "[[ ## random_detail ## ]]" in content or ('"random_detail"' in content and "naturally woven" in content):
+            return ['```json\n{"random_detail": "A small paper unicorn sat perched on the corner of the desk, its horn casting a faint shadow in the candlelight."}\n```']
         if "[[ ## expanded_chapter_text ## ]]" in content or '"expanded_chapter_text"' in content:
             return ['```json\n{"reasoning": "Mock reasoning", "expanded_chapter_text": "Mock expanded chapter text with richer detail and slower pacing."}\n```']
         if "[[ ## story ## ]]" in content or ('"story"' in content and "The final generated story" in content):
@@ -233,7 +233,7 @@ def test_pipeline(
 
     # 3. Spine Template
     st_gen = SpineTemplateGenerator()
-    st_result = st_gen(core_premise=cp_result.core_premise)
+    st_result = st_gen(idea=idea, qa_pairs=qa_text, core_premise=cp_result.core_premise)
     logger.info("Spine Template generated.")
     logger.debug("Spine template preview: %.300s", st_result.spine_template)
 


### PR DESCRIPTION
This PR addresses issue #50 by enhancing the Spine Template generation step with richer context and user refinement capabilities.

### Changes Made:
- **`story_modules.py`**: Added `idea` and `qa_pairs` as `InputField`s to `GenerateSpineTemplateSignature` and updated `SpineTemplateGenerator` to accept these parameters.
- **`main.py`**: Updated the pipeline to pass `idea` and `qa_text` to the Spine Template generator. Wrapped the spine template generation in a `while True:` loop to allow users to interactively review, reject, and refine the spine template, mirroring the functionality of the Core Premise generation step.
- **`test_story.py`**: Updated the test suite to pass the new required parameters to the generator and ensure `MockLM` fallback matching rules correctly handle the updated inputs. Tests have been fully verified.

---
*PR created automatically by Jules for task [7477231317488035225](https://jules.google.com/task/7477231317488035225) started by @ironharvy*