### PR TITLE
Add architecture rules and code quality tooling to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,15 @@ jobs:
       - name: Run Ruff lint
         run: ruff check .
 
+      - name: Pylint (design smells)
+        run: pylint main.py story_modules.py world_bible_modules.py postprocessing.py
+
+      - name: Radon (cyclomatic complexity)
+        run: radon cc . -s -n C --exclude ".venv/*" --no-assert
+
+      - name: Vulture (dead code)
+        run: vulture . --min-confidence 80 --exclude .venv
+
   test:
     runs-on: ubuntu-latest
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Story Writer is an interactive DSPy-based story generation pipeline with optiona
 ### Installation
 ```bash
 pip install -r requirements.txt      # Core dependencies
-pip install -r requirements-dev.txt  # Dev dependencies (pytest, ruff)
+pip install -r requirements-dev.txt  # Dev dependencies (pytest, ruff, pylint, radon, vulture)
 ```
 
 ### Running Tests
@@ -48,6 +48,14 @@ python main.py -vv                   # LLM debug logging
 python main.py -vvv                  # Full HTTP+LLM firehose
 ```
 
+### Code Quality Checks
+```bash
+pylint main.py story_modules.py        # Design smell detection
+radon cc main.py -s -n C               # Cyclomatic complexity (flag C and worse)
+radon mi main.py -s                     # Maintainability index
+vulture . --min-confidence 80           # Dead code detection
+```
+
 ### DSPy Pipeline Optimization
 ```bash
 python scripts/optimize_text_pipeline.py \
@@ -55,24 +63,59 @@ python scripts/optimize_text_pipeline.py \
   --manifest .tmp/dspy_optimized/text_pipeline_manifest.json
 ```
 
+## Architecture & Design Rules
+
+These rules are **mandatory**. AI agents must follow them for all new code and
+refactor violations when touching existing code.
+
+### Function Size & Responsibility
+- **Hard limit: 50 lines per function.** If a function exceeds 50 lines, it must be decomposed. No exceptions for "entry points" or "main functions."
+- **One job per function.** A function that parses arguments must not also initialize services, run a pipeline, or write files. Name each function after its single responsibility.
+- **CLI entry points are thin.** `main()` should parse args, call a handful of orchestration functions, and return. Target: ≤ 20 lines of logic (excluding the argparse block, which should be extracted to `build_arg_parser() -> argparse.ArgumentParser`).
+
+### Data Flow & State
+- **Use dataclasses for pipeline state.** When ≥ 3 related values are threaded through multiple functions, define a `@dataclass` to hold them. Never pass 5+ loose locals between pipeline phases.
+- **Functions take explicit inputs and return explicit outputs.** Avoid relying on mutable shared state. Each pipeline phase should be a pure-ish function: `def generate_spine(...) -> SpineResult`.
+
+### Indirection Must Earn Its Keep
+- **No dict-of-instances when a dataclass works.** If you create a dict and immediately destructure it into named variables, use a dataclass or NamedTuple instead. String keys for typed objects are a code smell.
+- **No wrapper functions that just forward arguments.** If a function's body is a single call to another function with the same arguments, delete the wrapper.
+
+### Separation of Concerns
+- **UI code must not live inside business logic.** `console.print()`, `Prompt.ask()`, `Confirm.ask()` belong in a UI/interaction layer. Pipeline functions must not import `rich`. Pass callbacks or return data and let the caller handle presentation.
+- **File I/O gets its own function.** Any block of ≥ 5 lines writing to a file must be a dedicated `save_*()` function with a clear signature.
+
+### Dead Code & Commented-Out Code
+- **Delete commented-out code.** Version control exists. Never leave `#old_function_call()` or `field="[REMOVED]"` in the codebase. If a feature is removed, remove all traces.
+- **Delete unused definitions.** If a class, function, or constant has no callers, delete it.
+
+### Error Reporting
+- **Use `logger` for all errors and warnings.** Never use `console.print("[bold red]Error:...")` for error handling. `console.print` is for user-facing output only; `logger.error/warning` is for error handling. User-visible errors should use `logger` and optionally `sys.exit(1)`.
+
+### Module Size
+- **One module, one domain.** If a file exceeds ~300 lines or contains more than one conceptual domain (e.g., Pydantic models + DSPy modules + text utilities), split it. A file named `story_modules.py` should not also be the home of generic text-cleaning utilities.
+
 ## Code Style Guidelines
 
 ### General Principles
-- Use type hints for all function parameters and return values
+- Use type hints for all function parameters and return values, **including return types (even `-> None`)**
 - Keep functions focused and small (prefer < 50 lines)
 - Use descriptive variable names; avoid single letters except in short loops
 - Add docstrings to public functions and classes
+- **Avoid `Any` in type hints.** If the real type is known, use it
 
-### Imports
+### Imports (strict ordering — violations must be fixed before commit)
 ```python
-# Standard library first, then third-party, then local
+# 1. Standard library
 import logging
 import re
 from typing import List, Optional
 
+# 2. Third-party
 import dspy
 from pydantic import BaseModel, Field
 
+# 3. Local
 from story_modules import QuestionGenerator
 ```
 
@@ -194,7 +237,6 @@ def test_specific_function():
 - `main.py` - CLI entry point and orchestration
 - `story_modules.py` - Core story generation modules
 - `world_bible_modules.py` - World bible generation
-- `alternate_story_modules.py` - 3-phase alternative pipeline
 - `postprocessing.py` - Post-generation utilities
 - `image_gen.py` - Replicate image generation
 - `logging_config.py` - Centralized logging setup

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,7 @@
 -r requirements.txt
 pytest
 ruff
+pylint
+radon
+vulture
 coloredlogs


### PR DESCRIPTION
## Summary

Adds mandatory architecture & design rules to `AGENTS.md` and integrates code quality tools into CI.

### AGENTS.md — New Architecture & Design Rules
- **Function size:** 50-line hard limit, single responsibility
- **CLI entry points:** thin `main()` (≤20 lines logic), extract arg parsing
- **Data flow:** dataclasses for pipeline state, explicit inputs/outputs
- **Indirection:** no dict-of-instances, no pass-through wrappers
- **Separation of concerns:** UI code out of business logic, dedicated `save_*()` for I/O
- **Dead code:** delete commented-out code and unused definitions
- **Error reporting:** `logger` only, no `console.print` for errors
- **Module size:** one domain per file, ~300 line cap

### Code Style (strengthened)
- Strict import ordering (stdlib → third-party → local)
- Mandatory return type annotations (including `-> None`)
- Avoid `Any` in type hints

### CI & Tooling
- Added **pylint**, **radon**, **vulture** to `requirements-dev.txt`
- Added CI steps: pylint (design smells), radon (cyclomatic complexity ≥ C), vulture (dead code)

> **Note:** These checks will flag existing violations in `main.py` — that's intentional. A follow-up PR will refactor to comply.