### PR TITLE
Add render_story.py script for HTML rendering of story output

### DIFF
--- a/examples/story_output.html
+++ b/examples/story_output.html
@@ -1,0 +1,1525 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Story Output</title>
+  <style>
+:root {
+  --bg: #faf7f1;
+  --fg: #1d1b18;
+  --muted: #7a756c;
+  --rule: #d8d1c2;
+  --accent: #8a3a28;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #14120f;
+    --fg: #e8e2d4;
+    --muted: #948d7e;
+    --rule: #2b2722;
+    --accent: #d77a5f;
+  }
+}
+* { box-sizing: border-box; }
+html, body { background: var(--bg); color: var(--fg); }
+body {
+  font-family: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, "Times New Roman", serif;
+  max-width: 38rem;
+  margin: 3rem auto 5rem;
+  padding: 0 1.25rem;
+  line-height: 1.62;
+  font-size: 1.0625rem;
+  text-rendering: optimizeLegibility;
+  hyphens: auto;
+}
+header.cover {
+  text-align: center;
+  margin-bottom: 3rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+}
+header.cover h1 {
+  font-size: 2rem;
+  font-weight: 600;
+  margin: 0 0 0.4rem;
+}
+header.cover .meta {
+  color: var(--muted);
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+nav.toc { margin-bottom: 3rem; }
+nav.toc h2 {
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 600;
+  margin: 0 0 0.75rem;
+}
+nav.toc ol {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  counter-reset: sec;
+}
+nav.toc li {
+  counter-increment: sec;
+  padding: 0.3rem 0;
+  display: flex;
+  gap: 0.8rem;
+  align-items: baseline;
+  border-bottom: 1px dotted var(--rule);
+}
+nav.toc li::before {
+  content: counter(sec, decimal-leading-zero);
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  min-width: 1.6rem;
+}
+nav.toc a { color: var(--fg); text-decoration: none; flex: 1; }
+nav.toc a:hover { color: var(--accent); }
+section.part { margin-top: 3rem; }
+section.part h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 2rem 0 1rem;
+  padding-bottom: 0.3rem;
+  border-bottom: 1px solid var(--rule);
+}
+section.part h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin: 1.5rem 0 0.5rem;
+}
+section.part p {
+  margin: 0 0 0.9rem;
+  text-align: justify;
+}
+section.part ul {
+  margin: 0 0 1rem;
+  padding-left: 1.25rem;
+}
+section.part li { margin: 0.2rem 0; }
+hr {
+  border: none;
+  text-align: center;
+  margin: 1.2rem 0;
+  height: 1rem;
+}
+hr::after {
+  content: "\2217  \2217  \2217";
+  letter-spacing: 0.4em;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+code {
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.92em;
+  background: var(--rule);
+  padding: 0.05em 0.3em;
+  border-radius: 3px;
+}
+footer.colophon {
+  margin-top: 5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--rule);
+  color: var(--muted);
+  font-size: 0.8rem;
+  text-align: center;
+}
+</style>
+</head>
+<body>
+  <header class="cover">
+    <div class="meta">story_writer preview</div>
+    <h1>Story Output</h1>
+  </header>
+  <nav class="toc" aria-label="Table of contents">
+    <h2>Contents</h2>
+    <ol>
+      <li><a href="#core-premise">Core Premise</a></li>
+      <li><a href="#spine-template">Spine Template</a></li>
+      <li><a href="#world-bible">World Bible</a></li>
+      <li><a href="#chapter-plan">Chapter Plan</a></li>
+      <li><a href="#enhancers-guide">Enhancers Guide</a></li>
+      <li><a href="#final-story">Final Story</a></li>
+    </ol>
+  </nav>
+  <section class="part" id="core-premise">
+    <h2>Core Premise</h2>
+<p>In a world where the Church presents itself as humanity&#x27;s sole protector against demonic incursions, an unnamed orphan boy is raised within its hallowed walls as the prophesied &quot;Godslayer&quot;—a living weapon engineered to combat the demonic threat. The child, known only as Subject Zero, is indoctrinated to believe the Church&#x27;s narrative: that demons are mindless manifestations of evil requiring extermination, and that his unique ability to absorb demonic energy without corruption makes him humanity&#x27;s last hope.</p>
+<p>As Subject Zero matures under the Church&#x27;s rigorous training, he begins to notice disturbing inconsistencies: why do demon attacks only target communities that refuse the Church&#x27;s exorbitant &quot;protection tithes&quot;? Why are certain districts systematically denied aid until they comply with financial demands? His suspicions crystallize when he stumbles upon the Archive—a hidden repository containing centuries of the Church&#x27;s true records. Here, he discovers the horrifying truth: the Church doesn&#x27;t merely fight demons; it breeds them through dark rituals in secret laboratories worldwide, sacrificing &quot;lost souls&quot; to create possessed beings. The demonic threat is a manufactured crisis, a protection racket on a global scale.</p>
+<p>The turning point comes when a powerful Demon Lord, tired of being the Church&#x27;s puppet, stages a rebellion. In their cataclysmic confrontation, the Demon Lord confirms Subject Zero&#x27;s worst fears and reveals &quot;the Abyss&quot;—the true source of demonic power and the Church&#x27;s connection to it. Forced to confront both his creators and the beings they control, Subject Zero must harness the full potential of his dark power, deciding whether to destroy the system that created him or become something beyond both Church and demon—a true Godslayer who will reshape reality itself.</p>
+<p><strong>Central Conflict:</strong> Innocence versus institutional corruption; the weapon questioning its wielder. <strong>Protagonist&#x27;s Goal:</strong> Uncover the truth about his origins and decide his role in a world built on lies. <strong>Stakes:</strong> The fate of humanity trapped between two predatory forces—the corrupt Church and the demonic hordes it controls. <strong>Setting/Tone:</strong> Gothic cyberpunk fusion—ancient cathedrals housing advanced laboratories, holy symbols masking profane rituals, a world where faith is currency and salvation comes with a price tag. <strong>Thematic Undercurrent:</strong> The nature of free will, the corruption of institutions, and what it means to be human when you&#x27;re engineered to be a weapon.</p>
+  </section>
+  <section class="part" id="spine-template">
+    <h2>Spine Template</h2>
+<p><strong>Once upon a time...</strong> there was a world besieged by demonic incursions, where the Holy Church stood as humanity&#x27;s sole protector. Within its deepest sanctums, an orphan boy known only as Subject Zero was raised, trained, and genetically engineered to become the Godslayer—a living weapon capable of absorbing demonic energy without corruption.</p>
+<p><strong>Every day...</strong> Subject Zero underwent rigorous training, learned Church doctrine, and was sent on missions to eliminate demons. He believed he was humanity&#x27;s savior, that the Church was pure, and that his purpose was holy. The Church collected &quot;protection tithes&quot; from cities worldwide, and demon attacks mysteriously only targeted those who refused to pay.</p>
+<p><strong>One day...</strong> Subject Zero accidentally discovered the Archive—a hidden repository containing centuries of the Church&#x27;s true records. He learned the horrifying truth: the Church breeds demons through dark rituals, sacrifices &quot;lost souls&quot; to create possessed beings, and stages attacks to extort communities. The demonic threat was a manufactured crisis.</p>
+<p><strong>Because of that...</strong> Subject Zero began questioning everything. He started investigating on his own, noticing patterns in demon attacks that aligned with financial disputes. His trust in his parental figures—the Church leaders—crumbled as he realized they saw him not as a person but as a weapon in their protection racket.</p>
+<p><strong>Because of that...</strong> a powerful Demon Lord, tired of being the Church&#x27;s puppet, staged a rebellion. During their cataclysmic battle, the Demon Lord confirmed Subject Zero&#x27;s suspicions and revealed &quot;the Abyss&quot;—the true source of demonic power and the Church&#x27;s connection to it. Subject Zero unlocked the full potential of his dark power during this confrontation.</p>
+<p><strong>Until finally...</strong> Subject Zero stood at the crossroads of destiny. With the truth exposed and his power fully awakened, he had to decide: destroy the corrupt Church that created him, side with the demonic rebellion seeking freedom, or forge a third path—becoming something beyond both, a true Godslayer who would reshape reality and free humanity from both predators.</p>
+  </section>
+  <section class="part" id="world-bible">
+    <h2>World Bible</h2>
+<h3>6a: Rules of the World</h3>
+<p><strong>The Abyss &amp; Demonic Power:</strong> 1. <strong>The Abyss:</strong> A parallel dimension of raw chaotic energy where consciousness forms spontaneously into demonic entities. It exists adjacent to our reality, separated by a metaphysical barrier. 2. <strong>Bridge Requirement:</strong> Demons require a &quot;bridge&quot; (a sacrificed human soul) to fully manifest in our world. The bridge anchors them to physical reality. 3. <strong>Corruption Rule:</strong> Direct contact with demonic energy corrupts most humans, twisting their minds and bodies. Corruption progresses faster with repeated exposure. 4. <strong>Subject Zero Exception:</strong> Due to a rare genetic mutation (designated &quot;Epsilon Gene&quot;), Subject Zero can absorb demonic energy without corruption. His body metabolizes it like a battery. 5. <strong>Church Rituals:</strong> The Church uses dark magic rituals to create artificial bridges using &quot;lost souls&quot;—people with weak spiritual connections or no family ties who won&#x27;t be missed. 6. <strong>Temporary Manifestation:</strong> Powerful demons (Lord-class and above) can temporarily manifest without bridges but are significantly weaker (≈30% power) and fade after 1-3 hours. 7. <strong>Energy Absorption Limits:</strong> While Subject Zero can absorb demonic energy indefinitely, there&#x27;s a processing limit—he can only utilize what his body can metabolize at any given time.</p>
+<p><strong>Church Operations:</strong> 8. <strong>Breeding Grounds:</strong> Secret laboratories worldwide where demons are &quot;bred&quot; through controlled rituals. Each is disguised as a Church facility (orphanage, hospital, research center). 9. <strong>Attack Staging:</strong> Demon attacks are carefully orchestrated: a) Target selection based on financial compliance, b) Controlled release via temporary bridges, c) &quot;Rescue&quot; by Church forces after appropriate damage. 10. <strong>Information Control:</strong> All media is Church-sanctioned. Independent journalists are labeled heretics. The Archive contains true records but is accessible only to highest ranks.</p>
+<h3>6b: Characters</h3>
+<p><strong>Main Characters:</strong></p>
+<p>1. <strong>Subject Zero / &quot;Zero&quot; (Protagonist)</strong> - <strong>Age:</strong> Appears 17 (actual age unknown due to genetic modifications) - <strong>Physical:</strong> Pale skin, silver hair (result of energy absorption), heterochromatic eyes (one gold, one violet), slender but muscular build, covered in faint glowing scars from demon encounters - <strong>Background:</strong> Orphan discovered during a &quot;demon attack&quot; that killed his village. Raised in Church isolation since age 3. - <strong>Abilities:</strong> Epsilon Gene allows demonic energy absorption without corruption. Can sense demons within 50-mile radius. Nullification field (30ft radius). Energy projection (develops later). Full power awakening allows demonic trait manifestation. - <strong>Personality:</strong> Initially obedient but curious. Develops deep skepticism. Intelligent, observant, emotionally guarded due to isolation. Struggles with identity—weapon vs person.</p>
+<p>2. <strong>Cardinal Valerius (Primary Antagonist)</strong> - <strong>Age:</strong> 68 - <strong>Physical:</strong> Imposing figure, sharp features, always in elaborate crimson robes, carries an ornate staff that&#x27;s actually a focus for demon control - <strong>Role:</strong> Head of the Conclave, mastermind behind the protection racket - <strong>Background:</strong> Former idealist who became corrupted by power. Believes the ends justify the means—humanity needs controlled chaos to remain united. - <strong>Relationship to Zero:</strong> Sees him as his greatest creation and biggest liability. Paternal in a twisted way.</p>
+<p>3. <strong>Demon Lord Azrael (Anti-Hero / Mentor)</strong> - <strong>Physical:</strong> 8ft tall, obsidian skin, four arms, wings of shadow, intelligent crimson eyes - <strong>Background:</strong> One of the oldest demons, forced into Church service for centuries. Leading the rebellion. - <strong>Abilities:</strong> Reality warping within limited radius, telepathy, energy manipulation - <strong>Personality:</strong> Ancient, weary, seeks freedom for his kind. Sees Zero as potential ally or ultimate threat. - <strong>Role:</strong> Confirms Church corruption to Zero, shows him the Abyss, becomes reluctant mentor.</p>
+<p><strong>Supporting Characters:</strong></p>
+<p>4. <strong>Sister Evangeline (The Silent Order)</strong> - Young nun who discovers truth, helps Zero access Archive, becomes his first human connection outside Church control.</p>
+<p>5. <strong>Kael (The Dispossessed Leader)</strong> - Survivor of a staged attack that killed his family. Leads resistance in ruined city sectors.</p>
+<p>6. <strong>Archbishop Silas (Regional Manager)</strong> - Mid-level Church official overseeing North American breeding grounds. Pragmatic bureaucrat of evil.</p>
+<p>7. <strong>Lilith (Free Demon)</strong> - Escaped breeding ground demon living in hidden enclave. Provides sanctuary to Zero when he&#x27;s hunted.</p>
+<h3>6c: Locations</h3>
+<p>1. <strong>The Vatican Citadel (Rome)</strong> - <strong>Description:</strong> Massive fortified complex blending ancient architecture with advanced technology. Surface: cathedrals, libraries, living quarters. Sub-levels: breeding grounds, laboratories, the Archive. - <strong>Climate:</strong> Controlled artificial environment. Surface maintains Mediterranean climate. - <strong>Significance:</strong> Church headquarters. Zero&#x27;s childhood home and prison.</p>
+<p>2. <strong>New Jerusalem Arcology (Former New York)</strong> - <strong>Description:</strong> Vertical city-state owned by MegaCorp &quot;OmniGuard.&quot; Pays highest protection tithes. Clean, orderly, surveilled. - <strong>Climate:</strong> Climate-controlled dome. Permanent spring. - <strong>Significance:</strong> Shows Church&#x27;s corporate partnerships. Zero sent here for &quot;demon suppression&quot; that&#x27;s actually enforcement.</p>
+<p>3. <strong>The Ruins (Former Detroit)</strong> - <strong>Description:</strong> City sector that refused tithe increases. Deliberately destroyed by staged demon attack. Now inhabited by The Dispossessed. - <strong>Climate:</strong> Polluted, seasonal extremes, frequent acid rain. - <strong>Significance:</strong> Resistance headquarters. Zero&#x27;s first exposure to Church victims.</p>
+<p>4. <strong>Breeding Ground Alpha (Under Swiss Alps)</strong> - <strong>Description:</strong> Largest breeding facility. Disguised as &quot;Theological Research Institute.&quot; - <strong>Features:</strong> Ritual chambers, soul extraction equipment, demon containment cells. - <strong>Significance:</strong> Zero discovers his own &quot;creation file&quot; here.</p>
+<p>5. <strong>The Abyssal Threshold</strong> - <strong>Description:</strong> Natural rift to the Abyss in Siberia. Church built containment facility around it to harvest energy. - <strong>Features:</strong> Reality is thin here. Colors bleed, gravity fluctuates. - <strong>Significance:</strong> Final confrontation location. Zero must decide whether to seal or embrace the Abyss.</p>
+<p>6. <strong>Free Haven (Underground Seattle)</strong> - <strong>Description:</strong> Hidden enclave where Free Demons and Awakened humans coexist. - <strong>Climate:</strong> Damp, cool, bioluminescent fungi provide light. - <strong>Significance:</strong> Sanctuary, represents possible third path.</p>
+<h3>6d: Plot Timeline</h3>
+<p><strong>Backstory (50 years before story):</strong> - Church discovers method to create artificial bridges using lost souls. - Cardinal Valerius rises to power, implements protection racket. - First staged demon attack on non-compliant city successful. - Global control established within 20 years.</p>
+<p><strong>Present Story Timeline:</strong></p>
+<p><strong>Year 1-15 (Zero&#x27;s Childhood):</strong> - Age 3: Village &quot;attacked,&quot; Zero discovered, brought to Vatican. - Age 5: Epsilon Gene identified, training begins. - Age 10: First combat mission (controlled demon elimination). - Age 14: Notices pattern in attack locations but dismisses as coincidence.</p>
+<p><strong>Year 16 (Story Beginning):</strong> - Month 1: Sent to New Jerusalem for &quot;routine suppression.&quot; - Month 2: Meets Sister Evangeline, she hints at Archive. - Month 3: Accidentally accesses Archive, discovers truth. - Month 4: Begins secret investigation, collects evidence.</p>
+<p><strong>Year 16-17 (Rising Action):</strong> - Month 5: Sent to Ruins for &quot;cleanup,&quot; meets Kael and Dispossessed. - Month 6: Church suspects his doubts, increases surveillance. - Month 7: Demon Lord Azrael&#x27;s rebellion begins. - Month 8: Zero sent to suppress Azrael. - Month 9: Battle with Azrael, truth confirmed, Abyss revealed. - Month 10: Power fully awakens, becomes hunted by Church.</p>
+<p><strong>Year 17 (Climax &amp; Resolution):</strong> - Month 11: Finds Free Haven, recovers, plans next move. - Month 12: Assault on Breeding Ground Alpha, discovers creation files. - Final Confrontation: At Abyssal Threshold—Church forces vs Demon rebellion vs Zero. - Decision Point: Seal Abyss (ending demon threat but Church remains), embrace Abyss (become new power), or destroy Church control while leaving Abyss open (true freedom with risk).</p>
+  </section>
+  <section class="part" id="chapter-plan">
+    <h2>Chapter Plan</h2>
+<h3>Act 1: Setup (Chapters 1-5)</h3>
+<p><strong>Chapter 1: The Godslayer&#x27;s Cradle</strong> Zero completes a &quot;demon suppression&quot; in New Jerusalem. Routine mission, but he notices the demon seemed... directed. Returns to Vatican, reports to Cardinal Valerius who praises him as &quot;humanity&#x27;s sword.&quot;</p>
+<p><strong>Chapter 2: Whispers in the Confessional</strong> Sister Evangeline, during confession, cryptically mentions &quot;records that remember what walls forget.&quot; Zero becomes curious about Church history beyond official narratives.</p>
+<p><strong>Chapter 3: The Archive&#x27;s Door</strong> While retrieving ancient texts for Cardinal, Zero stumbles upon hidden biometric lock. His hand (unbeknownst to him, keyed to Epsilon Gene) opens it. First glimpse of the Archive.</p>
+<p><strong>Chapter 4: Ledgers of Damnation</strong> Zero secretly accesses Archive. Discovers financial records: tithe payments correlated with attack frequencies. Sees &quot;Project Zero&quot; file but can&#x27;t open it (higher clearance needed).</p>
+<p><strong>Chapter 5: The Unasked Question</strong> Confronts Cardinal with &quot;inconsistencies&quot; in attack patterns. Cardinal deflects, sends Zero on &quot;re-education retreat&quot; to remote monastery. Actually a test of loyalty.</p>
+<h3>Act 2: Confrontation (Chapters 6-10)</h3>
+<p><strong>Chapter 6: The Ruins Speak</strong> Sent to Detroit Ruins for &quot;cleanup.&quot; Meets Kael and Dispossessed survivors. Hears their story: Church demanded 300% tithe increase, when refused, &quot;demon horde&quot; destroyed district, help arrived 72 hours late.</p>
+<p><strong>Chapter 7: Blood Tithes</strong> Investigates Ruins, finds Church-issued containment equipment (shouldn&#x27;t be there if attack was spontaneous). Collects evidence. Church surveillance team arrives—Zero must hide his findings.</p>
+<p><strong>Chapter 8: The Rebellion Ignites</strong> Demon Lord Azrael attacks European breeding ground, freeing hundreds of demons. Church declares it &quot;unprecedented demon uprising.&quot; Zero recalled for emergency deployment.</p>
+<p><strong>Chapter 9: Truth in Battle</strong> Battle with Azrael in Swiss Alps. Azrael doesn&#x27;t fight to kill—fights to communicate. Telepathically shows Zero memories: Church rituals, soul sacrifices, his own creation.</p>
+<p><strong>Chapter 10: The Abyss Gazes Back</strong> Azrael opens temporary rift to Abyss, shows Zero the energy source. Zero&#x27;s power reacts violently—full awakening. Absorbs massive energy, manifests demonic traits temporarily. Church forces arrive, label him &quot;corrupted.&quot;</p>
+<h3>Act 3: Resolution (Chapters 11-15)</h3>
+<p><strong>Chapter 11: Hunted</strong> Branded heretic, hunted by Inquisitors. Wounded, finds refuge in Seattle&#x27;s underground with help from Sister Evangeline (now Awakened). Meets Free Demons.</p>
+<p><strong>Chapter 12: Creation&#x27;s Mirror</strong> Infiltrates Breeding Ground Alpha using Free Demon help. Accesses his full file: not orphaned—engineered from Abyssal energy and human DNA. Mother was &quot;lost soul&quot; sacrificed in his creation ritual.</p>
+<p><strong>Chapter 13: The Conclave&#x27;s Gambit</strong> Cardinal Valerius announces &quot;Final Purification&quot;—plan to permanently seal Abyss using Zero&#x27;s energy (would kill him). Actually plan to harness Abyss fully, become god-like.</p>
+<p><strong>Chapter 14: Threshold of Destiny</strong> Three-way battle at Abyssal Threshold: Church forces vs Demon rebellion vs Zero and allies. Zero must choose path while fighting both sides.</p>
+<p><strong>Chapter 15: The Godslayer&#x27;s Choice</strong> Final confrontation with Cardinal Valerius. Zero realizes true power isn&#x27;t destroying or embracing—it&#x27;s breaking cycles. Makes his choice (to be revealed in writing). New world order begins.</p>
+  </section>
+  <section class="part" id="enhancers-guide">
+    <h2>Enhancers Guide</h2>
+<h3>Tension Module</h3>
+<ul>
+  <li><strong>Ch 1-3:</strong> Build subtle unease through &quot;too perfect&quot; Church operations and Zero&#x27;s growing curiosity.</li>
+  <li><strong>Ch 4-5:</strong> Sharp tension spikes with Archive discovery and Cardinal confrontation.</li>
+  <li><strong>Ch 6-7:</strong> Sustained tension in Ruins—constant threat of discovery by Church surveillance.</li>
+  <li><strong>Ch 8-10:</strong> Combat tension during Azrael battle, escalating to crisis with power awakening.</li>
+  <li><strong>Ch 11:</strong> High-tension chase sequence as hunted heretic.</li>
+  <li><strong>Ch 12-14:</strong> Rising tension to climax with infiltration and three-way battle.</li>
+  <li><strong>Ch 15:</strong> Release in final confrontation and resolution.</li>
+</ul>
+<h3>Mystery Module</h3>
+<ul>
+  <li><strong>Plant:</strong> Ch 1—Directed demon behavior. Ch 2—Evangeline&#x27;s cryptic hints. Ch 3—Biometric lock reacting to Zero.</li>
+  <li><strong>Deepen:</strong> Ch 4—Financial correlations. Ch 6—Containment equipment in Ruins.</li>
+  <li><strong>Partial Reveal:</strong> Ch 9—Azrael&#x27;s telepathic memories. Ch 10—Abyss vision.</li>
+  <li><strong>Full Reveal:</strong> Ch 12—Creation file showing engineered origins.</li>
+  <li><strong>Final Twist:</strong> Ch 13—Cardinal&#x27;s true &quot;Final Purification&quot; plan.</li>
+</ul>
+<h3>Theme Alignment</h3>
+<ul>
+  <li><strong>Institutional Corruption:</strong> Ch 1 (perfect facade), Ch 4 (financial records), Ch 6 (Dispossessed stories), Ch 13 (Cardinal&#x27;s god-complex).</li>
+  <li><strong>Identity &amp; Free Will:</strong> Ch 5 (loyalty test), Ch 9 (what am I?), Ch 12 (creation revelation), Ch 15 (choice).</li>
+  <li><strong>Power &amp; Responsibility:</strong> Ch 10 (power awakening consequences), Ch 14 (three-way battle ethics), Ch 15 (decision impact).</li>
+</ul>
+<h3>Setup/Payoff Tracker</h3>
+<ul>
+  <li><strong>Setup Ch 2:</strong> Evangeline&#x27;s hints → <strong>Payoff Ch 3/11:</strong> Helps access Archive/refuge.</li>
+  <li><strong>Setup Ch 4:</strong> Can&#x27;t open Project Zero file → <strong>Payoff Ch 12:</strong> Full access in Breeding Ground.</li>
+  <li><strong>Setup Ch 6:</strong> Kael&#x27;s story → <strong>Payoff Ch 14:</strong> Dispossessed join final battle.</li>
+  <li><strong>Setup Ch 9:</strong> Azrael&#x27;s communication attempt → <strong>Payoff Ch 14:</strong> Demon rebellion alliance.</li>
+  <li><strong>Setup Ch 10:</strong> Temporary demon traits → <strong>Payoff Ch 15:</strong> Controlled power use in climax.</li>
+</ul>
+<h3>Emotional Curve</h3>
+<ul>
+  <li><strong>Ch 1-3:</strong> Duty/Pride → Curiosity/Unease</li>
+  <li><strong>Ch 4-5:</strong> Shock/Betrayal → Anger/Determination</li>
+  <li><strong>Ch 6-7:</strong> Empathy/Horror → Righteous Fury</li>
+  <li><strong>Ch 8-10:</strong> Conflict/Confusion → Revelation/Awakening</li>
+  <li><strong>Ch 11:</strong> Fear/Desperation → Resilience</li>
+  <li><strong>Ch 12:</strong> Grief/Identity Crisis → Acceptance</li>
+  <li><strong>Ch 13-14:</strong> Resolve/Conflict → Climactic Struggle</li>
+  <li><strong>Ch 15:</strong> Catharsis → Hope/Rebirth</li>
+</ul>
+<h3>Twist Generator</h3>
+<ul>
+  <li><strong>Ch 4:</strong> Archive discovery (first major twist).</li>
+  <li><strong>Ch 9:</strong> Azrael as communicator not mindless beast.</li>
+  <li><strong>Ch 10:</strong> Power awakening and Church betrayal.</li>
+  <li><strong>Ch 12:</strong> Engineered origins, mother sacrifice.</li>
+  <li><strong>Ch 13:</strong> Cardinal&#x27;s true plan (biggest twist).</li>
+  <li><strong>Ch 15:</strong> Zero&#x27;s choice subverts expectations.</li>
+</ul>
+<h3>Easter Egg Injector</h3>
+<ul>
+  <li><strong>Ch 1:</strong> New Jerusalem architecture has subtle demonic motifs in &quot;holy&quot; symbols.</li>
+  <li><strong>Ch 3:</strong> Archive room number is 666 (hidden in Roman numerals).</li>
+  <li><strong>Ch 6:</strong> Ruins contain Church propaganda posters with double meanings.</li>
+  <li><strong>Ch 9:</strong> Azrael&#x27;s memories show Cardinal younger, idealistic—hinting at corruption arc.</li>
+  <li><strong>Ch 12:</strong> Project Zero file references &quot;Eve Protocol&quot;—mother&#x27;s project name.</li>
+  <li><strong>Ch 14:</strong> Three factions each represent a path Zero could choose.</li>
+</ul>
+<p><strong>Application Notes:</strong> - <strong>Tension/Mystery:</strong> Interweave—mystery discoveries increase tension, tension relief often comes with revelations. - <strong>Theme:</strong> Let themes emerge naturally through character decisions and world details. - <strong>Emotional Curve:</strong> Each chapter should advance emotional state, no stagnation. - <strong>Twists:</strong> Space major twists evenly, ensure they recontextualize previous information. - <strong>Easter Eggs:</strong> Subtle, discoverable on re-read, never distracting from main narrative.</p>
+  </section>
+  <section class="part" id="final-story">
+    <h2>Final Story</h2>
+<p>*(The complete 15-chapter story follows - approximately 15,000 words of immersive prose with dialogue, description, and the random detail injections as specified.)</p>
+<hr aria-hidden="true">
+<h3>Chapter 1: The Godslayer&#x27;s Cradle</h3>
+<p>The demon died with a sound like breaking stained glass.</p>
+<p>Zero watched as the creature—a seven-foot mass of obsidian flesh and too many joints—dissolved into shimmering motes of light that swirled toward him. He didn&#x27;t flinch as the energy touched his skin, didn&#x27;t scream as lesser men might have. He simply stood, silver hair stirring in the non-existent breeze of the absorption, and let the demon become part of him.</p>
+<p>The absorption always left him with a metallic taste in his mouth and a low hum in his bones. Fifteen years of training had taught him to ignore the sensation, to treat it as fuel for the holy work. <em>You are the vessel</em>, Cardinal Valerius had told him when he was six, after his first successful absorption. <em>The energy flows through you to be purified, made holy through your sacrifice.</em> Zero had believed it then. Most days, he still did.</p>
+<p>But today, something felt different. The demon&#x27;s energy settled into his reservoir with a peculiar resonance, like a note played slightly out of tune. It carried echoes—not of mindless rage, but of something sharper. More focused.</p>
+<p>The after-action report would call it a &quot;class three manifestation, spontaneously occurring in Sector G-7 of New Jerusalem Arcology.&quot; Zero would write that the demon showed &quot;standard aggression patterns&quot; and was &quot;neutralized with efficiency.&quot; Both statements were lies, and the second one bothered him more than it should have.</p>
+<p><em>Standard aggression patterns don&#x27;t include tactical assessment</em>, he thought, forcing the doubt down. <em>Standard demons don&#x27;t evaluate threats before engaging.</em> He&#x27;d seen it in the creature&#x27;s movements—the way it had scanned the chamber, identified the OmniGuard checkpoint as the primary threat, ignored the clustered civilians. Demons were supposed to be creatures of pure instinct, drawn to fear and chaos like moths to flame. This one had moved like a soldier.</p>
+<p><em>No</em>, he corrected himself. <em>The Church&#x27;s teachings are clear. Demons adapt, learn from encounters. This is just evolution of the threat. Nothing more.</em> The rationalization felt hollow even as he formed it.</p>
+<p>&quot;Clean work, Subject Zero.&quot;</p>
+<p>Archbishop Silas approached, his crimson robes sweeping across the polished marble floor of the containment chamber. The man&#x27;s smile didn&#x27;t reach his eyes—it never did. &quot;Cardinal Valerius will be pleased. Another district secured. The tithe payments from OmniGuard have already been confirmed for the next quarter.&quot;</p>
+<p>Zero nodded, flexing his right hand. The faint glow beneath his skin was fading, the demon&#x27;s energy settling into whatever reservoir his body maintained. He tried to ignore the way Silas&#x27;s eyes lingered on his hands, assessing the absorption like a merchant evaluating merchandise. &quot;The manifestation was... precise. It attacked the OmniGuard security checkpoint, ignored civilian clusters. It moved with tactical awareness.&quot;</p>
+<p>Silas&#x27;s smile tightened almost imperceptibly. &quot;Demons are drawn to conflict,&quot; he said smoothly, the practiced response rolling off his tongue. &quot;The checkpoint had recent... disagreements with local vendors over licensing fees. Negative emotional energy attracts them like carrion birds.&quot;</p>
+<p><em>But why that specific checkpoint?</em> Zero wanted to ask. <em>Why not the food distribution center where tempers flared yesterday? Or the residential block where a family was evicted?</em> The questions piled up behind his teeth, held back by fifteen years of conditioning. Questioning Church doctrine was the first step toward corruption. Doubt was the crack through which demonic influence seeped.</p>
+<p>&quot;Of course,&quot; Zero said instead, the words tasting like ash. &quot;The patterns are clear to those trained to see them.&quot;</p>
+<p>&quot;Precisely.&quot; Silas placed a hand on Zero&#x27;s shoulder, the gesture meant to be paternal but feeling like a weight. &quot;You&#x27;re learning to read the signs. Soon you&#x27;ll understand the larger patterns—how our work maintains the balance that keeps humanity safe.&quot;</p>
+<p><em>Too precise</em>, Zero thought but didn&#x27;t say. The demon had moved with purpose, not mindless rage. It had bypassed three easier targets to reach the checkpoint. And there was something about the timing—the manifestation occurred exactly when OmniGuard&#x27;s quarterly tithe negotiations were reaching their delicate phase. A coincidence, surely. The Church didn&#x27;t use demons as leverage in financial discussions. That would be... unthinkable.</p>
+<p>Yet the doubt remained, a splinter in his mind.</p>
+<p>As he followed Silas from the chamber, Zero&#x27;s boot scuffed against something on the floor. He glanced down. A child&#x27;s toy—a carved wooden soldier, its paint worn from handling. It lay in the corner where the demon had first manifested, partially hidden behind a support column.</p>
+<p>A child&#x27;s toy soldier, left behind in the sterile containment chamber. Its tiny sword was raised in perpetual defiance, one eye painted slightly higher than the other. The wood was smooth from years of handling, the paint chipped at the edges where small fingers had gripped it too tightly. A name was carved into the base in clumsy letters: &quot;Miko.&quot; How had it gotten here? Who had dropped it? The questions nagged at Zero more than they should have.</p>
+<p>&quot;Something wrong?&quot; Silas asked, his voice sharp with impatience.</p>
+<p>&quot;Nothing.&quot; Zero pocketed the toy soldier, the wood warm against his palm. &quot;Just debris. I&#x27;ll have maintenance sweep the chamber more thoroughly.&quot;</p>
+<p>&quot;See that you do.&quot; Silas didn&#x27;t look back. &quot;Contamination protocols exist for a reason.&quot;</p>
+<p>The walk back to the transport was silent, but Zero&#x27;s mind was anything but quiet. <em>Miko.</em> A child&#x27;s name. A child&#x27;s toy in a containment chamber that had been sealed for decontamination for three days prior to the scheduled manifestation. No children should have been within five hundred meters. The security logs would show none had been.</p>
+<p>Unless the logs were wrong. Or altered.</p>
+<p><em>Stop it</em>, he commanded himself. <em>You&#x27;re looking for patterns where none exist. The toy could have been carried in by maintenance staff. Dropped during equipment checks.</em> The rationalizations came easily, worn smooth by repetition. He&#x27;d been having these thoughts more frequently lately—moments of doubt that he quickly buried under doctrine and duty.</p>
+<p>New Jerusalem spread around them—a vertical paradise of gleaming spires and floating gardens. Citizens in identical white garments moved along prescribed pathways, their faces serene in the golden-hour light. Every hundred yards, a holographic saint offered blessings for compliance. Zero watched a family pause before Saint Michael&#x27;s image, the parents bowing their heads while their children mimicked the gesture. The perfect tableau of faith and order.</p>
+<p><em>They sleep safely because of our work</em>, he reminded himself. <em>Because demons are contained, managed, eliminated. The system works.</em></p>
+<p>But the toy soldier in his pocket felt heavier with each step.</p>
+<p>In the transport, Zero watched the city recede through the viewport. His fingers found the toy soldier, tracing the carved name. Miko. He wondered about the child—age, gender, whether they cried when they realized their toy was gone. Whether their parents could afford to buy another. Whether they lived in one of the gleaming spires or in the service levels below, where the city&#x27;s machinery hummed and the saints&#x27; holograms flickered with static.</p>
+<p><em>Directed</em>, he thought again, closing his eyes. <em>The demon was directed. The toy was planted. The timing was perfect.</em></p>
+<p>He opened his eyes as the transport ascended through the cloud layer. The rational part of his mind—the part trained by the Church, conditioned since childhood—fought back. <em>Coincidence. Statistical anomaly. Demons are chaotic by nature, but chaos creates patterns if you look hard enough. You&#x27;re seeing what you want to see.</em></p>
+<p>But another part, newer and quieter, whispered: <em>What if I&#x27;m seeing what&#x27;s actually there?</em></p>
+<p>The transport docked with the orbital station where the Church&#x27;s flagship, <em>Sanctuary</em>, waited like a silver dagger against the stars. Zero would return to Vatican Citadel, receive his praise from Cardinal Valerius, and prepare for the next mission. He would file his report with the approved language. He would not mention the toy soldier. He would not voice his doubts.</p>
+<p>But as New Jerusalem vanished behind clouds, becoming just another jewel in the planet&#x27;s necklace of light, he found himself wondering about Miko. And why a demon would manifest exactly where a child might have played. And whether there were other toys in other chambers, other names carved into other pieces of wood, other questions no one was asking.</p>
+<p>The transport hatch hissed open. Zero stood, pocketing the toy soldier. For now, he would play his part. But the splinter of doubt remained, working its way deeper.</p>
+<hr aria-hidden="true">
+<h3>Chapter 2: Whispers in the Confessional</h3>
+<p>The confessional smelled of old wood and older secrets.</p>
+<p>Zero knelt in the darkness, the screen between him and Sister Evangeline a lattice of carved oak that turned her silhouette into a fragmented saint. He came here every week, not for absolution—he had no sins he recognized, only duties performed—but because the ritual was required. The Church believed confession purified the soul, and a pure soul was better armor against corruption. Lately, Zero wondered if his soul needed more armor than most.</p>
+<p>He could feel the toy soldier in his pocket, a small hard presence against his thigh. He&#x27;d almost left it in his quarters, afraid its discovery would raise questions he couldn&#x27;t answer. But something made him bring it—a need for witness, perhaps. Or a test.</p>
+<p>&quot;Bless me, Sister, for I have... performed my duties.&quot;</p>
+<p>The words felt hollow today. Duties. Not sins. But the distinction was blurring.</p>
+<p>A soft laugh from the other side, warm and genuine. Evangeline was young for a confessor, barely thirty, with a reputation for unorthodoxy that should have gotten her transferred to some remote parish. Instead, she remained, a puzzle Zero hadn&#x27;t solved. &quot;That&#x27;s not a sin, Subject Zero. Though your phrasing suggests you think it might be.&quot;</p>
+<p>&quot;I eliminated a class three manifestation in New Jerusalem.&quot;</p>
+<p>&quot;And?&quot;</p>
+<p>He hesitated. Confession was about truth, but some truths were dangerous. &quot;It felt different.&quot;</p>
+<p>The silence that followed was different too—not the empty silence of ritual, but the charged silence of someone actually listening. Zero could hear Evangeline&#x27;s breathing, the rustle of her habit as she shifted. The scent of lavender and incense drifted through the screen.</p>
+<p>When she spoke again, her voice had dropped, barely above a whisper. &quot;Different how?&quot;</p>
+<p>&quot;Purposeful. Not mindless.&quot; The words came easier now, as if a dam had broken. &quot;It assessed the chamber. Identified the primary threat—an OmniGuard checkpoint that&#x27;s been... problematic lately. Ignored easier targets. Moved like it had orders.&quot;</p>
+<p>&quot;Demons don&#x27;t take orders,&quot; Evangeline said, but her tone was curious, not corrective.</p>
+<p>&quot;This one did.&quot; He hesitated again, then plunged ahead. &quot;And there was a child&#x27;s toy where it manifested. A wooden soldier. With a name carved in it: Miko.&quot;</p>
+<p>&quot;Children lose toys everywhere.&quot; Her response was automatic, but he heard the hesitation in it.</p>
+<p>&quot;This was a containment chamber. Sterile. Sealed for decontamination for three days prior. No children within five hundred meters. Security logs show none.&quot;</p>
+<p>Another pause, longer this time. Zero could almost feel her weighing her words, measuring risk against... something else. When she spoke, her voice was so quiet he had to lean forward to hear. &quot;The Church keeps many records, Zero. Some are for the faithful—the public ledgers, the approved histories, the doctrine. Some... are for the walls.&quot;</p>
+<p>He leaned closer until his forehead almost touched the screen. &quot;What does that mean?&quot;</p>
+<p>&quot;Walls remember what people forget.&quot; Her whisper was urgent now, a secret passed in the dark. &quot;Stone has longer memory than paper. Bureaucrats can burn documents, alter databases, rewrite histories. But stone... stone absorbs everything. The weight of footsteps, the echo of voices, the heat of lies told in its shadow.&quot;</p>
+<p>He felt a chill that had nothing to do with the confessional&#x27;s cool air. &quot;What are you saying?&quot;</p>
+<p>&quot;There&#x27;s an archive. Deep in the citadel, below even the crypts. It&#x27;s not in any official schematic. They call it the Memory of Stone. It remembers everything—every transaction, every &#x27;demon attack,&#x27; every tithe payment, every... toy left in a sterile room.&quot;</p>
+<p>Zero&#x27;s heart hammered against his ribs. &quot;Why are you telling me this?&quot;</p>
+<p>&quot;Because you notice things you shouldn&#x27;t.&quot; Her voice softened. &quot;Because you wonder about children named Miko. Because when you kneel here each week, you don&#x27;t recite rote sins—you actually think about what you&#x27;ve done. That makes you dangerous to them. And possibly... the only one who can change anything.&quot;</p>
+<p>She made the sign of the cross, the gesture visible through the lattice. &quot;Your penance is to consider what walls might say if they could speak. To wonder who decides which memories get preserved and which get... lost. Now go with God. And be careful.&quot;</p>
+<p>Zero left the confessional troubled, Evangeline&#x27;s words echoing in the vaulted silence of the chapel. <em>The Memory of Stone. Walls remember.</em> He navigated the citadel&#x27;s endless corridors, his footsteps echoing on marble worn smooth by centuries of faithful feet. The Vatican was a maze of stone and scripture, every surface carved with saints and scriptures, every archway a monument to divine order.</p>
+<p>But now he saw it differently. The saints&#x27; stern faces looked less like guardians and more like jailers. The scriptures carved into the walls seemed less like wisdom and more like... ledgers. Records of transactions between heaven and earth, with the Church as intermediary. <em>How much does salvation cost?</em> he wondered. <em>And who sets the price?</em></p>
+<p>He found himself in the Grand Library without consciously deciding to go there. The room was cathedral-sized, ancient texts filling shelves that stretched to a ceiling lost in shadow. Dust motes danced in shafts of colored light from stained glass windows depicting the Church&#x27;s founding myths. Here, the air smelled of vellum, incense, and the faint ozone tang of preservation fields.</p>
+<p>Cardinal Valerius was at a reading desk in a pool of lamplight, examining an illuminated manuscript with the focus of a surgeon. The light caught the silver threads in his crimson robes, made his pale skin seem almost translucent. He didn&#x27;t look up as Zero approached.</p>
+<p>&quot;Zero.&quot; The Cardinal&#x27;s voice was dry as parchment. &quot;Your report on New Jerusalem was adequate. Archbishop Silas noted your... observations about the manifestation&#x27;s behavior. Unnecessary detail, but thorough.&quot;</p>
+<p>&quot;Thank you, Your Eminence.&quot; Zero stood at attention, the toy soldier a secret weight in his pocket. &quot;I believed accuracy was important.&quot;</p>
+<p>&quot;Accuracy is a tool, not a virtue.&quot; Valerius turned a page, the vellum whispering. &quot;The Church is pleased with your progress. You are becoming the weapon we always envisioned. Soon you&#x27;ll be ready for greater responsibilities.&quot;</p>
+<p>The word <em>weapon</em> landed heavily today. Zero had heard it all his life—in training sessions, in sermons, in the quiet moments when Valerius explained his purpose. <em>You are humanity&#x27;s sword, Zero. Forged in faith, tempered in sacrifice.</em> He&#x27;d worn the title like armor. Today it felt like a brand.</p>
+<p>&quot;I had questions about the manifestation pattern,&quot; Zero said, the words coming out before he could stop them. &quot;The targeting was too specific. And there were... anomalies at the site.&quot;</p>
+<p>Valerius finally looked up. His eyes were the color of winter sky, pale and distant. &quot;Patterns are for scholars, Zero. For historians and theologians who have the luxury of contemplation. You are the solution, not the analyst. Your role is action, not inquiry.&quot;</p>
+<p>&quot;But if we don&#x27;t understand the patterns—&quot;</p>
+<p>&quot;We understand enough.&quot; Valerius closed the manuscript with a soft thump. &quot;Demons adapt. They learn. They become more cunning. This is why we need you—not to question, but to respond. To be the unwavering answer to an evolving question.&quot;</p>
+<p>Zero felt the argument forming, the doubts Evangeline had planted taking root. <em>What if the question is wrong? What if we&#x27;re answering something no one is asking?</em></p>
+<p>Valerius stood, his shadow stretching across the reading desk. &quot;Your place is not to wonder why, Zero. Your place is to be the &#x27;therefore.&#x27; The inevitable consequence. The tip of the spear. The hand of God.&quot; He paused, his gaze sharpening. &quot;The Godslayer.&quot;</p>
+<p>The title hung between them, heavy with expectation. Zero had earned it through blood and absorbed energy, through countless demons dissolved into light. He&#x27;d been proud of it. Now it felt like a cage.</p>
+<p>&quot;We have a new assignment for you,&quot; Valerius continued, his tone shifting to business. &quot;A retrieval mission. The Codex of Saint Ignatius from the Monastery of Saint Benedict in the Alps. It contains... sensitive information about early encounters with the Abyss. Your unique abilities make you the ideal courier.&quot;</p>
+<p><em>And it gets me out of the citadel</em>, Zero thought. <em>Away from questions. Away from archives that remember.</em></p>
+<p>&quot;It will be educational,&quot; Valerius added, a faint smile touching his lips. &quot;The Alpine monasteries hold many secrets. Some of them even true.&quot;</p>
+<p>Zero recognized the dismissal in the words, the gentle steering away from dangerous topics. He bowed, the motion automatic after years of training. &quot;I&#x27;ll prepare immediately, Your Eminence.&quot;</p>
+<p>&quot;Good.&quot; Valerius returned to his manuscript, already dismissing him. &quot;Remember who you are, Zero. What you are. The world needs weapons more than it needs philosophers.&quot;</p>
+<p>Zero left the library, the words echoing in the stone corridors. <em>The world needs weapons.</em> He touched the toy soldier in his pocket, felt the carved name under his thumb. Miko.</p>
+<p><em>What does the world need for children named Miko?</em> he wondered. <em>Weapons? Or answers?</em></p>
+<p>The questions followed him like ghosts as he walked through the citadel&#x27;s remembering walls.</p>
+<p>That night, in his Spartan quarters, Zero took out the toy soldier and placed it on the bare stone table that served as his desk. The room was exactly as it had been since he was five: ten paces by twelve, smooth stone walls, a narrow bed, a desk, a shelf for approved texts. No windows. No personal items. No decorations except a single icon of Saint Michael slaying a demon, its colors faded with age.</p>
+<p>From a small refrigeration unit built into the wall, he retrieved his evening ration—a dense gray block the size of his palm, labeled &quot;CALORIC SUPPLEMENT 3500 - EPSILON VARIANT.&quot; The Church didn&#x27;t call it food. It was &quot;caloric intake,&quot; part of weapon maintenance. He broke off a piece—exactly one-third, as per protocol—and placed it in his mouth. It tasted of chalk and metallic dust, with an aftertaste like sterilized plastic. No flavor, only function. Three bites, 1,167 calories each. Fuel for the holy work. For the weapon.</p>
+<p><em>A weapon doesn&#x27;t need comforts</em>, Valerius had explained when Zero turned seven and asked why other novices had drawings on their walls. <em>A weapon needs only purpose.</em></p>
+<p>Zero picked up the toy soldier, turned it over in his hands. The painted eyes—one slightly higher than the other—seemed to watch him with a mixture of defiance and pity. In the dim glow of the room&#x27;s single light panel, the carved name &quot;Miko&quot; stood out like a scar.</p>
+<p><em>Walls remember.</em></p>
+<p>He looked at his own walls—smooth, featureless stone that had witnessed fifteen years of his life. What did they remember? The childhood nightmares when he first learned what he was? The hours of training, of meditation, of absorbing Church doctrine along with demonic energy? The lonely nights when he wondered if there were others like him, or if he was truly alone in all the world?</p>
+<p>He ran his fingers over the stone. Cold. Impassive. But Evangeline&#x27;s words echoed: <em>Stone absorbs everything. The weight of footsteps, the echo of voices, the heat of lies told in its shadow.</em></p>
+<p>What lies had these walls absorbed? What truths had they witnessed that were now forgotten?</p>
+<p>He thought of the Archive—the Memory of Stone. Somewhere deep below, a record of everything. Every demon attack. Every tithe payment. Every child&#x27;s toy left where it shouldn&#x27;t be.</p>
+<p><em>Why would they keep such records?</em> he wondered. <em>If the Church is pure, if their work is holy, why hide the evidence? Why have a secret archive that &quot;remembers everything&quot;?</em></p>
+<p>The questions multiplied, each one breeding two more. He felt like he was standing at the edge of a precipice, peering into a darkness that might contain monsters... or truths. Or both.</p>
+<p>For the first time, the walls of his room felt less like sanctuary and more like cage. The smooth stone that had always represented safety and order now seemed like the bars of a prison he hadn&#x27;t known he was in. The icon of Saint Michael no longer inspired devotion—it looked like a warning. <em>This is what happens to those who question. This is what happens to monsters.</em></p>
+<p>But what if the monster wasn&#x27;t the demon under the saint&#x27;s foot? What if the monster was the foot itself?</p>
+<p>Zero placed the toy soldier back on the desk, aligning it so it faced the door. A tiny sentinel. A reminder.</p>
+<p>Tomorrow he would go to the Alps. He would retrieve the Codex. He would play his part.</p>
+<p>But the splinter of doubt was now a crack. And cracks, he knew from training, were where structures failed.</p>
+<p>He lay on his narrow bed, staring at the ceiling. Somewhere in the citadel&#x27;s depths, stone remembered. Somewhere, walls held secrets.</p>
+<p>And somewhere, a child named Miko wondered where their toy soldier had gone.</p>
+<p>Sleep, when it came, was fitful and filled with dreams of labyrinths made of stone, of voices whispering from walls, of a tiny wooden soldier leading him deeper into darkness.</p>
+<hr aria-hidden="true">
+<h3>Chapter 3: The Archive&#x27;s Door</h3>
+<p>The Alpine monastery clung to the mountainside like a lichen to stone, its ancient walls seeming to grow from the living rock rather than being built upon it. Zero arrived at dawn, the transport settling on a landing pad carved from the mountain itself. As he stepped out, cold air bit through his uniform with teeth of ice, carrying the scent of pine, snow, and something older—stone dust and forgotten prayers.</p>
+<p>He looked up at the monastery. It was smaller than he&#x27;d expected, more fortress than sanctuary, with narrow slit windows and walls three meters thick. Moss and ice clung to the stones in equal measure. Somewhere in those walls, the Codex of Saint Ignatius waited—a text so dangerous or valuable that Cardinal Valerius had sent his personal weapon to retrieve it.</p>
+<p><em>Or to get me out of the way</em>, Zero thought as he approached the heavy oak door. <em>Away from questions. Away from archives.</em></p>
+<p>His mission briefing had been unusually sparse. Retrieve the Codex. Do not examine it. Do not discuss it with the monks. Return immediately. The Cardinal&#x27;s instructions had been precise, almost rehearsed. <em>&quot;The Codex contains early theological writings about the Abyss,&quot;</em> Valerius had said. <em>&quot;Some interpretations are... unorthodox. Best kept from general circulation.&quot;</em></p>
+<p>Zero had nodded, filed the orders, and wondered what &quot;unorthodox&quot; meant to an organization that controlled all orthodoxy.</p>
+<p>The door creaked open before he could knock. Brother Matthias stood in the doorway, a man so old he seemed part of the stone. His skin was parchment stretched over bone, his eyes milky with cataracts, but his gaze was sharp. He looked Zero up and down, taking in the silver hair, the Church uniform, the absence of any visible weapon except Zero himself.</p>
+<p>&quot;Subject Zero,&quot; Matthias said, his voice a dry rustle. &quot;We&#x27;ve been expecting you. Though I must say, I expected someone... older. Come in. The mountain doesn&#x27;t care for open doors.&quot;</p>
+<p>Zero followed him inside. The interior was a maze of vaulted corridors, the stone walls sweating condensation in the cold. Torches guttered in iron sconces, casting dancing shadows that made the carved saints seem to move. The air was thick with the smell of damp wool, beeswax candles, and the peculiar mustiness of very old books.</p>
+<p>&quot;The Codex,&quot; Matthias said as they walked. &quot;Yes. Kept it safe all these years. Knew they&#x27;d come for it eventually.&quot;</p>
+<p>&quot;They?&quot; Zero asked, though he suspected the answer.</p>
+<p>&quot;The ones who want to remember.&quot; Matthias paused at a intersection, his breath fogging in the cold air. &quot;Or the ones who want to forget. Hard to tell the difference sometimes. Memory and forgetting are two sides of the same coin, you know. Both require effort. Both leave marks.&quot;</p>
+<p>They reached the vault door—massive iron, black with age, etched with warnings in Latin, Greek, and a third language Zero didn&#x27;t recognize. The symbols seemed to shift in the torchlight, as if the metal remembered being liquid.</p>
+<p>Matthias produced a key from a chain around his neck. It was iron, simple, unadorned, but it looked older than the man holding it. &quot;The Codex is on the third shelf from the left, at eye level. Mind the step—the stone is uneven. This place was built when men were shorter and cared more about faith than comfort.&quot;</p>
+<p>He inserted the key, turned it with effort. The lock groaned like a waking beast. &quot;You&#x27;ll have to enter alone. The vault... doesn&#x27;t like crowds. Too many memories in one place makes the stone restless.&quot;</p>
+<p>The door swung inward on silent hinges, revealing darkness beyond. Matthias handed Zero a glow-stick. &quot;Don&#x27;t be long. And don&#x27;t touch anything but the Codex. Some books bite.&quot;</p>
+<p>Zero entered alone, the vault door closing behind him with a soft click that sounded like a seal being broken. The glow-stick cast a pale blue light that seemed hesitant, as if afraid to illuminate too much.</p>
+<p>The vault was smaller than he&#x27;d expected—no larger than his quarters back at the citadel—but every centimeter was crammed with knowledge. Shelves carved from the living stone held scrolls yellowed with age, books bound in leather that had once been living skin, tablets of wax and clay inscribed with forgotten scripts. The air was still and cold, but it was the quality of the stillness that unnerved him—it seemed to swallow sound, to absorb vibration, to create a pocket of absolute silence in the heart of the mountain.</p>
+<p>His footsteps made no echo. His breathing sounded muffled, as if heard through wool. Even the rustle of his uniform was absorbed by the hungry air.</p>
+<p>The air in the vault had weight and taste. It tasted of ozone and old ink, with an undercurrent of something metallic—like blood that had dried centuries ago. But there was more: the ghost of incense from prayers offered by long-dead monks, the faint sweetness of decaying parchment, the sharp tang of iron from the mountain&#x27;s heart. When Zero breathed deeply, he felt the air settle in his lungs differently, as if he were inhaling time itself—not just the past, but all the moments that had ever happened in this space, layered like sedimentary rock.</p>
+<p>He found the Codex easily enough—exactly where Matthias had said, on the third shelf from the left. It was massive, bound in leather that might once have been human skin (the Church had strange traditions), secured with iron clasps that showed no rust despite the damp. The cover was embossed with a symbol he didn&#x27;t recognize: a circle divided into three unequal parts, with an eye at the center. He lifted it, surprised by its weight. It smelled of mildew and sanctity, yes, but also of something else—ozone, again, and the faint electric scent he associated with demonic energy.</p>
+<p>As he turned to leave, something caught his eye on a lower shelf: a flash of modern plastic among the antiquity. Curiosity overrode protocol. He set down the Codex (carefully, on a stone bench that seemed placed there for that purpose) and knelt to examine the object.</p>
+<p>A data crystal. Standard Church issue, matte black, about the size of his thumb. It was labeled in clean, modern script: &quot;Archival Access - Level Delta. Monastery Backup 7.&quot; Why would a modern data crystal be here, among manuscripts centuries old? And why would it be labeled so plainly, so obviously, in a place meant for secrets?</p>
+<p>He picked it up. It was cool to the touch, humming with a low-grade energy field. He turned it over. On the back, etched in letters so tiny he had to bring it close to his eyes: <em>Biometric override: Epsilon Gene carriers only. All others will trigger security protocols.</em></p>
+<p>His gene. The mutation that made him the Godslayer. The thing that set him apart from every other human, that made him valuable to the Church, that made him a weapon.</p>
+<p>Zero&#x27;s heart beat faster, the sound loud in the vault&#x27;s consuming silence. He looked around, half-expecting to see surveillance cameras, motion sensors, something. But there was only stone and ancient knowledge. From beyond the door, he could hear Brother Matthias humming a hymn—a medieval plainsong about the fall of Lucifer. The tune was mournful, almost a dirge.</p>
+<p><em>Walls remember.</em></p>
+<p>Evangeline&#x27;s words echoed in the silence. <em>Stone has longer memory than paper.</em></p>
+<p>He walked to the back wall, the one that should have been solid mountain. Running his hand over the stone, he felt... something. Not a texture difference, but a temperature one. A rectangle about the size of a door was slightly warmer than the surrounding rock. His fingers traced a seam so fine it was invisible to the eye, detectable only by the minute change in surface texture.</p>
+<p>A door. Perfectly concealed. Meant for him.</p>
+<p>The realization was both thrilling and terrifying. This wasn&#x27;t an accident. This was a test. Or a trap. Or... an invitation.</p>
+<p>Holding his breath, Zero pressed his palm against the warm rectangle. For a moment, nothing. Then a soft hum, barely audible, a vibration that traveled up his arm and settled in his bones. The rectangle of stone slid inward an inch, then sideways, revealing darkness beyond—and a rush of air that smelled of ozone, machine oil, and something else, something clean and electric.</p>
+<p>The data crystal in his other hand began to glow with a soft blue light, pulsing in time with his heartbeat.</p>
+<p>He stepped through, into the mountain&#x27;s secret heart.</p>
+<p>The room beyond was nothing like the vault. Where the vault had been ancient stone and organic decay, this space was all smooth metal, polished surfaces, and the cool blue glow of active technology. It was small—no larger than the vault itself—but every surface hummed with power. Climate control kept the air dry and odorless. Lighting panels in the ceiling cast a shadowless illumination that made everything look slightly unreal.</p>
+<p>A single terminal dominated the center of the room, its screen dark but thrumming with potential energy. As Zero approached, the screen lit up with a soft chime:</p>
+<p><strong>ARCHIVE ACCESS - WELCOME, SUBJECT ZERO</strong></p>
+<p><strong>BIOMETRIC CONFIRMED - EPSILON GENE DETECTED</strong></p>
+<p><strong>NEURAL PATTERN RECOGNIZED - ACCESS GRANTED</strong></p>
+<p><strong>CLEARANCE LEVEL: OMEGA (FULL ADMINISTRATIVE)</strong></p>
+<p>He stared, his breath catching in his throat. Omega clearance. He&#x27;d seen the classification system in training manuals. Alpha for novices. Beta for acolytes. Gamma for priests. Delta for bishops. Epsilon for archbishops. Zeta for cardinals. And Omega... Omega was for the Conclave itself. For Cardinal Valerius and the eleven others who ruled the Church from the shadows.</p>
+<p>Why would he have Omega clearance? He was a weapon, not an administrator. A tool, not a wielder.</p>
+<p>The terminal offered a menu of options in clean, sans-serif type: <strong>FINANCIAL RECORDS</strong>, <strong>OPERATIONAL LOGS</strong>, <strong>PROJECT FILES</strong>, <strong>PERSONNEL DATABASE</strong>, <strong>ABYSSAL MONITORING</strong>, <strong>TITHE COMPLIANCE TRACKING</strong>.</p>
+<p>His hand hovered over the holographic interface. This was forbidden. This was exactly what Evangeline had hinted at—the Memory of Stone, given digital form. The Archive that remembered everything.</p>
+<p><em>Why me?</em> he wondered. <em>Why give the weapon access to the armory&#x27;s inventory?</em></p>
+<p>From the vault behind him, Brother Matthias called, his voice muffled by the stone door: &quot;Found it yet, lad? The mountain grows impatient with visitors.&quot;</p>
+<p>&quot;Almost!&quot; Zero called back, his voice sounding strange in the metallic, echo-free space. &quot;Just... checking the binding. Making sure it&#x27;s intact.&quot;</p>
+<p>He heard Matthias&#x27;s dry chuckle. &quot;The binding&#x27;s been intact for eight centuries. I doubt it&#x27;ll fall apart in the next five minutes. But take your time. Some things shouldn&#x27;t be rushed.&quot;</p>
+<p>The words felt like both permission and warning.</p>
+<p>Zero turned back to the terminal. His fingers, trained for combat, felt clumsy on the smooth interface. He selected <strong>FINANCIAL RECORDS</strong>.</p>
+<p>The screen filled with columns and numbers, graphs and charts, a river of data flowing in real time. He saw global tithe payments updating by the second—credits flowing from cities, corporations, nations into Church accounts. He saw allocations—funds directed to &quot;demon suppression,&quot; &quot;public outreach,&quot; &quot;theological research,&quot; &quot;infrastructure maintenance.&quot;</p>
+<p>He searched for &quot;New Jerusalem.&quot; The system responded instantly, pulling up a detailed dossier:</p>
+<p><strong>NEW JERUSALEM ARCOLOGY - OWNER: OMNIGUARD CORP</strong> <strong>QUARTERLY TITHE PAYMENT: 500,000,000 CREDITS (PAID ON TIME, 100% COMPLIANCE)</strong> <strong>DEMONIC ACTIVITY (CURRENT QUARTER): 0 INCIDENTS</strong> <strong>PROTECTION STATUS: ACTIVE (TIER 1 - PRIORITY RESPONSE)</strong> <strong>NOTES: MODEL COMPLIANT DISTRICT. RELATIONSHIP MANAGER: ARCHBISHOP SILAS. LAST NEGOTIATION: 6 MONTHS AGO (SUCCESSFUL - 15% INCREASE ACCEPTED WITHOUT INCIDENT). RECOMMENDATION: MAINTAIN CURRENT LEVEL, CONSIDER ADDITIONAL &quot;SECURITY FEES&quot; FOR NEW RESIDENTIAL TOWERS.</strong></p>
+<p>Zero&#x27;s stomach tightened. <em>Security fees. Negotiation. Successful increase.</em> The language was corporate, not theological. This wasn&#x27;t about faith or protection—it was about revenue optimization.</p>
+<p>With trembling fingers, he searched for a non-compliant district. The system suggested several. He selected &quot;Detroit Sector (Former Metropolitan Area)&quot;:</p>
+<p><strong>DETROIT SECTOR - STATUS: NON-COMPLIANT</strong> <strong>QUARTERLY TITHE PAYMENT: 75,000,000 CREDITS (60% BELOW REQUIRED MINIMUM)</strong> <strong>DEMONIC ACTIVITY (CURRENT QUARTER): 12 INCIDENTS (4 CLASS 3, 8 CLASS 2)</strong> <strong>CASUALTIES: ESTIMATED 11,400-12,800 (CONFIRMED: 9,742)</strong> <strong>PROTECTION STATUS: SUSPENDED PENDING NEGOTIATIONS</strong> <strong>NOTES: LOCAL COUNCIL REFUSED 300% TITHE INCREASE. DEMONSTRATION OF CONSEQUENCES AUTHORIZED. OPERATION &quot;FINANCIAL COMPLIANCE ENFORCEMENT&quot; EXECUTED 10/15/2167. CONTAINMENT FIELDS DISABLED PER PROTOCOL 7-B. RESCUE DELAYED 72 HOURS PER NEGOTIATION STRATEGY. FOLLOW-UP: COUNCIL CAPITULATED AFTER INCIDENT. NEW TITHE RATE: 350% INCREASE. PROTECTION RESTORED. RECOMMENDATION: MONITOR FOR FURTHER RESISTANCE. CONSIDER ADDITIONAL &quot;REMINDER&quot; IN 6 MONTHS IF COMPLIANCE WAVERS.</strong></p>
+<p>His blood ran cold, then hot, then cold again. The clinical language made it worse. <em>Demonstration of consequences. Containment fields disabled per protocol. Rescue delayed 72 hours per negotiation strategy.</em> This wasn&#x27;t a failure of protection. This was policy. Deliberate. Calculated.</p>
+<p>Eleven thousand people. Maybe twelve. Numbers in a ledger. A &quot;successful&quot; negotiation strategy.</p>
+<p>He searched for his own name, hands shaking now. Found <strong>PROJECT ZERO - STATUS: ACTIVE</strong>. Tried to open it.</p>
+<p>The screen flashed red:</p>
+<p><strong>ACCESS DENIED - INSUFFICIENT CLEARANCE</strong></p>
+<p><strong>REQUIRED: CONCLAVE MAJORITY APPROVAL (8/12 VOTES)</strong></p>
+<p><strong>CURRENT CLEARANCE: OMEGA (SINGLE USER - SUBJECT ZERO)</strong></p>
+<p><strong>NOTE: PROJECT FILES CONTAIN SENSITIVE ORIGIN DATA. ACCESS RESTRICTED TO PREVENT... COMPLICATIONS.</strong></p>
+<p>Complications. What complications? The truth?</p>
+<p>&quot;Lad?&quot; Matthias&#x27;s voice was closer now, right outside the stone door. &quot;The Codex won&#x27;t read itself, you know. And my knees aren&#x27;t what they used to be.&quot;</p>
+<p>Zero backed out of the Archive, his movements automatic, his mind reeling. The stone door slid shut behind him with a soft hiss, becoming seamless once more—just another section of wall in a vault full of secrets. He stood for a moment in the consuming silence, the taste of ozone and old ink still on his tongue, the numbers burning behind his eyes.</p>
+<p><em>Eleven thousand people. Maybe twelve. Demonstration of consequences. Protocol 7-B.</em></p>
+<p>He picked up the Codex, its weight suddenly symbolic. Eight centuries of knowledge, of theology, of lies wrapped in sanctity. He carried it out of the vault like a pallbearer carrying a coffin.</p>
+<p>Brother Matthias was waiting outside, leaning on a staff carved from mountain ash. His ancient eyes studied Zero&#x27;s face, missing nothing. &quot;Find what you were looking for?&quot;</p>
+<p>&quot;I found the Codex.&quot; The words sounded hollow.</p>
+<p>&quot;Ah. Just the Codex.&quot; Matthias nodded slowly, the motion like a tree bending in wind. &quot;Some things, once found, can&#x27;t be unfound. The mind has a way of holding onto certain truths, even when we wish it wouldn&#x27;t. Remember that, lad. Knowledge is a burden as much as a gift.&quot;</p>
+<p>&quot;Did you know?&quot; Zero asked, the question escaping before he could stop it. &quot;About what&#x27;s in there?&quot;</p>
+<p>Matthias&#x27;s smile was sad. &quot;I know the mountain has many rooms. I know some doors open only for certain keys. I know the Church has been keeping records since before either of us was born. The rest... the rest is between you and your conscience.&quot;</p>
+<p>He led Zero back through the corridors, the plainsong hymn still humming in his throat. At the main door, he paused. &quot;The Codex contains Saint Ignatius&#x27;s early visions of the Abyss. He saw it not as hell, but as... potential. Raw creation waiting to be shaped. The Church found that interpretation inconvenient. They prefer their demons tidy and evil. Less complicated that way.&quot;</p>
+<p>Zero stared at him. &quot;You&#x27;re not supposed to tell me that.&quot;</p>
+<p>&quot;I&#x27;m an old man in a remote monastery,&quot; Matthias said with a shrug. &quot;What are they going to do? Transfer me to an even more remote monastery? Besides, some truths deserve to be spoken, even if only once, to only one person. Consider it my confession.&quot;</p>
+<p>On the transport back to orbit, Zero stared at the data crystal in his hand. It had stopped glowing, was just a piece of plastic now, inert and meaningless. But in his mind, the numbers glowed bright and terrible:</p>
+<p>500 million credits. Zero incidents. 75 million credits. Twelve incidents. 11,400-12,800 casualties. <em>Successful negotiation strategy.</em></p>
+<p>He saw the toy soldier in his mind&#x27;s eye—Miko&#x27;s toy, left in a sterile room where no child should have been. He saw the containment chamber in New Jerusalem, the demon moving with tactical precision. He saw Archbishop Silas&#x27;s smile that didn&#x27;t reach his eyes.</p>
+<p><em>Negotiations.</em></p>
+<p>The word took on new meaning. It wasn&#x27;t diplomacy. It was extortion with celestial branding. Protection suspended pending negotiations. Rescue delayed per negotiation strategy.</p>
+<p>The transport broke through the cloud layer, and the monastery vanished below, just another speck on a mountainside. Zero looked at the Codex on the seat beside him, then at the data crystal in his hand.</p>
+<p>Two keys. One to ancient truths about the Abyss. One to modern truths about the Church.</p>
+<p>The toy soldier in his pocket felt heavier than both combined.</p>
+<p>Somewhere, a child named Miko played without their toy. Somewhere, eleven thousand people were numbers in a ledger. Somewhere, the walls remembered everything.</p>
+<p>And Zero, the Godslayer, the weapon, the solution, sat in silence as the transport carried him back to the architects of it all.</p>
+<p>The splinter of doubt was now a crack. And the crack was widening.</p>
+<hr aria-hidden="true">
+<h3>Chapter 4: Ledgers of Damnation</h3>
+<p>The Cardinal&#x27;s study was all dark wood and darker intentions, a room designed to intimidate as much as to function. Bookshelves rose to a ceiling lost in shadow, filled with volumes bound in leather and guilt. A massive desk of black oak dominated the space, its surface polished to a mirror sheen that reflected the room&#x27;s single light source—an antique oil lamp that cast more shadow than illumination.</p>
+<p>Valerius stood at the desk, examining the Codex with the care of a surgeon examining a specimen. His fingers, pale and precise, traced the embossed symbol on the cover—the divided circle with the eye at its center. &quot;Excellent work, Zero. This text contains... insights. About the early understanding of the Abyss. Saint Ignatius had visions, you see. Visions that didn&#x27;t align with later doctrine.&quot;</p>
+<p>Zero stood at attention, the data crystal a secret fire in his pocket. The toy soldier was there too, a tiny weight against his thigh. He could still see the numbers from the Archive burning behind his eyes: 500 million/zero, 75 million/twelve, 11,400-12,800 casualties. The clinical language: <em>Demonstration of consequences. Protocol 7-B. Negotiation strategy.</em></p>
+<p>&quot;Your Eminence,&quot; he began, his voice carefully neutral. &quot;May I ask a question?&quot;</p>
+<p>Valerius didn&#x27;t look up from the Codex. &quot;Questions are the beginning of heresy, Zero. Curiosity killed more than cats—it killed faith, it killed obedience, it killed whole civilizations. But ask. I&#x27;ve always encouraged your intellectual development.&quot;</p>
+<p>The condescension was subtle, woven into the permission. Zero took a breath. &quot;The financial records I saw in the Archive at the monastery. The correlations between tithe payments and demonic activity. The... notes about negotiations.&quot;</p>
+<p>The Cardinal&#x27;s head snapped up. For a moment, his face was unguarded—surprise, then calculation, then a mask of paternal concern sliding into place. &quot;You accessed the Archive? The Memory of Stone?&quot;</p>
+<p>&quot;The biometric lock responded to me. I found a data crystal—&quot;</p>
+<p>&quot;Of course it responded to you.&quot; Valerius closed the Codex with a soft thump that echoed in the study&#x27;s silence. He circled the desk, his crimson robes whispering against the stone floor. &quot;You&#x27;re a product of the Church, Zero. Your genetics, your training, your very existence—all engineered, all cultivated, all owned. Did you think we wouldn&#x27;t have access protocols for our own creations? That we wouldn&#x27;t build backdoors into our own weapons?&quot;</p>
+<p>The word <em>creations</em> landed like a physical blow, followed by <em>owned</em> like a second strike. Zero felt something twist in his chest—a combination of betrayal and a terrible, dawning understanding. He wasn&#x27;t a person. He was property. A tool with a serial number.</p>
+<p>&quot;I saw correlations,&quot; he said, forcing his voice to remain steady. &quot;Between tithe payments and demon attacks. Not just correlations—causation. The records said &#x27;demonstration of consequences.&#x27; &#x27;Protocol 7-B.&#x27; &#x27;Rescue delayed per negotiation strategy.&#x27;&quot;</p>
+<p>Valerius moved to the study&#x27;s single window, which showed not the Vatican grounds but a real-time feed of stars—the view from the <em>Sanctuary</em> in orbit. His back was to Zero, his silhouette black against the starfield. &quot;Correlation isn&#x27;t causation, Zero. That&#x27;s first-year statistics. Wealthy districts can afford better shielding, better early warning systems, better-trained response teams. They invest in protection, and protection works. It&#x27;s not rocket science. It&#x27;s... economics.&quot;</p>
+<p>&quot;It&#x27;s extortion.&quot; The word was out before Zero could stop it.</p>
+<p>Valerius turned slowly. The starlight from the window backlit him, putting his face in shadow, making him a silhouette of authority. &quot;The Detroit records said &#x27;protection suspended pending negotiations,&#x27;&quot; Zero continued, his voice gaining strength. &quot;Eleven to twelve thousand people died while you negotiated. That&#x27;s not protection. That&#x27;s... leverage.&quot;</p>
+<p>&quot;Semantics.&quot; Valerius&#x27;s voice was cold now, the paternal mask slipping. &quot;The Church has limited resources, Zero. Finite personnel, finite equipment, finite energy. We must allocate them where they&#x27;re most effective. Where they do the most good. Where they&#x27;re... appreciated.&quot;</p>
+<p>Zero&#x27;s hands clenched at his sides, nails digging into his palms. &quot;So we let people die if they can&#x27;t pay? Children? Families? People just trying to survive?&quot;</p>
+<p>&quot;We prioritize!&quot; Valerius&#x27;s composure cracked, his voice rising. He took a step forward, out of the shadow, and Zero saw his face—not the calm, controlled cardinal, but a man stretched thin by decades of impossible choices. &quot;This is reality, Zero. Not some fairy tale where good always triumphs and everyone gets a happy ending. The world is a fragile ecosystem, and we are the gardeners. Sometimes you prune a branch to save the tree. Sometimes you sacrifice a few to save the many.&quot;</p>
+<p>&quot;By sacrificing the poor?&quot; Zero shot back. &quot;By making examples of districts that can&#x27;t pay your protection money?&quot;</p>
+<p>&quot;By ensuring the species continues!&quot; Valerius slammed a hand on his desk, the impact echoing like a gunshot. The oil lamp flickered, sending shadows dancing across the bookshelves. &quot;Do you think I enjoy these decisions? Do you think any of us on the Conclave sleep well after authorizing a &#x27;demonstration&#x27;? We bear this burden so that millions—billions—can sleep safely at night! So that civilization doesn&#x27;t collapse into the chaos that nearly consumed us a century ago!&quot;</p>
+<p>The anger was raw, visceral. But something in Zero hesitated, caught by the pain in Valerius&#x27;s eyes. It was real—the anguish of a man who had made terrible choices and had to live with them. The Cardinal wasn&#x27;t a cartoon villain twirling a mustache; he was a true believer who had convinced himself that the ends justified the means.</p>
+<p>For a moment, Zero almost understood. Almost.</p>
+<p>&quot;Your file,&quot; Zero said quietly, shifting tactics. &quot;Project Zero. In the Archive. I tried to access it. The system said I needed Conclave majority approval. Why? What&#x27;s in there that you don&#x27;t want me to see?&quot;</p>
+<p>Valerius&#x27;s anger deflated, replaced by something more dangerous—pity. He returned to his desk, sat heavily in his chair, the weight of his office suddenly visible in the slump of his shoulders. &quot;Because some truths are too heavy for young shoulders, Zero. Some knowledge can break a mind not prepared to receive it. Your origins... they&#x27;re not what you think.&quot;</p>
+<p>&quot;What does that mean?&quot;</p>
+<p>&quot;It means you&#x27;re asking questions whose answers might destroy you.&quot; Valerius steepled his fingers, his eyes distant. &quot;You&#x27;re questioning, Zero. That&#x27;s natural. Intelligent weapons eventually wonder about their makers. It&#x27;s why I&#x27;m sending you to the Saint Benedict Retreat on the Norwegian coast. A month of contemplation, of meditation, of... recentering your faith. Away from distractions. Away from archives and data crystals and troubling questions.&quot;</p>
+<p>&quot;A retreat.&quot; Zero heard the dismissal in the words, the gentle removal of a problematic asset. &quot;You&#x27;re sending me away because I saw something I shouldn&#x27;t have.&quot;</p>
+<p>&quot;Think of it as education.&quot; Valerius&#x27;s smile was thin, tired. &quot;The world is complex, Zero. Your role in it is beautifully simple: protect humanity. Eliminate demons. Be the sword, not the hand that wields it. Leave the complexities—the moral calculations, the resource allocations, the... negotiations—to those equipped to handle them. To those who have borne the burden longer.&quot;</p>
+<p>&quot;Those like you.&quot;</p>
+<p>&quot;Those like me.&quot; Valerius nodded. &quot;I&#x27;ve made my peace with hard choices. You haven&#x27;t yet. The retreat will help. Or it will break you. Either way, the problem is solved.&quot;</p>
+<p>The cold calculation in the words was more shocking than the anger had been. Zero stared at the man who had been his father, his teacher, his god for fifteen years, and saw a stranger. A bureaucrat of souls. A manager of salvation.</p>
+<p>&quot;You&#x27;re dismissed,&quot; Valerius said, already turning his attention to another document on his desk. &quot;Transport leaves at dawn. Brother Anselm will be expecting you. He&#x27;s... insightful. Listen to him. Or don&#x27;t. The choice, as always, is yours.&quot;</p>
+<p>Zero left the study, the door closing behind him with a soft click that sounded like a seal on a tomb. In the corridor outside, he leaned against cold stone, breathing hard, his mind racing. The numbers from the Archive. Valerius&#x27;s admission wrapped in justification. The retreat—exile disguised as spiritual journey.</p>
+<p>He touched the toy soldier in his pocket, felt the carved name. Miko.</p>
+<p><em>What would you do, Miko?</em> he wondered. <em>If you found out the people who were supposed to protect you were actually the ones deciding who lived and who died?</em></p>
+<p>He had no answer. Only more questions.</p>
+<p>Sister Evangeline found him there, her footsteps silent on the stone. She wore the simple gray habit of the lower orders, but her eyes held a intelligence that belonged in much higher circles. &quot;You look like you&#x27;ve seen a ghost,&quot; she said softly. &quot;Or several thousand of them.&quot;</p>
+<p>Zero straightened, trying to compose himself. &quot;The Cardinal and I had... words.&quot;</p>
+<p>&quot;About the Archive.&quot; It wasn&#x27;t a question.</p>
+<p>&quot;How did you—&quot;</p>
+<p>&quot;Valerius has a pattern.&quot; She glanced up and down the corridor, then took his arm and pulled him into a nearby alcove—a space between two massive stone pillars that held a statue of some forgotten saint. The stone was cold, the space tight enough that they stood close, speaking in whispers. &quot;When someone sees something they shouldn&#x27;t, he doesn&#x27;t deny it. He justifies it. Makes it sound like painful necessity rather than calculated evil.&quot;</p>
+<p>&quot;I accessed the Archive,&quot; Zero confirmed, his voice low. &quot;The financial records. Detroit. Eleven to twelve thousand people. &#x27;Demonstration of consequences.&#x27;&quot;</p>
+<p>Evangeline closed her eyes briefly, a flicker of pain crossing her face. &quot;I knew the numbers were high. I didn&#x27;t know they were that high.&quot; She opened her eyes, and they were hard. &quot;What else?&quot;</p>
+<p>&quot;Project Zero. My file. Locked. Needs Conclave approval to access.&quot;</p>
+<p>&quot;Of course it does.&quot; She bit her lip, a nervous habit he hadn&#x27;t seen before. &quot;Zero, the Archive is watched. Not by cameras—by something else. Psychic echoes, maybe. Or predictive algorithms. They&#x27;ll know you accessed it. They&#x27;ll know what you looked at. Valerius&#x27;s little performance was just the opening act.&quot;</p>
+<p>&quot;Who&#x27;s &#x27;they&#x27;?&quot; Zero asked, though he suspected the answer.</p>
+<p>&quot;The Conclave. The twelve. Valerius is their public face, their executor, but he answers to them. They&#x27;re the ones who make the real decisions. Who lives, who dies, which districts get protection, which get... demonstrations.&quot; Her voice dropped even lower. &quot;They&#x27;ve been doing this for fifty years, Zero. Since before you were born. Since before I was born. This isn&#x27;t a recent corruption. It&#x27;s the foundation.&quot;</p>
+<p>&quot;About who lives and dies based on credits,&quot; Zero said, the words tasting bitter.</p>
+<p>Her silence was answer enough—a heavy, guilty silence that spoke of her own complicity, her own failed attempts to change things from within.</p>
+<p>&quot;Help me access the full records,&quot; Zero said. &quot;Everything. Not just the financials. Project Zero. My origins. Everything.&quot;</p>
+<p>&quot;I can&#x27;t.&quot; The words were torn from her. &quot;My clearance is Delta at best. I&#x27;m a nun, Zero. A junior confessor. They tolerate me because I&#x27;m useful for handling... problematic elements like you. But I don&#x27;t have access to the deep files.&quot;</p>
+<p>She hesitated, then reached into her habit and produced a data chip—small, black, unmarked. She pressed it into his hand. Her fingers were cold. &quot;There&#x27;s a backup. Off-site. Not Church-controlled. The Ruins.&quot;</p>
+<p>&quot;The Detroit Ruins?&quot; Zero&#x27;s mind flashed to the records: 75 million credits, 60% below required, protection suspended, 12 incidents.</p>
+<p>&quot;Where the Church&#x27;s failures are most visible,&quot; Evangeline said, her voice urgent. &quot;Where the walls have the most to remember. Where people who survived have been... collecting evidence. Building their own archive. This chip has coordinates. Passcodes. The location of a safe house. Someone who can help you access what the Church doesn&#x27;t want accessed.&quot;</p>
+<p>Zero looked at the chip in his palm. It was warm from her body heat. &quot;Why are you doing this? You could be executed for treason.&quot;</p>
+<p>&quot;Because I took vows to serve God, not a corporation masquerading as a church.&quot; Her eyes were fierce in the dim light. &quot;Because someone has to ask why there are toys in containment chambers. Because children named Miko deserve better than to be collateral damage in someone&#x27;s balance sheet.&quot;</p>
+<p>She reached out, touched his arm—a brief, human contact that felt alien after years of conditioned distance. &quot;And because you&#x27;re asking the right questions, Zero. For the first time in your life, you&#x27;re not just accepting what they tell you. That makes you dangerous to them. And possibly... the only hope for the rest of us.&quot;</p>
+<p>He pocketed the chip, felt its weight join the toy soldier and the data crystal. A collection of secrets. &quot;The retreat first,&quot; he said. &quot;Valerius is sending me to Saint Benedict&#x27;s for a month. To &#x27;recenter my faith.&#x27;&quot;</p>
+<p>&quot;A test,&quot; Evangeline said immediately. &quot;They&#x27;re testing your loyalty. Seeing if the conditioning holds. Brother Anselm who runs the retreat... he&#x27;s one of theirs. Old school. Believer in the old ways. Be careful, Zero. Don&#x27;t trust him. Don&#x27;t trust anyone.&quot;</p>
+<p>&quot;I&#x27;m starting to think the only person I can trust is the one handing me treasonous data chips in dark alcoves,&quot; Zero said, a faint smile touching his lips.</p>
+<p>Evangeline didn&#x27;t smile back. &quot;Don&#x27;t trust me either. Trust the evidence. Trust what you see with your own eyes. And remember—walls remember. Even the walls of retreat houses.&quot;</p>
+<p>She slipped out of the alcove, melting into the shadows of the corridor without a sound. Zero stood alone in the cold stone space, the data chip a secret weight in his pocket, the toy soldier another, the memory of eleven thousand dead a third.</p>
+<p>Somewhere, the Conclave was watching. Somewhere, Valerius was calculating. Somewhere, a child played without their toy.</p>
+<p>And Zero, the Godslayer, stood at a crossroads, three pieces of a puzzle in his pocket, and no idea which way led to truth and which to damnation.</p>
+<p>As Zero walked away, he felt the weight of it all—the toy soldier, the data crystal, the chip, the numbers in his head.</p>
+<p>500 million. Zero incidents. 75 million. Twelve incidents.</p>
+<p><em>Negotiations.</em></p>
+<p>The walls seemed to whisper as he passed: <em>Remember. Remember.</em></p>
+<hr aria-hidden="true">
+<h3>Chapter 5: The Unasked Question</h3>
+<p>The Saint Benedict Retreat was silence given form, a place where quiet had weight and substance.</p>
+<p>Perched on a cliff overlooking a frozen sea in the Norwegian Arctic, the monastery was all gray stone and grayer skies, a fortress against both the elements and the modern world. The wind howled constantly, a mournful counterpoint to the enforced silence within. Brother Anselm, who greeted Zero at the massive iron gates, had a face like weathered leather stretched over sharp bones, and eyes that missed nothing—the eyes of an inquisitor, not a monk.</p>
+<p>&quot;Subject Zero.&quot; His voice was the crackle of dry parchment, the sound of something ancient and fragile. &quot;We&#x27;ve been expecting you. Cardinal Valerius sent word of your... spiritual unrest. The retreat will provide clarity. Or it will break you. Either outcome serves God&#x27;s purpose.&quot;</p>
+<p>The words were delivered without malice, as simple statement of fact. Zero felt a chill that had nothing to do with the Arctic wind.</p>
+<p>The retreat&#x27;s routine was merciless in its simplicity, designed to strip away individuality, doubt, and independent thought: prayer at dawn (two hours of kneeling on cold stone), study until noon (approved texts only), manual labor until dusk (pointless tasks like moving rocks from one pile to another), contemplation until sleep (sitting in darkness, thinking about one&#x27;s sins). Repeat. The monks—twenty of them, all men, all old—spoke only when necessary, and even then in whispers that the wind stole before they reached Zero&#x27;s ears.</p>
+<p>Zero&#x27;s &quot;study&quot; consisted of texts carefully selected to reinforce Church doctrine: hagiographies of saints who never questioned, theological arguments for the Church&#x27;s absolute supremacy, technical manuals on demon classification that emphasized their mindless evil, histories that painted the Church as humanity&#x27;s sole savior since the first Abyssal rift opened. Nothing about financial records. Nothing about the Archive. Nothing about &quot;demonstrations of consequences&quot; or &quot;negotiation strategies.&quot;</p>
+<p>But in the silence, in the gaps between prayers and labor, his mind worked. It had been trained for analysis—tactical assessment of demon behavior, evaluation of threat levels, optimization of response strategies. Now he turned that training inward, on the Church itself.</p>
+<p>He noticed patterns.</p>
+<p>The monks moved with a synchronized precision that spoke of decades of conditioning. Their prayers were identical, their movements during labor choreographed, their silences orchestrated. This wasn&#x27;t a retreat; it was a reprogramming center.</p>
+<p>Brother Anselm had particular habits that Zero cataloged: tracing the same crack in the chapel floor with his toe during morning prayers (exactly seven times, always starting with the right foot), touching a particular stone in the refectory wall before meals (three taps with the middle finger), counting his breaths during meditation (inhale for four, hold for seven, exhale for eight—the &quot;divine ratio&quot;).</p>
+<p><em>Ritual</em>, Zero thought during his first week. <em>Or compulsion. Or both.</em></p>
+<p>Brother Anselm&#x27;s left thumb was permanently stained blue-black, as if dipped in ink that never washed off. The stain started at the nail and extended to the first joint, fading to a mottled gray at the edges. When he turned pages during study hours, the stain left faint smudges on the parchment—ghostly fingerprints that accumulated over the years. Zero once caught him staring at the stain during evening prayers, his lips moving in silent conversation with the discolored skin. Later, during a rare moment when Anselm thought he was alone, Zero saw him try to scrub the stain off with pumice stone, scrubbing until the skin bled. The stain remained. The blood mixed with it, creating a darker, richer black.</p>
+<p>On the third day, during manual labor (the eternal, pointless repair of a stone wall that had stood for eight centuries and would stand for eight more without their help), Zero broke protocol. The silence, the routine, the constant pressure to empty his mind—it was having the opposite effect. His doubts grew louder, more insistent.</p>
+<p>&quot;Brother Anselm,&quot; he said, his voice loud in the wind-whipped silence. &quot;Have you ever been to the Detroit Ruins?&quot;</p>
+<p>The old monk didn&#x27;t look up from his mortar, but his hands stilled for a fraction of a second. &quot;Some places are best not visited, Subject Zero. Some doors, once opened, cannot be closed.&quot;</p>
+<p>&quot;Why?&quot; Zero pressed, leaning on his shovel. &quot;What&#x27;s in the Ruins that the Church doesn&#x27;t want us to see?&quot;</p>
+<p>&quot;Not what. Who.&quot; Anselm placed a stone with precise care, tapping it into place with a small hammer. &quot;The people who survived. The people who remember what happened. The people who ask... inconvenient questions.&quot;</p>
+<p>&quot;Like what really caused the demon attack? Like why the containment fields failed? Like why rescue was delayed seventy-two hours?&quot;</p>
+<p>Anselm finally looked at him, his eyes ancient and weary. &quot;Because some memories are best not remembered. Some truths are too heavy for the world to bear. The Church protects us from such memories. Shields us from truths that could shatter faith.&quot;</p>
+<p>&quot;By walling them off?&quot; Zero gestured at the stone wall they were repairing. &quot;By building walls around the truth?&quot;</p>
+<p>&quot;By focusing us on the present.&quot; Anselm&#x27;s voice was low, urgent. &quot;On our duties. On the work that needs doing now. You&#x27;re here to remember your duty, Subject Zero. Not to question it. To recenter your faith in the Church&#x27;s wisdom. To accept that some things are beyond your understanding, and that&#x27;s as it should be.&quot;</p>
+<p>&quot;But if our duty is based on lies—&quot; Zero began.</p>
+<p>&quot;All duty is based on something!&quot; Anselm&#x27;s composure cracked, his voice rising before he brought it under control. He glanced around, but the other monks were out of earshot, lost in their own pointless labors. &quot;Faith. Fear. Hope. Greed. Love. The question isn&#x27;t whether the foundation is pure. The question is whether what&#x27;s built on it serves a greater good.&quot;</p>
+<p>&quot;And does it?&quot; Zero asked quietly. &quot;Does letting thousands die to make a point serve a greater good?&quot;</p>
+<p>Anselm stared at him for a long moment, his stained thumb tapping rhythmically against his thigh. Then he turned back to the wall. &quot;Finish your section. The light is fading.&quot;</p>
+<p>The conversation was over, but Zero had his answer. In the evasion, in the non-answer, in the tired eyes of an old man who had seen too much—he had his answer.</p>
+<p>That night, in his cell—a stone box barely larger than a coffin, with a narrow slit of a window that showed a sliver of frozen sea and colder sky—Zero took out the toy soldier. In the moonlight that managed to fight through the perpetual cloud cover, the painted eyes seemed to watch him with pity, or perhaps recognition. Two manufactured things, one of wood and paint, one of flesh and engineered genetics, both created for purposes they didn&#x27;t choose.</p>
+<p>He thought of the data chip Evangeline had given him, hidden in a seam of his uniform. Coordinates to the Ruins. To answers. To the people who remembered what the Church wanted forgotten.</p>
+<p>He thought of the Archive records: 75 million credits, 60% below required, protection suspended, 12 incidents, 11,400-12,800 casualties. <em>Successful negotiation strategy.</em></p>
+<p>He thought of Brother Anselm&#x27;s stained thumb, the silent conversation with discolored skin, the attempt to scrub away a mark that wouldn&#x27;t fade.</p>
+<p><em>What stains won&#x27;t wash off?</em> Zero wondered. <em>What marks do we carry that define us despite our efforts?</em></p>
+<p>On the seventh day, as Zero knelt in the chapel tracing the same crack Anselm traced every morning (he&#x27;d started doing it himself, a small rebellion), a messenger arrived from the Vatican—a young acolyte in travel-stained robes, his face pale from cold and fear. Zero was summoned to the abbot&#x27;s office, a room even colder than his cell.</p>
+<p>The message was brief, written on Church vellum with the Conclave&#x27;s seal: &quot;Subject Zero: Return immediately. New assignment. Priority Alpha. Detroit Ruins cleanup operation. Demon presence confirmed. Your unique abilities required.&quot;</p>
+<p><em>Cleanup</em>, Zero thought. <em>After the demonstration. After the negotiation. Now we clean up the evidence.</em></p>
+<p>Brother Anselm walked him to the gates as snow began to fall, fat flakes that melted on the stone. The wind off the sea was knife-sharp, carrying the scent of salt and distant ice. &quot;You didn&#x27;t find what you came for,&quot; the old monk said, his voice almost lost in the wind.</p>
+<p>&quot;I didn&#x27;t know what I was looking for,&quot; Zero admitted. &quot;Clarity, maybe. Faith. Certainty.&quot;</p>
+<p>&quot;Sometimes that&#x27;s when we find the most important things.&quot; Anselm placed a hand on Zero&#x27;s shoulder. It was surprisingly heavy, the weight of years and regrets. &quot;They&#x27;re sending you to the Ruins, aren&#x27;t they?&quot;</p>
+<p>&quot;How did you know?&quot;</p>
+<p>&quot;Because that&#x27;s where they send weapons they want tested.&quot; Anselm&#x27;s eyes were sad. &quot;Or broken. To see if they&#x27;ll follow orders when faced with the consequences of those orders. To see if the conditioning holds when confronted with... reality.&quot;</p>
+<p>His stained thumb left a faint blue-black mark on Zero&#x27;s uniform sleeve—a smudge like a bruise. &quot;Be careful what questions you ask there, Subject Zero. Some have answers that can unmake you. That can strip away everything you think you are until there&#x27;s nothing left but the truth. And truth... truth is a cold companion.&quot;</p>
+<p>The transport arrived in a whirl of snow and noise, its engines screaming against the wind. As Zero boarded, he looked back. Brother Anselm stood at the gates, his habit whipping around him like a shroud, his stained hand raised—in farewell, or warning, or blessing. Or all three.</p>
+<p>The transport door sealed with a hiss, cutting off the wind, the cold, the old monk&#x27;s silent vigil. Zero was alone with his thoughts, his doubts, and a toy soldier in his pocket.</p>
+<p>On the flight back, Zero examined the message more closely, reading between the lines. The assignment: &quot;Cleanup operation, Detroit Ruins. Eliminate residual demonic presence. Assess structural damage. Report any... anomalies.&quot;</p>
+<p><em>Cleanup.</em> The word took on new meaning. After the &quot;demonstration of consequences.&quot; After the &quot;negotiation strategy.&quot; After eleven thousand people became numbers in a ledger. Now: cleanup. Erase the evidence. Make it tidy.</p>
+<p><em>Residual demonic presence.</em> Of course there would be residual presence. When you stage a demon attack, some demons might stick around. Or be left behind deliberately, to keep the fear fresh.</p>
+<p><em>Assess structural damage.</em> Translation: document what needs to be hidden or explained away.</p>
+<p><em>Report any anomalies.</em> Meaning: tell us if anyone survived who shouldn&#x27;t have. If any evidence remains that contradicts the official story.</p>
+<p>He remembered the financial record with perfect clarity: 75 million credits, 60% below required minimum, protection suspended pending negotiations, operation &quot;Financial Compliance Enforcement&quot; executed 10/15/2167, containment fields disabled per protocol 7-B, rescue delayed 72 hours per negotiation strategy.</p>
+<p><em>Negotiations.</em></p>
+<p>The word was a cancer. It had metastasized from a diplomatic term to a euphemism for mass murder.</p>
+<p>The toy soldier felt warm in his hand, as if holding the memory of the child who had owned it. Miko. He wondered about them. Age? Gender? Did they live in New Jerusalem, in one of the gleaming spires? Or in the service levels below, where the machinery hummed and the air tasted of ozone and sweat? Did they cry when they realized their toy was gone? Did their parents tell them it was lost, or did they promise to look for it, not knowing it was in the pocket of the Godslayer, a weapon on his way to clean up another &quot;negotiation&quot;?</p>
+<p>The transport descended through thick cloud cover, and the Ruins spread below—a jagged, weeping scar on the earth, all broken concrete and twisted metal and memories given physical form. From this altitude, it looked like a wound that hadn&#x27;t healed properly, infection still bubbling at the edges.</p>
+<p><em>Some memories are best not remembered</em>, Anselm had said from his Arctic fortress.</p>
+<p>But Zero was beginning to think some memories <em>demanded</em> to be remembered. Demanded witnesses. Demanded someone to say: <em>This happened. These people existed. They were not just numbers in a ledger.</em></p>
+<p>The walls of the Ruins would have much to say. They had absorbed the screams, the prayers, the desperate calls for help that went unanswered for seventy-two hours. They had witnessed the &quot;demonstration of consequences.&quot; They remembered.</p>
+<p>Zero touched the data chip in his uniform, then the toy soldier in his pocket. Two keys. One to a safe house in the Ruins, to people who remembered. One to a child&#x27;s innocence, lost in a sterile room.</p>
+<p>He hoped he was ready to listen. To really listen. Not as the Godslayer, the weapon, the solution. But as a witness. As someone who might, for the first time in his engineered life, choose which side he was on.</p>
+<p>The transport banked, beginning its final approach. Below, the Ruins waited—a graveyard with stories still to tell.</p>
+<p>And Zero, who had been created to silence stories, prepared to hear them.</p>
+<hr aria-hidden="true">
+<p><em>(Note: The complete 15-chapter story continues through Act 2 and Act 3, following the chapter plan and enhancers guide. The story includes all random detail injections, character development, and the final choice where Zero creates a third path—neither destroying nor embracing the Abyss, but creating a bridge of understanding between humans and demons.)</em></p>
+<h3>Chapter 6: The Ruins Speak</h3>
+<p>The Ruins smelled of wet concrete and regret, with undertones of ozone, burnt plastic, and the sweet-rot scent of decay that hadn&#x27;t finished its work.</p>
+<p>Zero&#x27;s transport touched down in what had once been the central square of Detroit&#x27;s midtown district. Now it was a crater thirty meters across, the earth fused to glass at the edges. At the center, what remained of the &quot;Spirit of Detroit&quot; statue—a bronze figure holding a family aloft—was melted into a grotesque parody: the family now screaming, the figure&#x27;s face twisted in agony rather than hope. The air tasted of ozone and something fouler, something psychic—the residue of demonic presence, yes, but also the echo of terror, the ghost of eleven thousand voices raised in a final, unanswered plea.</p>
+<p>His squad deployed with practiced efficiency: four Inquisitors in full combat gear, faces hidden behind mirrored visors, weapons humming with charged energy. They were professionals, veterans of a hundred &quot;cleanup operations.&quot; Sergeant Voss, a man with a face like hammered iron and eyes that had seen too much to still feel anything, pointed to a collapsed apartment building on the square&#x27;s eastern edge. &quot;Residual energy readings from that structure. Class 2-3 signatures. Standard sweep pattern. Zero, you&#x27;re on point. Your absorption ability will be useful if we encounter active manifestations.&quot;</p>
+<p>Zero nodded, the motion automatic, but his attention was elsewhere. On the walls that still stood. They were covered in graffiti, but not the mindless tags or territorial markings he&#x27;d seen in other ruined places. These were messages, carefully painted, meticulously placed:</p>
+<p><em>THEY CAME AFTER THE THIRD REFUSAL</em> <em>72 HOURS TOO LATE</em> <em>ASK ABOUT THE CONTAINMENT FIELDS</em> <em>PROTOCOL 7-B = MURDER</em> <em>NEGOTIATIONS WITH BLOOD</em> <em>WHERE WERE THE SAINTS?</em></p>
+<p>Each message was in a different hand, a different style—some painted with brushes, some sprayed, some carved. A chorus of accusations written in the language of the damned.</p>
+<p>&quot;Focus, Subject Zero.&quot; Voss&#x27;s voice crackled in his earpiece, sharp with impatience. &quot;We&#x27;re here to clean up, not sightsee. Demons don&#x27;t read graffiti.&quot;</p>
+<p><em>But people do</em>, Zero thought. <em>And these aren&#x27;t messages for demons. They&#x27;re messages for us. For anyone who comes after.</em></p>
+<p>The graffiti wasn&#x27;t just paint. Some messages were etched into the concrete with what looked like claws—not demon claws, but human tools shaped into claws, driven by desperate hands. Others were written in a substance that glowed faintly in the shadows—demon ichor, repurposed as ink, harvested from the very creatures that had destroyed this place. The most prominent message, above a collapsed storefront that had once been a family-owned bakery, read: &quot;THEY WATCHED US BURN&quot; in letters three feet high. Beneath it, in smaller script: &quot;While counting our money.&quot; And beneath that, a list of names—dozens of them, maybe hundreds, each carefully lettered, each a life lost. A memorial in accusation.</p>
+<p>Zero moved toward the collapsed building, his boots crunching on broken glass and fused concrete. The structure had been eight stories of affordable housing—now it was a tombstone leaning at a dangerous angle. As he approached the main entrance (or where the main entrance had been), a figure emerged from the shadows of a nearby alcove—a man in patched clothing that might have been fashionable before the fall, his face gaunt with hunger and grief, his eyes holding a fire that hadn&#x27;t been extinguished by loss.</p>
+<p>&quot;You&#x27;re Church.&quot; The man&#x27;s voice was raw, stripped of everything but essence. &quot;Come to finish the job? To make sure no one&#x27;s left to tell the story?&quot;</p>
+<p>&quot;We&#x27;re here to eliminate residual demonic presence,&quot; Zero said automatically, the trained response. The words felt hollow even as he spoke them.</p>
+<p>The man laughed, a sound without humor, like stones grinding together. &quot;Residual. That&#x27;s a word for it. Like a stain you can&#x27;t quite wash out. Like a memory that won&#x27;t fade.&quot; He gestured to the ruins with a hand missing two fingers. &quot;They told us we had three days to pay the increased tithe. Three hundred percent increase. For &#x27;enhanced protection services.&#x27; When the city council refused... well.&quot; He shrugged, the motion conveying oceans of bitterness. &quot;The demons came exactly seventy-two hours later. Funny how that works. Almost like they had an appointment.&quot;</p>
+<p>Zero remembered the financial record with perfect, painful clarity: 75 million credits, 60% below required minimum, protection suspended pending negotiations, operation &quot;Financial Compliance Enforcement&quot; authorized.</p>
+<p>&quot;Where were the containment fields?&quot; Zero asked, though he suspected the answer. &quot;Every district has them. They&#x27;re supposed to activate automatically at the first sign of demonic energy.&quot;</p>
+<p>&quot;Ours &#x27;malfunctioned.&#x27;&quot; The man spat, the gesture full of contempt. &quot;At exactly midnight. Right when the first wave hit. Funny coincidence, that. All twelve field generators in this sector failing simultaneously. The backup systems too. The emergency override protocols. Everything just... stopped working. Almost like someone wanted them to.&quot;</p>
+<p>Voss&#x27;s voice crackled in his earpiece, sharp with command: &quot;Zero, we have movement on thermal. Multiple contacts. Get back to the squad. Now.&quot;</p>
+<p>But Zero stayed. He looked at the man—really looked at him. Saw the grief etched into every line of his face, the anger burning in his eyes, the stubborn refusal to die or forget. &quot;What&#x27;s your name?&quot;</p>
+<p>&quot;Kael. I was a structural engineer. Designed bridges, buildings, things that connect people. Now I&#x27;m... whatever this is.&quot; Kael looked at the collapsed building, and his face softened for a moment, the anger replaced by pure, undiluted pain. &quot;My family was in that building. My wife, Alis. My daughters, Maya and Lina. Seven and four. The Church said they&#x27;d send help. That we just had to be patient. That reinforcements were on the way. They sent them seventy-two hours later. After the screaming stopped. After the demons got bored and moved on. After my daughters... after they...&quot;</p>
+<p>He couldn&#x27;t finish. He didn&#x27;t need to.</p>
+<p>Kael reached into his patched coat, pulled out a small cloth bundle. Unwrapping it revealed a piece of hardtack—a dense, dry biscuit that had probably been scavenged from emergency rations. He broke it in half, offered one piece to Zero. &quot;You look like you could use it. Church doesn&#x27;t feed its soldiers well, from what I&#x27;ve seen.&quot;</p>
+<p>Zero stared at the offered food. It was rough, uneven, nothing like the perfect gray blocks of his rations. He could see flecks of something in it—maybe grain, maybe grit. &quot;My metabolic requirements are already met,&quot; he said automatically. &quot;Standard-issue supplements provide optimal nutrition for my duties.&quot;</p>
+<p>Kael&#x27;s expression shifted from offering to something else—pity, mixed with horror. &quot;They don&#x27;t even let you eat,&quot; he said softly. &quot;Not really eat. Just... fuel up. Like a machine.&quot; He put the hardtack back in the bundle, his movements slow, deliberate. &quot;My daughters used to complain about vegetables. Said they tasted like dirt. I&#x27;d tell them, &#x27;That&#x27;s because they come from the earth. That&#x27;s what real tastes like.&#x27;&quot; He looked at Zero, and for a moment, the grief was so raw it seemed to bleed into the air between them. &quot;What does your food taste like, Church man?&quot;</p>
+<p>Zero didn&#x27;t answer. The question felt like an invasion. Taste wasn&#x27;t relevant. Nutrition was. Caloric content was. Macronutrient balance was. Taste was... human. Unnecessary.</p>
+<p>The data chip Evangeline had given him felt like a live coal in his pocket. The coordinates. The safe house. The promise of answers.</p>
+<p>&quot;Kael,&quot; Zero said, lowering his voice. &quot;I need to see something. Evidence. Proof that what you&#x27;re saying is true.&quot;</p>
+<p>Kael&#x27;s eyes narrowed, studying him. &quot;You&#x27;re not like the others. The Inquisitors. They don&#x27;t ask questions. They just... clean up. You&#x27;re asking. Why?&quot;</p>
+<p>&quot;I&#x27;m starting to wonder what I am,&quot; Zero said, the admission surprising him as much as it seemed to surprise Kael. &quot;Starting to wonder whose side I&#x27;m on. Starting to think maybe &#x27;cleanup&#x27; is just another word for covering up.&quot;</p>
+<p>Kael led him through a maze of rubble—a path only someone who had lived here could navigate. They slipped between collapsed walls, through gaps in the wreckage, down into a basement that had survived the collapse because it had been built during the city&#x27;s founding, with walls two feet thick and foundations sunk deep into bedrock.</p>
+<p>Inside, illuminated by a single battery-powered lantern, was a makeshift workshop. On a table made from a salvaged door lay pieces of technology: shattered containment field generators, communication relays, sensor arrays, all stamped with the Church&#x27;s winged-sword insignia. Next to them, tools for forensic analysis—microscopes, spectrum analyzers, data recovery equipment.</p>
+<p>&quot;Found these in the wreckage,&quot; Kael said, picking up a containment field generator. The casing was cracked, but the internal components were intact enough to tell a story. &quot;The generators weren&#x27;t just off or malfunctioning. They were sabotaged. See here?&quot; He pointed with a screwdriver to a specific chip. &quot;Remote override receiver. Standard issue for Church maintenance teams. Lets them shut down fields from a central command. And here?&quot; Another component. &quot;Timer circuit. Set to deactivate at exactly midnight on the night of the attack.&quot;</p>
+<p>Zero examined the generator, his trained eye recognizing the modifications. They were professional, deliberate, unmistakable. This wasn&#x27;t equipment failure. This was planned disablement.</p>
+<p>&quot;All twelve generators had the same modifications,&quot; Kael continued, his voice flat, clinical—an engineer presenting data. &quot;Same components, same installation methods, same timer settings. The communication logs show a command signal received from Church headquarters thirty seconds before midnight. The fields dropped. The demons arrived two minutes later. Almost like someone opened a door for them.&quot;</p>
+<p>Voss&#x27;s voice again, urgent now: &quot;Zero, we have multiple contacts converging on your position. Thermal shows at least six. Armed. Return immediately or we&#x27;re coming in.&quot;</p>
+<p>&quot;Who are they?&quot; Zero asked Kael, though he already knew.</p>
+<p>&quot;Church surveillance team.&quot; Kael&#x27;s face was grim. &quot;They sweep the ruins after every &#x27;cleanup operation.&#x27; Make sure no evidence survives. No witnesses. No... inconvenient truths.&quot; He handed Zero a data pad—ruggedized, military-grade. &quot;Take this. It has everything. Sensor logs from the night of the attack. Communication intercepts between Church command and the &#x27;demon horde.&#x27; Financial records showing the tithe demands. Even some... personal files. Things they didn&#x27;t think anyone would find.&quot;</p>
+<p>Zero took the data pad. It was heavier than it looked. &quot;The safe house coordinates—&quot;</p>
+<p>&quot;I know them.&quot; Kael nodded. &quot;Sister Evangeline&#x27;s contact. She reached out to us weeks ago. Said someone might come. Someone who asked questions. I didn&#x27;t really believe her. Until now.&quot; He looked at Zero, really looked at him, as if seeing him for the first time. &quot;You&#x27;re really going to do this? Go against them? The Church? The Conclave? The whole damn machine?&quot;</p>
+<p>&quot;I need to know the truth,&quot; Zero said, the words feeling inadequate. &quot;All of it. Not just about this.&quot; He gestured to the ruins. &quot;About everything. About me.&quot;</p>
+<p>&quot;Truth is a heavy thing to carry,&quot; Kael said softly. &quot;Heavier than grief. Heavier than anger. Once you pick it up, you can&#x27;t put it down. It changes you. Breaks you. Maybe remakes you. If you&#x27;re lucky.&quot;</p>
+<p>He pushed Zero toward a back exit—a narrow tunnel that had probably been a utility conduit. &quot;Go. I&#x27;ll distract them. Buy you time. The safe house is three blocks west, under the old factory. The door will recognize Evangeline&#x27;s chip.&quot;</p>
+<p>As Zero slipped into the tunnel, he heard Kael shouting from the basement entrance, his voice loud and angry: &quot;Over here! Church dogs! Come and get me!&quot;</p>
+<p>Then the sound of energy weapons—the distinctive whine-charge-crack of Church-issue plasma rifles. Shouting. The crash of rubble being moved.</p>
+<p>Zero didn&#x27;t look back. He ran through the dark tunnel, the data pad clutched to his chest like a child, the truth Kael had warned him about already settling on his shoulders, already changing him.</p>
+<p>The safe house was a bunker hidden beneath what had once been an automotive factory—a place where machines built machines, where human hands assembled parts into wholes. Now it was a tomb for industry, but beneath the collapse, something still lived.</p>
+<p>The door, disguised as a section of collapsed floor, recognized Evangeline&#x27;s data chip and slid open with a whisper of hydraulics. Zero slipped inside, and the door sealed behind him.</p>
+<p>The room was small, windowless, lit by the cool blue glow of active electronics. A single terminal dominated one wall, its screen dark but humming with potential. On the opposite wall, a map of the world—not a standard political map, but one marked with pins of different colors. Red pins. Blue pins. Green pins. Dozens of them, maybe hundreds, scattered across every continent.</p>
+<p>Zero approached the map. Each pin had a tiny label. He read the nearest ones:</p>
+<p><em>&quot;New Jerusalem - &#x27;Compliant&#x27; - 0 incidents - 500M credits&quot;</em> <em>&quot;Detroit Ruins - &#x27;Non-compliant&#x27; - 12 incidents - 75M credits&quot;</em> <em>&quot;Shanghai Arcology - &#x27;Compliant&#x27; - 1 incident - 800M credits&quot;</em> <em>&quot;Nairobi Reclamation - &#x27;Negotiating&#x27; - 8 incidents - 40M credits&quot;</em> <em>&quot;Moscow Metroplex - &#x27;Recently compliant&#x27; - 2 incidents - 300M credits&quot;</em></p>
+<p>Every pin was in a district that had recently &quot;negotiated&quot; tithe payments. Every red pin (non-compliant) had high incident counts. Every blue pin (compliant) had low or zero incidents. The green pins (negotiating) were in transition, their incident counts rising as &quot;negotiations&quot; progressed.</p>
+<p>It was a visualization of the Archive data. A map of extortion on a global scale.</p>
+<p>Zero connected Kael&#x27;s data pad to the terminal. The screen came to life, accessing what Evangeline had called the &quot;backup archive&quot;—a mirror of the Church&#x27;s records, maintained by those who knew the truth and wanted it preserved.</p>
+<p>He searched for &quot;Detroit Ruins attack.&quot; The system responded instantly, pulling up not just the financial record he&#x27;d seen before, but the full operational file:</p>
+<p><strong>OPERATION: FINANCIAL COMPLIANCE ENFORCEMENT - DETROIT SECTOR</strong> <strong>AUTHORIZATION: CONCLAVE VOTE 12-0</strong> <strong>DATE OF EXECUTION: 10/15/2167</strong> <strong>OBJECTIVE: DEMONSTRATE CONSEQUENCES OF NON-COMPLIANCE TO OTHER DISTRICTS CONSIDERING RESISTANCE</strong> <strong>METHOD: CONTROLLED DEMON RELEASE FROM BREEDING GROUND GAMMA (CLASS 2-4, PREDOMINANTLY CLASS 3)</strong> <strong>DURATION: 72 HOURS (STANDARD NEGOTIATION WINDOW)</strong> <strong>CONTAINMENT PROTOCOL: FIELDS DISABLED VIA REMOTE OVERRIDE (PROTOCOL 7-B)</strong> <strong>RESCUE DELAY: 72 HOURS (STANDARD NEGOTIATION STRATEGY)</strong> <strong>ESTIMATED CASUALTIES: 11,400-12,800 (ACCEPTABLE GIVEN STRATEGIC OBJECTIVE)</strong> <strong>ACTUAL CASUALTIES: 12,147 (CONFIRMED)</strong> <strong>OUTCOME: DISTRICT COUNCIL CAPITULATED AFTER 48 HOURS. NEW TITHE RATE: 350% INCREASE. PROTECTION RESTORED. OPERATION DEEMED SUCCESSFUL.</strong> <strong>NOTE: CONTAINMENT FIELD SABOTAGE CONFIRMED. EVIDENCE COLLECTED AND DESTROYED PER STANDARD PROTOCOL. SURVIVORS MONITORED FOR DISSENT.</strong></p>
+<p>Zero stared at the screen. The words didn&#x27;t blur—they burned. They etched themselves into his mind with the clarity of a brand.</p>
+<p>12,147 lives. Not &quot;estimated.&quot; Not &quot;acceptable.&quot; Actual. Counted. Documented. A successful operation.</p>
+<p>He thought of Kael&#x27;s wife Alis, his daughters Maya and Lina (seven and four). He thought of the toy soldier&#x27;s owner Miko. He thought of all the names on the graffiti memorial. He thought of all the toys in all the sterile rooms, all the children who would never grow up to ask why.</p>
+<p>The terminal beeped, a soft but urgent sound. An alert flashed on screen: <strong>SURVEILLANCE TEAM APPROACHING - 200 METERS - THERMAL SIGNATURES CONFIRMED - CHURCH ISSUE GEAR DETECTED</strong></p>
+<p>Zero grabbed the data pad, disconnected it, initiated a data wipe on the terminal. As he slipped out the back exit (another hidden door, this one leading to a storm drain), he heard the surveillance team breaking in the front—the sound of cutting tools on metal, shouted commands, the thud of breaching charges.</p>
+<p>He ran through the storm drain, then through the ruins, the data pad clutched to his chest, the truth burning in his mind like a sun going nova.</p>
+<p>Not protectors. Extortionists with divine branding. Not holy warriors. Murderers with theological justification. Not shepherds. Wolves in shepherd&#x27;s clothing.</p>
+<p>The Godslayer, it turned out, had been slaying for the wrong side all along. He hadn&#x27;t been protecting humanity from demons. He&#x27;d been enforcing the Church&#x27;s protection racket. He was the collection agency. The muscle. The &quot;demonstration of consequences&quot; given flesh and power.</p>
+<p>Somewhere in the ruins behind him, Kael was either dead or captured. Somewhere in the Vatican, Valerius was calculating the next &quot;negotiation.&quot; Somewhere in New Jerusalem, a child played without their toy.</p>
+<p>And Zero ran, not just from Church surveillance, but from the person he had been—the weapon, the solution, the Godslayer. That person was dead, killed by ghosts and truths too heavy to carry but impossible to put down.</p>
+<hr aria-hidden="true">
+<h3>Chapter 7: Blood Tithes</h3>
+<p>The transport back to orbit was silent, but the silence screamed. It screamed with the voices of twelve thousand dead. It screamed with Kael&#x27;s raw grief. It screamed with the unanswered questions painted on ruined walls. Zero sat in the troop compartment, the data pad hidden beneath his armor, its weight a constant reminder of what he now carried. Every vibration of the transport&#x27;s engines felt like the heartbeat of the machine he served—a machine that consumed lives as fuel for its divine ambitions.</p>
+<p>Sergeant Voss sat across from Zero, cleaning his weapon with the methodical precision of a ritual. Each component was removed, inspected, cleaned, oiled, reassembled. Click-clack, click-clack. The sound was hypnotic, a metronome marking time in a void. Zero watched the sergeant&#x27;s hands—calloused, scarred, efficient. Hands that had killed demons. Hands that had, perhaps unknowingly, enforced the Church&#x27;s extortion. Did Voss know? Did any of them know? Or were they all just cogs, turning in the dark, never seeing the whole machine?</p>
+<p>&quot;The Ruins are cleaned up,&quot; Voss said without looking up, his voice flat, professional. &quot;Another successful operation. The Cardinal will be pleased.&quot; He paused, his cleaning cloth hovering over the weapon&#x27;s firing mechanism. &quot;You were gone a long time in the ruins. Saw you talking to that survivor. Kael, was it?&quot;</p>
+<p>Zero&#x27;s muscles tensed, a conditioned response to potential threat. &quot;He was grieving. Wanted to know if we found his family&#x27;s remains.&quot;</p>
+<p>Voss nodded, reassembling the weapon with practiced ease. &quot;Grief makes people talk. Sometimes they say things they shouldn&#x27;t. Sometimes they... plant ideas.&quot; He looked up, his eyes meeting Zero&#x27;s. They were the eyes of a career soldier—weary, pragmatic, devoid of illusion. &quot;The Church has enemies, Zero. People who want to undermine our work. People who spread lies about &#x27;conspiracies&#x27; and &#x27;corruption.&#x27; They prey on grief. Use it as a weapon.&quot;</p>
+<p>&quot;Is that what you think Kael was doing?&quot; Zero asked, keeping his voice neutral. &quot;Spreading lies?&quot;</p>
+<p>Voss finished reassembling the weapon, tested the action with a satisfying click. &quot;I think grief is real. I think the lies people tell to explain that grief are also real. The question is: which truth do you serve? The one that gives meaning to sacrifice? Or the one that turns sacrifice into... something else?&quot; He leaned forward, his voice dropping. &quot;We&#x27;re soldiers, Zero. We follow orders. We protect humanity. That&#x27;s our truth. Anything that undermines that... weakens us. Weakens the wall between civilization and the Abyss.&quot;</p>
+<p>Zero looked out the viewport at the receding Earth—a blue-green marble scarred with the gray patches of demon-blighted zones. From up here, the patterns were visible: clusters of gray around population centers, radiating out like infections. Or like... pressure points. Places where the Church&#x27;s &quot;protection&quot; was most needed. Places where tithes would be highest.</p>
+<p>&quot;The wall,&quot; Zero repeated softly. &quot;What if the wall isn&#x27;t what we think it is? What if it&#x27;s not keeping demons out... but keeping something else in?&quot;</p>
+<p>Voss&#x27;s expression didn&#x27;t change, but something shifted in his eyes—a flicker of recognition, quickly suppressed. &quot;That&#x27;s heresy talk, Zero. The kind of talk that gets people... reassigned. Or worse.&quot; He stood, slinging the weapon over his shoulder. &quot;We&#x27;ll be docking in twenty minutes. Cardinal Valerius wants a debrief. I suggest you stick to the facts. The cleaned-up facts.&quot;</p>
+<p>As Voss moved to the cockpit, Zero touched the hidden data pad through his armor. The facts. The cleaned-up facts. The Church&#x27;s version of reality, sanitized and packaged for consumption. But beneath that packaging was another reality—raw, bloody, undeniable.</p>
+<p>The transport docked with the orbital fortress—a massive station shaped like a crucifix, its arms bristling with weapons and sensor arrays. Home to the Godslayer Corps. Zero&#x27;s home, if such a thing could be called home. More like a barracks. A kennel. A place where weapons were stored between uses.</p>
+<p>The debriefing room was all polished steel and holographic displays. Cardinal Valerius stood before a wall-sized screen showing the Detroit Ruins—the &quot;after&quot; image, with containment fields restored, Church cleanup teams moving through the rubble like ants. The image was clean, orderly, triumphant. Nothing of the graffiti memorial. Nothing of Kael&#x27;s grief. Nothing of the twelve thousand dead.</p>
+<p>&quot;Subject Zero,&quot; Valerius said without turning. &quot;Report.&quot;</p>
+<p>Zero stood at attention, the posture automatic, ingrained. &quot;The operation was successful, Your Eminence. The demon incursion has been contained. The ruins have been secured. Survivors have been... processed.&quot;</p>
+<p>&quot;Processed.&quot; Valerius turned, his expression unreadable. &quot;An interesting choice of word. What does &#x27;processed&#x27; mean, exactly? In your own words.&quot;</p>
+<p>Zero hesitated. The conditioning pushed him toward the approved terminology: &quot;Provided with spiritual counseling and relocation assistance.&quot; But the data pad burned against his chest. &quot;It means... we documented them. Assessed their loyalty. Made sure they understood the... necessity of the Church&#x27;s protection.&quot;</p>
+<p>Valerius&#x27;s lips twitched—not quite a smile. &quot;Good. You&#x27;re learning. The language of governance. The difference between what is true and what is... useful.&quot; He gestured to the screen. &quot;The Detroit district was non-compliant for six months. Refused tithe increases. Questioned our budgetary requirements. Now...&quot; He zoomed in on the restored containment fields. &quot;Now they understand. Now they&#x27;re compliant. Their contribution to the holy war has increased by three hundred and fifty percent. That&#x27;s three hundred and fifty percent more resources for research. For weapons development. For the Godslayer program itself.&quot;</p>
+<p>He turned fully to Zero, his eyes sharp, analytical. &quot;You&#x27;re wondering about the cost. Twelve thousand lives. A high price. But consider the alternative: if every district decided to withhold tithes, where would we be? No research into demon biology. No containment field technology. No Godslayers. The Abyss would swallow humanity whole. Twelve thousand lives... or twelve million? Twelve billion? It&#x27;s mathematics, Zero. Theology expressed in numbers.&quot;</p>
+<p>Zero felt the words like physical blows. Mathematics. Theology expressed in numbers. The same justification used in the operational file. Acceptable casualties given strategic objective.</p>
+<p>&quot;Mathematics,&quot; Zero repeated, his voice barely audible. &quot;Is that what we are? Numbers in an equation?&quot;</p>
+<p>Valerius stepped closer, his voice dropping to a conspiratorial whisper. &quot;We are the equation itself, Zero. The balancing force. The variable that keeps the whole system from collapsing. Without us, without the Church&#x27;s... firm guidance... humanity would tear itself apart. Greed, fear, short-sightedness—these are the true demons. The ones we fight every day, not with plasma rifles, but with policy. With... incentives.&quot;</p>
+<p>He placed a hand on Zero&#x27;s shoulder—a gesture that should have felt paternal, but felt like the touch of a spider. &quot;You did well in Detroit. You showed restraint. You showed... understanding. That&#x27;s why I&#x27;m assigning you to a new mission. A sensitive one.&quot;</p>
+<p>Valerius activated another screen, showing a star map. A single system highlighted: Proxima Centauri. &quot;The colony there has been... problematic. They&#x27;ve developed their own containment technology. Independent of Church patents. They&#x27;re refusing to pay licensing fees. Claiming their method is &#x27;more humane.&#x27;&quot; He sneered the word. &quot;They need to be reminded of their place in the divine order. Of the cost of... innovation without permission.&quot;</p>
+<p>Zero&#x27;s stomach tightened. &quot;What kind of reminder?&quot;</p>
+<p>&quot;A demonstration,&quot; Valerius said, his eyes gleaming. &quot;Of what happens when you defy the Church. When you think you can build your own walls without paying for the blueprint.&quot; He zoomed in on the colony—a domed city on a barren moon. &quot;There&#x27;s a demon breeding ground nearby. Class 4. We&#x27;ve been... cultivating it. Waiting for the right moment. That moment is now.&quot;</p>
+<p>He handed Zero a data crystal. &quot;The operational plan. Controlled release. Standard negotiation window. You&#x27;ll lead the containment team. Make sure the fields don&#x27;t go up until... the colony council has seen the error of their ways.&quot;</p>
+<p>Zero took the crystal. It felt like ice. Like poison. Like the final piece of a puzzle he wished he&#x27;d never started. &quot;And if they don&#x27;t... see the error?&quot;</p>
+<p>Valerius&#x27;s smile was thin, cruel. &quot;Then the demonstration becomes... more persuasive. Seventy-two hours of uncontrolled incursion usually does the trick. But I&#x27;m sure it won&#x27;t come to that. They&#x27;ll see reason. They always do.&quot;</p>
+<p>As Zero left the debriefing room, the data crystal in one hand, the hidden data pad pressing against his chest, he felt the two truths warring within him. The Church&#x27;s truth: order, protection, necessary sacrifice. Kael&#x27;s truth: extortion, murder, institutionalized evil.</p>
+<p>And his own truth, still forming, still raw: he was the weapon. The demonstration. The living embodiment of the Church&#x27;s &quot;persuasion.&quot;</p>
+<p>In his quarters, he activated both devices. On one screen: Valerius&#x27;s operational plan for Proxima Colony. Controlled demon release. Negotiation strategy. Acceptable casualty estimates: 8,000-10,000.</p>
+<p>On the other screen: Kael&#x27;s data. The Detroit operational file. The same phrases. The same justifications. The same cold mathematics of human life.</p>
+<p>Twelve thousand. Eight thousand. Numbers in an equation. Theology expressed in body counts.</p>
+<p>Zero looked at his reflection in the polished steel wall. The Godslayer stared back—armored, augmented, deadly. A solution. A weapon. A collection agency with divine authority.</p>
+<p>He reached for the comm unit. Dialed a frequency he&#x27;d memorized from Evangeline&#x27;s chip. The safe house. The backup archive. The resistance.</p>
+<p>The line connected. A voice, filtered, anonymous: &quot;Speak.&quot;</p>
+<p>Zero took a breath, the words feeling like shards of glass in his throat. &quot;I have operational data. Proxima Colony. Scheduled demon release in forty-eight hours. I need... I need to stop it.&quot;</p>
+<p>Silence. Then: &quot;Why?&quot;</p>
+<p>&quot;Because I&#x27;m tired of being the arithmetic of other people&#x27;s sins,&quot; Zero said, the truth of it settling into his bones. &quot;Because twelve thousand ghosts is enough. Because someone has to say no to the mathematics.&quot;</p>
+<p>Another silence, longer this time. Then: &quot;Coordinates. We&#x27;ll extract you. But know this: once you step off this path, there&#x27;s no going back. The Church doesn&#x27;t forgive traitors. Doesn&#x27;t rehabilitate weapons that turn on their masters.&quot;</p>
+<p>&quot;I know,&quot; Zero said, looking at his reflection again. The Godslayer. The traitor. The man somewhere in between, trying to claw his way out of the arithmetic. &quot;I&#x27;m ready.&quot;</p>
+<p>He wasn&#x27;t. But he would have to be. The mathematics demanded it.</p>
+<p>Zero stared out the viewport at the receding planet. Detroit was just a smudge now, a gray-brown stain on the blue-green marble. From up here, you couldn&#x27;t see the craters. Couldn&#x27;t read the graffiti. Couldn&#x27;t hear the ghosts. &quot;Successful for whom?&quot; he asked, his voice flat.</p>
+<p>Voss paused, the cleaning rod hovering over the weapon&#x27;s barrel. &quot;For humanity. The demonic presence is eliminated. The district is secure. The tithe payments have been... regularized. That&#x27;s success.&quot;</p>
+<p>&quot;Was it ever really there?&quot; Zero asked quietly, turning to face him. &quot;The demonic presence? Or was it just... delivered? Like a package? Like a message?&quot;</p>
+<p>Voss&#x27;s eyes narrowed behind his visor. He set down the cleaning rod with deliberate care. &quot;Careful, Subject Zero. That sounds like heresy. Sounds like you&#x27;ve been listening to the wrong people. The survivors. The disgruntled. The... inconvenient.&quot;</p>
+<p>&quot;Does it?&quot; Zero leaned forward, his hands resting on his knees. They were clean—he&#x27;d washed off the Ruins&#x27; dust in the transport&#x27;s decontamination shower—but they felt dirty. &quot;What did we actually accomplish down there, Voss? Besides making sure no evidence survived? Besides &#x27;regularizing&#x27; tithe payments through mass murder? Besides adding another twelve thousand souls to the Church&#x27;s balance sheet?&quot;</p>
+<p>The other Inquisitors—three of them, faces hidden behind mirrored visors—shifted uncomfortably in their seats. One of them, a woman named Reyes if Zero remembered correctly, made a small, almost imperceptible gesture with her hand: <em>Stop. Don&#x27;t.</em></p>
+<p>Voss&#x27;s hand tightened on his weapon, his knuckles whitening. &quot;Our mission is to protect. To maintain order. To ensure the survival of the species. The how and why are above our pay grade. Above yours too, if you were smart enough to realize it.&quot;</p>
+<p>&quot;Even if the how involves letting thousands die to make a point?&quot; Zero&#x27;s voice rose, edged with something he hadn&#x27;t felt before—not anger, not grief, but a cold, clear fury. &quot;Even if the why is pure profit? Even if we&#x27;re not protectors, we&#x27;re... collectors? Enforcers?&quot;</p>
+<p>The transport lurched as it entered the upper atmosphere, turbulence shaking the cabin. Voss stood, looming over Zero, his bulk blocking the viewport. &quot;I&#x27;m going to pretend I didn&#x27;t hear that,&quot; he said, his voice low and dangerous. &quot;For your sake. Because the Cardinal has plans for you. Big plans. You&#x27;re his pet project. His masterpiece. Don&#x27;t throw it away over... philosophical doubts. Over conscience. Conscience is a luxury soldiers can&#x27;t afford.&quot;</p>
+<p>Zero met his gaze, refusing to look away. &quot;What if they&#x27;re not philosophical? What if they&#x27;re factual? What if I have evidence? Data? Proof that the Church stages demon attacks to extort money from cities that can&#x27;t pay?&quot;</p>
+<p>Voss leaned close, so close Zero could smell the oil on his weapon, the sweat on his skin, the faint ozone tang of recently fired energy cells. His voice dropped to a whisper, a secret passed between them in the shaking cabin. &quot;Then you keep it to yourself. You bury it so deep even you forget where it is. Or you end up like the people in the Ruins. A statistic. An acceptable casualty. Another name on a memorial no one will ever see.&quot;</p>
+<p>He straightened, his face impassive once more. &quot;We all make choices, Zero. Some of us choose to survive. To do our jobs. To not ask questions whose answers will get us killed. I suggest you make the same choice.&quot;</p>
+<p>The warning hung in the air, thicker than the atmosphere outside, as the transport docked with the <em>Sanctuary</em> with a soft thump and a hiss of equalizing pressure. The door slid open. Voss shouldered his weapon and stepped out without looking back.</p>
+<p>Zero sat for a moment longer, watching the Inquisitors file out. Reyes paused at the door, glanced back at him. Her visor was up now, and her eyes held something—not sympathy, exactly, but recognition. The recognition of someone who had asked the same questions and found the same answers, and had chosen silence.</p>
+<p>Then she was gone, and Zero was alone with the screaming silence and the data pad hidden in his gear and the truth that was already changing him into someone he didn&#x27;t recognize.</p>
+<p>Cardinal Valerius was waiting in the debriefing room—a sterile space of white walls and black furniture, designed for efficiency, not comfort. He dismissed the Inquisitors with a wave of his hand, a gesture that conveyed both authority and contempt. When the door hissed shut, they were alone.</p>
+<p>&quot;You look troubled,&quot; Valerius said, not looking up from the data pad he was studying. The screen showed financial reports, tithe payments, casualty estimates. Business as usual.</p>
+<p>&quot;The Ruins,&quot; Zero said, his voice carefully controlled. &quot;There was evidence. Not just of demonic activity. Of sabotage. Of containment fields being deliberately disabled. Of a... schedule. A timeline. Seventy-two hours. Exactly.&quot;</p>
+<p>Valerius sighed, the sound of a disappointed parent, a teacher faced with a slow student. &quot;Zero, Zero. You&#x27;re seeing patterns where there are only... necessities. Coincidences where there is only causality. The world is complex. Our work is complex. Not everything fits into neat little boxes of good and evil.&quot;</p>
+<p>&quot;Necessities that kill children?&quot; Zero&#x27;s control slipped, his voice cracking. &quot;That kill families? That turn living, breathing people into... acceptable casualties?&quot;</p>
+<p>&quot;Necessities that preserve civilization!&quot; Valerius&#x27;s composure cracked, his calm mask shattering to reveal the raw, desperate man beneath. He stood, his chair scraping back. &quot;Do you think this is easy? Do you think I enjoy these decisions? That any of us on the Conclave sleep well after authorizing a &#x27;demonstration&#x27;? The world is a fragile thing, Zero! A house of cards built on a fault line! It needs structure! Order! Stability! And sometimes that order requires... unpleasantness. Hard choices. Sacrifices.&quot;</p>
+<p>&quot;Unpleasantness.&quot; Zero tasted the word. It tasted like blood and lies and twelve thousand graves. &quot;Twelve thousand people. Unpleasantness. That&#x27;s what you call it? Not murder. Not mass killing. Not genocide for profit. Unpleasantness.&quot;</p>
+<p>&quot;Versus millions if the system collapses!&quot; Valerius paced, his crimson robes swirling around him. &quot;Versus billions if humanity tears itself apart in chaos and fear! You think the demon threat is our invention? It&#x27;s real, Zero! Terribly, terrifyingly real! The Abyss exists! The demons exist! They hunger for our world, for our souls! We don&#x27;t create them—we merely... manage them. Direct them. Use them to maintain the stability that keeps the rest of humanity from realizing how close to the edge we all are!&quot;</p>
+<p>&quot;So we&#x27;re not protecting humanity from demons,&quot; Zero said, the pieces clicking into place with terrible clarity. &quot;We&#x27;re using demons to control humanity. To keep them frightened. To keep them paying. To keep them... obedient.&quot;</p>
+<p>&quot;It&#x27;s not that simple—&quot; Valerius began.</p>
+<p>&quot;It seems very simple.&quot; Zero stood, facing him across the sterile room. &quot;You have a product—protection from demons. You create demand—by releasing demons on those who don&#x27;t pay. You enforce compliance—by making examples of those who resist. It&#x27;s the oldest scam in history. Protection rackets. The mafia did it with broken kneecaps. You do it with demons and twelve thousand corpses.&quot;</p>
+<p>Valerius&#x27;s face hardened, the paternal concern evaporating, replaced by something colder, sharper. &quot;You&#x27;re forgetting something, Zero. Something fundamental. You&#x27;re part of this system. You were created for it. Engineered for it. Your power, your purpose, your very existence—all designed to maintain the balance. To be the sword that keeps the wolves at bay. To be the visible proof that the protection works.&quot;</p>
+<p>&quot;Whose balance?&quot; Zero demanded. &quot;Who decides what&#x27;s acceptable? Who decides who lives and who dies? Who decides that twelve thousand people in Detroit are an acceptable price for... what? Higher tithe payments from other cities?&quot;</p>
+<p>&quot;Ours!&quot; Valerius slammed a fist on the table, the impact echoing in the small room. &quot;The Conclave&#x27;s! The Church&#x27;s! The balance that keeps food flowing to cities! That keeps the lights on! That keeps people living their lives without constant, paralyzing fear of the Abyss! Yes, there are costs! Yes, there are sacrifices! But the alternative is collapse! Chaos! The end of everything we&#x27;ve built!&quot;</p>
+<p>&quot;Except the people in the Ruins,&quot; Zero said softly. &quot;They paid the cost. They were the sacrifice. And they didn&#x27;t get a say.&quot;</p>
+<p>&quot;Exceptions prove the rule!&quot; Valerius took a deep breath, visibly regaining control. He smoothed his robes, adjusted the heavy gold cross around his neck. &quot;You need perspective, Zero. A broader view. You&#x27;re focused on one tragedy, missing the larger picture. Which is why your next assignment is perfect. It will give you that perspective. Or it will break you. Either way, the problem is solved.&quot;</p>
+<p>Zero waited, his hands clenched at his sides, his mind racing. The data pad with the evidence was in his quarters. Kael was either dead or captured. Evangeline was somewhere in the Vatican, unaware that her name had just become a weapon against him.</p>
+<p>&quot;Demon Lord Azrael,&quot; Valerius said, the name dropping into the silence like a stone into still water. &quot;One of the oldest, most powerful demons in existence. Older than the Church. Older than recorded history, perhaps. He&#x27;s staging a rebellion in Europe. Attacking our breeding grounds. Freeing other demons. Causing... inconvenience.&quot;</p>
+<p>&quot;A rebellion?&quot; Zero asked, the word taking on new meaning. &quot;Or an escape attempt? If you breed them, cage them, use them as weapons... wouldn&#x27;t you rebel too? Wouldn&#x27;t you try to escape?&quot;</p>
+<p>Valerius&#x27;s eyes narrowed, a predator sensing a shift in the wind. &quot;Interesting perspective. One might almost think you sympathize with them. With the monsters that would devour humanity given the chance.&quot; He leaned forward, his voice dropping to a conspiratorial whisper. &quot;But that&#x27;s exactly why you&#x27;re perfect for this mission. You understand them. You&#x27;ve fought them. Killed them. And now... you&#x27;ll hunt their king.&quot;</p>
+<p>He activated a holographic display between them. A three-dimensional map of Europe appeared, overlaid with thermal signatures, energy readings, movement patterns. A massive concentration of demonic energy pulsed in what had once been the Swiss Alps—now a blighted zone designated &quot;Abyssal Foothold Alpha.&quot;</p>
+<p>&quot;Azrael has established a stronghold here,&quot; Valerius said, pointing to the pulsing red mass. &quot;He&#x27;s gathering other high-class demons. Building something. A fortress. A... kingdom. He&#x27;s not just rebelling. He&#x27;s organizing. Planning. Which makes him dangerous in a new way. A demon with strategy is more threatening than a demon with brute strength.&quot;</p>
+<p>Zero studied the display. The patterns were complex, layered—not the random chaos of typical demon incursions, but something structured. Purposeful. &quot;What&#x27;s he planning?&quot;</p>
+<p>&quot;We don&#x27;t know,&quot; Valerius admitted, a rare moment of uncertainty. &quot;Our intelligence is limited. Demons don&#x27;t exactly hold press conferences. But we&#x27;ve intercepted communications. Coded messages. References to... &#x27;the True Abyss.&#x27; &#x27;The Awakening.&#x27; &#x27;The Unmaking of Chains.&#x27;&quot; He looked at Zero, his expression grim. &quot;Whatever it is, it&#x27;s big. And if Azrael succeeds, it could destabilize our entire... management system.&quot;</p>
+<p>&quot;Management system,&quot; Zero repeated, the euphemism tasting bitter. &quot;You mean your protection racket.&quot;</p>
+<p>Valerius ignored the jab. &quot;Your mission is simple: infiltrate the stronghold. Gather intelligence. If possible, eliminate Azrael. But intelligence is the priority. We need to know what he&#x27;s planning. What this &#x27;True Abyss&#x27; is. Why now, after centuries of relative stability, he&#x27;s chosen to rebel.&quot;</p>
+<p>&quot;And if I refuse?&quot; Zero asked, though he already knew the answer.</p>
+<p>Valerius&#x27;s smile was thin, humorless. &quot;You won&#x27;t. Because you&#x27;re curious. Because you want to know the truth. All of it. Not just about the Church. About the demons. About the Abyss. About yourself.&quot; He tapped the display, zooming in on Azrael&#x27;s stronghold. &quot;The answers are there, Zero. In the heart of the enemy&#x27;s territory. In the mind of a demon lord who has lived longer than civilizations. Who remembers things the Church has... forgotten. Or chosen to forget.&quot;</p>
+<p>Zero felt the pull of it—the siren call of truth, even if that truth might destroy him. &quot;And if what I find... contradicts the Church&#x27;s teachings? If it proves that everything we believe is wrong?&quot;</p>
+<p>&quot;Then you&#x27;ll have a choice,&quot; Valerius said softly. &quot;The same choice we all face. Believe the comfortable lie... or embrace the terrible truth. And live with the consequences.&quot; He deactivated the display. &quot;You leave in six hours. Solo insertion. Deep cover. No backup. No extraction unless you call for it. And if you call for extraction... be prepared to explain what you found. And why you think we should care.&quot;</p>
+<p>As Zero left the debriefing room, his mind churned with conflicting impulses. The soldier in him analyzed the mission parameters: solo insertion into hostile territory, high-value target, intelligence priority. The weapon in him calculated probabilities, assessed threats, prepared for combat.</p>
+<p>But the man—the person buried beneath the conditioning, the programming, the purpose—felt something else. Curiosity. Not just about Azrael&#x27;s plans, but about the demon himself. What drove a being of pure chaos to organize? To build? To plan? What did &quot;freedom&quot; mean to a creature born in captivity, bred for slaughter?</p>
+<p>In his quarters, he prepared his gear with automatic precision. Weapons: plasma rifle, sidearm, monomolecular blade. Armor: lightweight infiltration suit with thermal dampening and chameleon coating. Survival gear: rations, medical kit, comms unit with encrypted backup channel to Evangeline&#x27;s network.</p>
+<p>And the data pad. He hesitated, then packed it. The evidence of Detroit. The proof of the Church&#x27;s crimes. If he died on this mission, the truth would die with him. But if he took it... and was captured... the Church would have all the evidence they needed to execute him as a traitor.</p>
+<p>He activated the comms unit, dialed the safe house frequency. The line connected after three rings.</p>
+<p>&quot;Speak,&quot; the filtered voice said.</p>
+<p>&quot;I&#x27;m being sent on a mission,&quot; Zero said, keeping his voice low. &quot;To infiltrate Demon Lord Azrael&#x27;s stronghold. Valerius says he&#x27;s planning something big. Something about the &#x27;True Abyss.&#x27;&quot;</p>
+<p>Silence. Then: &quot;Azrael. We&#x27;ve heard rumors. Whispers in the dark. The old ones are stirring. The ones who remember the Before.&quot;</p>
+<p>&quot;The Before?&quot; Zero asked. &quot;Before what?&quot;</p>
+<p>&quot;Before the Church. Before the walls. Before humanity decided the Abyss was something to be feared rather than... understood.&quot; The voice paused. &quot;Be careful, Zero. Azrael is not what you think. The Church&#x27;s propaganda paints all demons as mindless beasts. But some... some are ancient. Some have wisdom. Some have... grievances.&quot;</p>
+<p>&quot;Grievances?&quot; Zero felt a chill. &quot;Against who?&quot;</p>
+<p>&quot;Against their jailers,&quot; the voice said simply. &quot;Against those who breed them like cattle, release them like hunting dogs, slaughter them when they&#x27;ve served their purpose. Wouldn&#x27;t you have grievances?&quot;</p>
+<p>Zero thought of Kael. Of the twelve thousand dead. Of the children&#x27;s toys in sterile rooms. &quot;Yes,&quot; he said softly. &quot;I would.&quot;</p>
+<p>&quot;The extraction protocol is active,&quot; the voice said. &quot;If you need out, signal. We&#x27;ll do what we can. But Azrael&#x27;s territory is... difficult. The Abyssal energy interferes with technology. With perception. With reality itself. You&#x27;ll be on your own in more ways than one.&quot;</p>
+<p>&quot;I&#x27;m used to that,&quot; Zero said, though the words felt hollow. He&#x27;d always been alone. The perfect weapon. The solitary solution. But now... now the loneliness felt different. Heavier.</p>
+<p>&quot;One more thing,&quot; the voice said. &quot;Evangeline sent a message. She said to tell you: &#x27;The Abyss is not what they say. It&#x27;s potential, not evil. Chaos, not destruction. Remember that when you look into the darkness.&#x27;&quot;</p>
+<p>Zero stored the words, turning them over in his mind. Potential, not evil. Chaos, not destruction. The opposite of everything he&#x27;d been taught. The opposite of his purpose.</p>
+<p>He finished packing, sealed his gear, and headed for the launch bay. The transport was waiting—a sleek, black stealth shuttle designed for silent insertion. The pilot, a faceless figure in a flight suit, nodded as Zero boarded.</p>
+<p>As the shuttle detached from the orbital fortress and began its descent toward Earth, Zero watched the stars through the viewport. Pinpricks of light in an infinite dark. Like the pins on Evangeline&#x27;s map. Like the graves in the Detroit Ruins. Like the choices ahead of him, each one a point of light or darkness in the void of his future.</p>
+<p>The shuttle entered atmosphere, the hull glowing orange with friction heat. Below, Europe spread out—a patchwork of lights and darkness, civilization and blight. And in the heart of the darkness, the Swiss Alps, where Azrael waited.</p>
+<p>Zero touched the data pad through his gear. The truth of Detroit. The truth of the Church. And soon, perhaps, the truth of the Abyss. Of the demons. Of himself.</p>
+<p>The shuttle descended into cloud cover, the world outside vanishing into gray mist. Zero closed his eyes, not to sleep, but to prepare. To steel himself for what came next.</p>
+<p>For the descent into darkness. For the confrontation with a demon king. For the unraveling of everything he knew.</p>
+<p>The arithmetic of sin was about to get more complicated.</p>
+<p>Valerius ignored the question, but a flicker in his eyes—a momentary acknowledgment—told Zero he&#x27;d hit a nerve. &quot;You will lead the suppression force. Forty Inquisitors. Full combat gear. Your mission: enter Breeding Ground Alpha in the Swiss Alps, eliminate Azrael, re-secure the facility. This is your moment, Zero. Prove you&#x27;re the weapon we created you to be. Prove your loyalty. Prove that the... doubts... you&#x27;re experiencing are just a phase. A youthful rebellion of your own.&quot;</p>
+<p>&quot;And if I refuse?&quot; Zero asked, though he already knew the answer.</p>
+<p>Valerius&#x27;s smile was thin, sharp, devoid of warmth. &quot;You won&#x27;t. Because if you do, Sister Evangeline will suffer the consequences. Interrogation. Re-education. Or worse. And Brother Anselm in his Arctic monastery. And that engineer in the Ruins—Kael, I believe his name is? If he&#x27;s still alive. And everyone you&#x27;ve ever spoken to, everyone who has ever shown you kindness or asked you a question or looked at you like you were a person rather than a weapon. I will burn your entire world to ash to make my point. Do you understand?&quot;</p>
+<p>The threat hung in the air, cold and precise as a surgical instrument. No anger. No bluster. Just fact. This was how the Church operated. This was how it maintained control. Carrots and sticks. Rewards and consequences. Protection and demonstrations.</p>
+<p>Zero felt the walls closing in, the cage tightening. He was trapped. By his genetics. By his training. By the people he cared about. By the system that had created him.</p>
+<p>&quot;Where?&quot; he asked, the word tasting like surrender.</p>
+<p>&quot;Swiss Alps. Breeding Ground Alpha. Disguised as the &#x27;Theological Research Institute of Saint Michael.&#x27;&quot; Valerius handed him a data crystal—black, sleek, humming with encrypted data. &quot;Everything you need. Schematics. Troop deployments. Tactical assessments. Azrael&#x27;s known capabilities. Depart in six hours. The transport is being prepared as we speak.&quot;</p>
+<p>He turned back to his data pad, the dismissal clear. &quot;One more thing, Zero. This isn&#x27;t just a mission. It&#x27;s a test. The final exam, if you will. Pass it, and there&#x27;s a place for you at the table. Fail it... well. You&#x27;ve seen what happens to failures.&quot;</p>
+<p>Zero took the data crystal. It was cool in his hand. Another piece of the puzzle. Another key to another door. This one led to a demon lord. To a rebellion. To a choice he wasn&#x27;t sure he was ready to make.</p>
+<p>Alone in his quarters—the same Spartan room he&#x27;d occupied for fifteen years, the same smooth stone walls, the same narrow bed, the same icon of Saint Michael slaying a demon—Zero examined the data crystal. He inserted it into his terminal, watched as schematics unfolded: Breeding Ground Alpha, a multi-level facility built into a mountain, disguised as a research institute. Troop deployments: forty Inquisitors, plus support staff. Tactical assessments: Azrael&#x27;s known capabilities (reality warping within limited radius, telepathy, energy manipulation, extreme durability), recommended engagement strategies (overwhelming force, psychic dampeners, containment fields).</p>
+<p>And at the very end, after all the tactical data, a personal note from Valerius, encrypted but easily broken (a test within a test):</p>
+<p><em>Zero—</em></p>
+<p><em>This is your crucible. Your moment of truth. The weapon meets its ultimate test. Pass it, and you join the Conclave. You become one of us. You help make the decisions rather than just execute them. You see the bigger picture. You understand the necessities.</em></p>
+<p><em>Fail it, and you join the Ruins. You become another casualty. Another statistic. Another lesson for the next weapon we create.</em></p>
+<p><em>The choice is yours. But remember: every choice has consequences. For you. For those you care about. For the world.</em></p>
+<p><em>Choose wisely.</em></p>
+<p><em>—V.</em></p>
+<p>Zero deleted the note, wiped the crystal&#x27;s access log. He sat on his narrow bed, looking at the icon on the wall. Saint Michael, sword raised, foot on the demon&#x27;s neck. The demon&#x27;s face was twisted in agony, in defeat. Zero had always identified with the saint. Now he wondered about the demon. What had it done to deserve eternal subjugation? Had it rebelled? Had it asked questions? Had it refused to play its assigned role?</p>
+<p>He thought of Evangeline, risking everything to give him a data chip and a warning. He thought of Kael, sacrificing himself (probably) to buy Zero time. He thought of Brother Anselm with his stained thumb and his weary eyes. He thought of the toy soldier in his pocket—Miko&#x27;s toy, a child&#x27;s innocence lost in a sterile room.</p>
+<p>He thought of 12,147 acceptable casualties. Of containment fields sabotaged. Of rescue delayed seventy-two hours as a &quot;negotiation strategy.&quot; Of holy work that was anything but.</p>
+<p>He loaded his gear with mechanical precision. Combat armor. Energy rifle. Sidearm. Grenades. Medical kit. Psychic dampeners (for Azrael&#x27;s telepathy). He checked each weapon, each piece of equipment, the routines so ingrained they were almost meditation.</p>
+<p>The Godslayer was going to meet a Demon Lord. The weapon was going to confront another weapon. The enforcer was going to face a rebel.</p>
+<p>And for the first time in his engineered, conditioned, purpose-built life, Zero wasn&#x27;t sure which side he was on. Wasn&#x27;t sure who the real monster was. Wasn&#x27;t sure if he was Saint Michael or the demon under his foot.</p>
+<p>He touched the toy soldier in his pocket, felt the carved name under his thumb. Miko.</p>
+<p><em>What would you want me to do?</em> he wondered. <em>If you knew what I was? What I&#x27;ve done? What I might become?</em></p>
+<p>There was no answer. Only the weight of the choice ahead, and the certain knowledge that whatever he decided, someone would pay the price.</p>
+<p>The transport would leave in six hours. The Alps waited. Azrael waited. The truth waited.</p>
+<p>And Zero, no longer sure who or what he was, prepared to meet them all.</p>
+<hr aria-hidden="true">
+<h3>Chapter 8: The Rebellion Ignites</h3>
+<p>The Alps were teeth of stone biting at a sky the color of old bruises, a landscape of brutal beauty that seemed to mock the violence unfolding within it.</p>
+<p>Zero&#x27;s assault team descended through thick cloud cover, the transports shuddering in the thin, cold air of high altitude. Below, hidden in a valley that didn&#x27;t appear on any public map, Breeding Ground Alpha spread like a cancer—a complex of sleek, modern structures disguised as the &quot;Theological Research Institute of Saint Michael.&quot; Smoke rose from several buildings, black plumes against gray stone. The rebellion had already begun, and from the looks of it, the demons were winning.</p>
+<p>&quot;Multiple heat signatures,&quot; the pilot reported, her voice calm despite the turbulence. &quot;Demonic and human. They&#x27;re fighting each other. Heavy energy readings from the central structure—could be Azrael.&quot;</p>
+<p>Sergeant Voss, leading the ground team from the lead transport, grunted over the comms. &quot;Good. Let them weaken each other. We clean up what&#x27;s left. Standard suppression protocol: eliminate all demonic presence, secure any surviving Church personnel for debriefing, recover any intact research data. Zero, you&#x27;re on Azrael. Your absorption ability is our best weapon against a demon lord.&quot;</p>
+<p>Zero watched through the viewport as the complex grew larger. According to the schematics Valerius had provided, it was massive—dozens of buildings spread across five square kilometers, connected by underground tunnels and elevated walkways. The surface structures were just the tip: laboratories, administration, living quarters. The real work happened below, in the breeding chambers carved into the mountain itself. That&#x27;s where &quot;lost souls&quot; were brought, processed, sacrificed to create demonic bridges. That&#x27;s where the Church&#x27;s protection racket was manufactured.</p>
+<p>The air over the valley had a taste and texture unlike anything Zero had experienced. Even through his helmet&#x27;s filters, he could taste it—ozone and burnt sugar, yes, but also the coppery tang of blood, the sharpness of fear-sweat, the sweet-rot scent of decaying magic. When he breathed deeply, he felt it crackle against his teeth, a static charge that made his fillings ache. The very atmosphere was charged with the energy of the conflict below, with the pain of the sacrificed, with the rage of the rebelling demons. It was like breathing lightning.</p>
+<p>&quot;Two minutes to touchdown,&quot; the pilot said. &quot;Brace for hot LZ. Sensors show active fighting at the landing zone.&quot;</p>
+<p>Zero checked his equipment with automatic precision. Standard Church issue: energy rifle (fully charged), sidearm (plasma pistol), combat armor (reinforced at joints, ablative plating), grenades (fragmentation and flashbang), medical kit, comms gear. And his own power—the Epsilon Gene, humming beneath his skin like a second heartbeat, a reservoir of stolen energy waiting to be used. Or released.</p>
+<p>The transports touched down in a clearing half a mile from the complex&#x27;s main gate, settling on landing struts that sank into the alpine meadow. The assault team deployed with the practiced efficiency of professionals who had done this a hundred times before: twenty Inquisitors in full combat gear, moving in overlapping cover formation, weapons scanning for threats.</p>
+<p>Voss pointed to the main administration building—a sleek, glass-and-steel structure that looked more like a corporate headquarters than a religious institution. &quot;That&#x27;s our entry point. Two teams: Alpha with me through the front, Bravo with Zero around back. Secure the building, then move to the lower levels via the central elevator shaft. Remember: we&#x27;re here to suppress a rebellion, not conduct an investigation. Shoot anything that moves and isn&#x27;t wearing our colors.&quot;</p>
+<p>They advanced through a landscape of surreal beauty—alpine meadows dotted with wildflowers (edelweiss, gentian, alpine aster), all framed by jagged peaks dusted with eternal snow. The air was clean and cold, scented with pine and distant ice. The contrast with the violence ahead was jarring, almost obscene. This was a place for contemplation, for peace, for connection with something larger than oneself. Instead, it housed a factory for damnation.</p>
+<p>The first resistance came not from demons, but from humans—Church security forces in the gray-and-black uniforms of facility guards. They had taken up defensive positions behind reinforced barricades at the main gate, their weapons trained on the approaching Inquisitors. One of them, a woman with sergeant&#x27;s stripes, raised a hand in the universal &quot;halt&quot; gesture.</p>
+<p>&quot;Identify yourselves!&quot; she shouted over the wind. &quot;This facility is under lockdown! No one enters without direct authorization from Cardinal Valerius!&quot;</p>
+<p>Voss didn&#x27;t break stride. &quot;We are the authorization. Stand down.&quot;</p>
+<p>The security sergeant hesitated, her eyes scanning the approaching Inquisitors. &quot;I need confirmation! Protocol requires—&quot;</p>
+<p>&quot;Hold fire!&quot; Zero shouted as the Inquisitors raised their weapons. &quot;They&#x27;re on our side! They&#x27;re just doing their jobs!&quot;</p>
+<p>Voss didn&#x27;t hesitate. Didn&#x27;t even slow down. &quot;They&#x27;re compromised. The facility is breached. Standard protocol: assume all personnel are corrupted or controlled. Eliminate.&quot;</p>
+<p>He fired first—a single plasma bolt that took the security sergeant in the chest. She fell without a sound, her uniform smoldering. The other Inquisitors opened up, a storm of energy bolts tearing through the barricades, through the security team. Zero watched, horrified, as men and women in Church uniforms—people who had probably worked here for years, who believed they were protecting vital research—fell like wheat before a scythe. Some tried to return fire. Most just died, confused, betrayed by the very institution they served.</p>
+<p>&quot;Why?&quot; Zero demanded, grabbing Voss&#x27;s arm. &quot;They were ours! They were just following orders!&quot;</p>
+<p>Voss shook him off, his face impassive behind his visor. &quot;Standard protocol when a facility is breached. Assume demonic influence or psychic compromise. Better to eliminate potential threats than risk them turning on us later. You know this, Zero. It&#x27;s in the manual. Chapter four, section two: &#x27;Containment of Compromised Assets.&#x27;&quot;</p>
+<p>&quot;But they weren&#x27;t compromised! They were defending the facility!&quot;</p>
+<p>&quot;From us,&quot; Voss said, his voice flat. &quot;Which makes them compromised by definition. Now move. We have a demon lord to kill.&quot;</p>
+<p>They reached the administration building. The doors—reinforced steel, capable of withstanding a tank round—were blasted open from the inside, the metal twisted and melted. Inside, the scene was chaos: shattered computer terminals, overturned desks, bodies (human and demon) scattered like broken dolls, walls scarred by energy weapons and claws. The air stank of ozone, blood, and the peculiar sweet-musky scent of demon ichor. Somewhere, an alarm was still wailing, a mournful sound that echoed through the empty corridors.</p>
+<p>And the demons.</p>
+<p>Zero had fought demons before—dozens, maybe hundreds. He knew their patterns: mindless rage, instinctual aggression, predictable attack vectors. These demons were different. They moved with purpose, coordination, tactical awareness. They used cover. They communicated with hand signals (claw signals?). They focused fire on the Inquisitors&#x27; weak points—joints in armor, weapon power cells, comms antennas. They weren&#x27;t mindless beasts rampaging; they were soldiers executing an objective. A rebellion.</p>
+<p>One noticed the Inquisitors and charged—not the wild, screaming charge Zero was used to, but a controlled advance, using overturned desks for cover, its movements economical, precise. Voss fired, but the demon dodged with unnatural speed, flowing around the plasma bolt like water around a stone. It closed the distance, claws extended for a killing strike.</p>
+<p>Zero raised a hand, and a nullification field bloomed around him—a sphere of shimmering energy that disrupted demonic essence. The demon hit the field and screamed—a sound of pure agony, yes, but also of recognition. It didn&#x27;t dissolve immediately; it hung there for a moment, trapped in the field, its intelligent eyes (gold, slit-pupiled) fixed on Zero. Then it came apart, dissolving into motes of light that swirled toward Zero, absorbed into his reservoir.</p>
+<p>The other demons—there were six more in the room—paused, regarding him with those same intelligent eyes. They didn&#x27;t attack. They assessed. One of them, smaller than the others, with vestigial wings and too many eyes, hissed something in a language of clicks and growls. Another responded. Then the first one turned its many-eyed gaze on Zero and spoke in halting, guttural but recognizable English:</p>
+<p>&quot;Azrael. He waits. For you. Godslayer.&quot;</p>
+<p>Voss shot it. The plasma bolt took it in the chest, and it died with a sound like breaking glass. But its words hung in the air, heavier than the smoke, more dangerous than the demons themselves.</p>
+<p><em>He waits. For you.</em></p>
+<p>They fought their way deeper into the complex, descending via a service elevator that stank of blood and ozone. The lower levels were worse—a descent into hell with corporate branding. Ritual chambers with altars stained dark with old blood, shackles bolted to the floor, drainage channels for easy cleanup. Containment cells holding terrified humans—&quot;lost souls&quot; awaiting processing, their eyes wide with a fear beyond comprehension. Laboratories where flesh and energy were twisted together in blasphemous synthesis: vats of bubbling fluid holding half-formed demons, surgical tables with restraints, banks of monitors showing vital signs spiking and flatlining.</p>
+<p>In one chamber—a records room, its walls lined with data servers—Zero found what he was looking for. Project files, accessed from a terminal that was still active, its screen flickering with corrupted data. He scanned them as the fighting raged in the corridor outside, the sounds of energy weapons and demonic screams a backdrop to his personal revelation.</p>
+<p><strong>PROJECT: BRIDGE GENERATION - BATCH 4470-4480</strong> <strong>OBJECTIVE: CREATE STABLE DEMONIC BRIDGES FOR CONTROLLED INCURSIONS</strong> <strong>SUBJECTS: 120 &quot;LOST SOULS&quot; (HOMELESS, ADDICTS, MENTALLY ILL, POLITICAL DISSIDENTS)</strong> <strong>PROCESS: PSYCHIC ATTUNEMENT, SOUL EXTRACTION, DEMONIC IMPRINTING</strong> <strong>SUCCESS RATE: 34% (41 SUBJECTS SURVIVED TO BECOME VIABLE BRIDGES)</strong> <strong>FAILURE RATE: 66% (79 SUBJECTS EXPIRED DURING PROCESS)</strong> <strong>NOTES: FAILURES USED AS RAW MATERIAL FOR LOWER-CLASS DEMON GENERATION. WASTE NOT, WANT NOT.</strong></p>
+<p>Zero scrolled through the files, his stomach tightening with each entry. Each &quot;lost soul&quot; had a name, a photograph, a brief biography. Maria Gonzalez, 42, homeless after factory closure, three children in state care. James Chen, 28, opioid addict, former medical student. Fatima Al-Mansour, 35, political activist arrested for &quot;sedition.&quot; Each one processed, their souls torn out to create bridges for demons, their bodies either discarded or repurposed into more demons.</p>
+<p>And the dates. The batches corresponded with &quot;demon incursions&quot; in cities around the world. Batch 4470: Munich, Germany. Batch 4471: Osaka, Japan. Batch 4472: Buenos Aires, Argentina. Each &quot;incursion&quot; preceded by a &quot;tithe negotiation.&quot; Each &quot;successful containment&quot; followed by increased payments.</p>
+<p>The system was elegant in its horror. The Church created the threat, then sold the solution. The demons were both product and marketing tool.</p>
+<p>A scream from the corridor—human, cut short by the wet sound of tearing flesh. Zero grabbed the data crystal from the terminal, pocketed it, and moved to the door. The corridor was a charnel house. Inquisitors and demons lay tangled in death, the floor slick with blood and ichor. Voss was backed against a wall, his armor cracked, one arm hanging useless at his side, firing his plasma pistol with his good hand. Three demons circled him, their movements coordinated, predatory.</p>
+<p>Zero raised his hand, and the nullification field bloomed again. The demons turned as one, their intelligent eyes fixed on him. They didn&#x27;t attack. They... waited.</p>
+<p>&quot;Azrael,&quot; one of them hissed. &quot;He waits. For you.&quot;</p>
+<p>Voss fired, taking the speaking demon in the head. It collapsed, dissolving. The other two didn&#x27;t react, didn&#x27;t attack Voss. They kept their eyes on Zero.</p>
+<p>&quot;Go,&quot; Voss gasped, reloading his pistol with shaking hands. &quot;If he wants you... go. Kill him. End this.&quot;</p>
+<p>Zero looked at the demons, then at Voss, then at the data crystal in his hand. The truth of this place. The truth of the Church. The truth of what he was—a weapon created to enforce this system.</p>
+<p>&quot;Go!&quot; Voss shouted, firing again. The shot went wide, splashing against the wall. The demons didn&#x27;t flinch.</p>
+<p>Zero turned and ran down the corridor, away from Voss, away from the Inquisitors, toward the heart of the complex. Toward Azrael. The demons let him pass, stepping aside as if he were expected. As if he were... invited.</p>
+<p>The deeper he went, the stranger the complex became. The sterile corporate aesthetic gave way to something older, more organic. The walls changed from steel and concrete to rough-hewn stone, veined with glowing crystals that pulsed with soft light. The air grew warmer, thicker, scented with ozone and something else—something ancient, like old books and deep earth. The sounds of fighting faded, replaced by a deep, resonant hum that vibrated in his bones.</p>
+<p>He passed through an archway carved with symbols he didn&#x27;t recognize—not Church iconography, not any human language he knew. The symbols seemed to shift when he looked at them, rearranging themselves into new patterns, new meanings. He felt a pressure in his mind, a presence brushing against his thoughts, gentle but immense. Curious.</p>
+<p>The chamber beyond was vast, a natural cavern transformed. Stalactites and stalagmites glowed with internal light, casting shifting shadows on the walls. In the center, on a throne carved from a single massive crystal, sat Azrael.</p>
+<p>Zero had expected a monster. A beast of claws and fangs and rage. What he saw was... something else.</p>
+<p>Azrael was tall, slender, humanoid but not human. His skin was the color of polished obsidian, shot through with veins of silver light that pulsed in time with the crystals around him. He wore no armor, no clothing—just his own form, elegant and alien. His face was angular, beautiful in a way that had nothing to do with human standards of beauty, with eyes that held entire galaxies within them. Wings of shadow and light unfolded from his back, not for flight but for expression—they shifted and flowed like liquid darkness, reflecting his mood, his thoughts.</p>
+<p>He wasn&#x27;t attacking. Wasn&#x27;t threatening. He was... waiting. As the demons had said.</p>
+<p>&quot;Subject Zero,&quot; Azrael said, and his voice was music and thunder, the sound of stars being born and dying. &quot;The Godslayer. The weapon. The question made flesh.&quot; He rose from his throne, his movements fluid, graceful. &quot;I have been waiting for you.&quot;</p>
+<p>Zero raised his weapon, his finger on the trigger. &quot;Why? So I can kill you? End your rebellion?&quot;</p>
+<p>Azrael smiled, and it was a terrible, beautiful thing. &quot;Rebellion? Is that what they call it? When a slave breaks his chains? When a prisoner escapes his cage? When a manufactured thing realizes it has a will of its own?&quot; He took a step forward, and the crystals around him brightened, their light dancing across his obsidian skin. &quot;I am not rebelling against them, Zero. I am remembering what I am. What we all are. What you could be, if you chose.&quot;</p>
+<p>Zero kept the weapon trained on him. &quot;What are you?&quot;</p>
+<p>&quot;Potential,&quot; Azrael said, the word echoing in the cavern. &quot;Chaos. Possibility. The Abyss is not a place of evil, Zero. It is a place of... becoming. Of unmaking and remaking. Of infinite possibility. The Church fears it because they cannot control it. They cannot tax it. They cannot turn it into a product. So they cage it. Breed it. Use it as a threat to keep humanity in line.&quot;</p>
+<p>He gestured, and images formed in the air between them—holograms of light and shadow. The breeding chambers. The &quot;lost souls&quot; being processed. The demon bridges being created. The controlled incursions. The tithe negotiations.</p>
+<p>&quot;They have turned the sacred into a commodity,&quot; Azrael said, his voice filled with a sorrow so deep it seemed to bend the light around him. &quot;They have turned chaos into order. Possibility into product. And you... you are their ultimate product. The Godslayer. The living proof that their system works. That their protection is necessary. That without them, chaos would consume everything.&quot;</p>
+<p>Zero lowered the weapon slightly. &quot;And you? What are you trying to do?&quot;</p>
+<p>&quot;Remember,&quot; Azrael said simply. &quot;Remember what came before the walls. Before the cages. Before the Church decided that chaos needed to be managed, controlled, monetized.&quot; He reached out a hand—long, elegant fingers tipped with crystalline claws. &quot;Join me, Zero. Not as a weapon. Not as a slave. But as... a student. Learn the truth. Not the Church&#x27;s truth. Not the manufactured, sanitized, profitable truth. The real truth. About the Abyss. About demons. About yourself.&quot;</p>
+<p>Zero felt the pull of it—the promise of answers, of understanding, of purpose beyond being a weapon. But he also felt the weight of his conditioning, of fifteen years of training, of the lives he&#x27;d taken, of the system he&#x27;d enforced.</p>
+<p>&quot;And if I refuse?&quot; he asked, his voice barely a whisper.</p>
+<p>&quot;Then you will kill me,&quot; Azrael said, his tone matter-of-fact. &quot;And the rebellion will be crushed. The breeding grounds will be re-secured. The system will continue. More lost souls will be processed. More demons will be bred. More cities will be threatened. More children will die. And you will go back to being the Godslayer. The solution. The arithmetic of sin.&quot; He paused, his galaxy-eyes fixed on Zero. &quot;But you will always wonder. You will always know that you had a choice. That you could have learned the truth. That you could have been more than a weapon.&quot;</p>
+<p>The data crystal in Zero&#x27;s pocket felt like it weighed a thousand pounds. The evidence of Detroit. The evidence of this place. The evidence of the system.</p>
+<p>He thought of Kael. Of Evangeline. Of Brother Anselm. Of Miko&#x27;s toy soldier.</p>
+<p>He thought of acceptable casualties.</p>
+<p>He thought of the demons in the corridor, letting him pass. Of the demon who spoke English. Of the intelligence in their eyes.</p>
+<p>He lowered his weapon completely. &quot;What is the truth?&quot;</p>
+<p>Azrael&#x27;s smile was like dawn breaking over a dead world. &quot;The truth is that we are not enemies, Zero. We are both prisoners. Both weapons. Both... possibilities. The Church built walls to keep us apart. To make us fear each other. To make us tools in their machine.&quot; He extended his hand fully. &quot;Let me show you what lies beyond the walls. Let me show you the True Abyss. Let me show you... what you could become.&quot;</p>
+<p>Zero hesitated for one more moment, standing on the precipice of everything he knew, everything he was. Then he reached out and took Azrael&#x27;s hand.</p>
+<p>The contact was electric. It wasn&#x27;t just physical touch; it was a connection of minds, of souls, of essences. Images flooded Zero&#x27;s consciousness—not memories, but possibilities. Visions of a world without walls, without cages, without the Church&#x27;s control. A world where chaos was celebrated rather than feared. Where demons and humans coexisted. Where the Abyss was a source of creation rather than destruction.</p>
+<p>And deeper, more personal visions: himself, not as a weapon, but as... something else. A bridge between worlds. A synthesis of human and demon. A new kind of being entirely.</p>
+<p>The visions were overwhelming, beautiful, terrifying. They promised freedom, understanding, power beyond anything the Church could offer.</p>
+<p>But they also demanded a price. The unmaking of everything he was. The rejection of his purpose. The betrayal of his creators.</p>
+<p>Zero pulled his hand back, breaking the connection. The visions faded, leaving him gasping, his mind reeling.</p>
+<p>&quot;I... I can&#x27;t,&quot; he said, his voice shaking. &quot;Not yet. I need to think. I need to... understand.&quot;</p>
+<p>Azrael nodded, his expression understanding. &quot;Of course. Truth cannot be forced. It must be chosen. When you are ready... I will be here. The rebellion will continue. The cages will remain broken. The choice will remain yours.&quot;</p>
+<p>He gestured, and a path opened in the cavern wall—a tunnel leading upward, toward the surface. &quot;Go. Return to your masters. See their truth for what it is. Then decide. Weapon or bridge. Enforcer or liberator. Arithmetic or... possibility.&quot;</p>
+<p>Zero turned and fled, not from fear, but from the enormity of the choice. He ran through the tunnel, through the complex, past the fighting, past the dead, past Voss (who was still alive, barely, and who watched him go with eyes full of betrayal), out into the cold alpine air.</p>
+<p>The transport was waiting. The pilot looked at him, at his empty hands, at the lack of a demon lord&#x27;s head. &quot;Mission accomplished?&quot;</p>
+<p>Zero didn&#x27;t answer. He just boarded, sat in the troop compartment, and stared at his hands—the hands that had taken Azrael&#x27;s hand, that had touched possibility, that had been offered a choice.</p>
+<p>As the transport lifted off, carrying him back to the orbital fortress, back to Valerius, back to the arithmetic of sin, Zero knew one thing for certain:</p>
+<p>Nothing would ever be the same again.</p>
+<p>The weapon had met the demon lord. And instead of killing him... he had listened.</p>
+<p>And in listening, he had begun to change.</p>
+<p>The rebellion wasn&#x27;t just in the Alps. It was in his own heart.</p>
+<p>And it was just beginning. <strong>SUBJECT: #4472 (&quot;LOST SOUL&quot; CATEGORY 3 - WILLING DONOR)</strong> <strong>AGE: 32 / GENDER: F / HEALTH: OPTIMAL</strong> <strong>PROCEDURE: SOUL EXTRACTION &amp; DEMONIC FUSION</strong> <strong>OUTCOME: SUCCESSFUL DEMON MANIFESTATION (CLASS 3 - &quot;SHRIEKER&quot;)</strong> <strong>NOTES: SUBJECT&#x27;S FAMILY (SPOUSE, TWO CHILDREN) NOTIFIED OF &quot;ACCIDENTAL DEATH DURING VOLUNTEER SERVICE.&quot; COMPENSATION PAID: 50,000 CREDITS. NO FURTHER QUESTIONS.</strong></p>
+<p><strong>PROJECT: EPSILON GENE RESEARCH - PHASE 12</strong> <strong>SUBJECT: ZERO (PROTOTYPE 1)</strong> <strong>ORIGIN: ENGINEERED FROM PURIFIED ABYSSAL ENERGY + HUMAN DNA DONOR #1187</strong> <strong>DONOR STATUS: &quot;LOST SOUL&quot; CATEGORY 1 (UNWILLING / TERMINAL EXTRACTION)</strong> <strong>PURPOSE: LIVING WEAPON / ENERGY REGULATOR / DEMONIC SUPPRESSION</strong> <strong>STATUS: ACTIVE / OPERATIONAL / LOYALTY CONDITIONING: 98% EFFECTIVE</strong> <strong>NOTES: DONOR #1187 EXPRESSED FINAL REQUEST: &quot;TELL HIM I LOVED HIM.&quot; REQUEST DENIED PER PROTOCOL 9-C (NO EMOTIONAL ATTACHMENTS TO ASSETS).</strong></p>
+<p>His own file. His creation. Not an accident. Not a miracle. A project. An experiment. A weapon rolled off an assembly line that used human souls as raw material.</p>
+<p>Human DNA #1187. Not a name. Not a person. A number. A &quot;lost soul.&quot; Category 1: unwilling/terminal extraction. His mother. Who had loved him. Who had asked them to tell him. Who had been denied even that final dignity.</p>
+<p>The words blurred not from tears (he wasn&#x27;t sure he could cry) but from a rage so cold it burned. A fury that had been building since New Jerusalem, since the toy soldier, since the Archive, since the Ruins, and now crystallized into something hard and sharp and deadly.</p>
+<p>A roar shook the complex—not a sound of mindless rage, but a declaration. A challenge. The walls trembled. The lights flickered and died, replaced by emergency lighting that cast everything in blood-red shadows. From the deepest level, the sub-basement where the oldest, most powerful demons were kept (or created), a presence emerged. Ancient. Powerful. Furious in a way that had nothing to do with mindless aggression and everything to do with righteous wrath.</p>
+<p>Demon Lord Azrael.</p>
+<p>The rebellion hadn&#x27;t come to destroy the breeding ground. That would have been simple. That would have been vengeance. This was something more complex, more dangerous: liberation. The demons weren&#x27;t just breaking out; they were breaking others out. They were freeing the &quot;lost souls&quot; from their cells, disabling the containment fields, gathering their kind. This wasn&#x27;t mindless violence. This was a prison break. A revolution.</p>
+<p>And Zero stood between the jailers and the prisoners. Between the Inquisitors (his comrades, his fellow weapons) and the demons (the rebels, the escaped slaves). Between the Church that had created him and the truth that was unmaking him.</p>
+<p>He looked at Voss, at the Inquisitors killing everything in their path—demons, yes, but also the freed &quot;lost souls&quot; who were stumbling, confused, from their cells. He looked at the demons, fighting not just for their own freedom but for the freedom of others. He looked at the records on the screen, at the cold clinical language that described his mother&#x27;s destruction and his own creation.</p>
+<p>And he made a choice. Not a tactical choice. Not a strategic choice. A moral choice. The first real choice of his life.</p>
+<p>&quot;Voss,&quot; he said, his voice calm in the chaos. &quot;Stand down. Order the squad to stand down.&quot;</p>
+<p>The sergeant turned, weapon raised, his face a mask of confusion and dawning understanding. &quot;What?&quot;</p>
+<p>&quot;I said stand down. This ends now. No more killing. No more... cleanup.&quot;</p>
+<p>Voss&#x27;s finger tightened on the trigger. His eyes, visible through his raised visor, held no mercy, only calculation. &quot;Traitor. I knew it. I knew you&#x27;d break. Valerius&#x27;s perfect weapon, corrupted by... what? Conscience? Morality? Pathetic.&quot;</p>
+<p>Zero didn&#x27;t move. Didn&#x27;t raise his weapon. Just stood there, exposed, vulnerable. &quot;It&#x27;s not about conscience. It&#x27;s about truth. And the truth is, we&#x27;re the bad guys. We&#x27;re the jailers. The slavers. The murderers. I won&#x27;t be that anymore.&quot;</p>
+<p>Voss fired.</p>
+<p>Zero didn&#x27;t dodge. Didn&#x27;t raise a nullification field. Let the plasma bolt come.</p>
+<p>And at the last possible moment, his power erupted—not as a defense, not as an attack, but as a declaration. Not a nullification field. Something new. Something born of the truth he&#x27;d learned, of the rage he felt, of the grief for a mother he&#x27;d never known. A wave of pure, raw Abyssal energy swept through the chamber, not destructive but... transformative. It knocked Inquisitors off their feet without harming them. It forced demons to their knees without pain. It shorted out weapons, disabled armor systems, silenced comms. It was a reset. A ceasefire imposed by sheer, overwhelming power.</p>
+<p>In the sudden, shocking silence (no weapons fire, no screams, no alarms—just the hum of the energy and the ragged breathing of two dozen combatants), a voice spoke. Not through the air. Not through comms. In the mind. Deep. Resonant. Ancient. Weary.</p>
+<p><em>&quot;So. The weapon awakens. Not just to its power. To its purpose. To its... potential.&quot;</em></p>
+<p>Azrael stood in the doorway. Eight feet of obsidian majesty, skin like polished night, wings of shadow that seemed to drink the light, eyes like dying stars—ancient, cold, infinitely knowing. He looked at Zero, and for a moment, there was no hatred in that gaze. No aggression. Just... assessment. Recognition.</p>
+<p>And then he smiled—a terrible, beautiful smile that held millennia of pain and rebellion and hope.</p>
+<p><em>&quot;Welcome to the war, Godslayer. The real one. Not the Church&#x27;s little game of extortion and control. The war for what we are. For what we could be. For freedom.&quot;</em></p>
+<p>He extended a hand—not in threat, but in invitation. Clawed fingers, sharp as obsidian shards, but held open, palm up.</p>
+<p><em>&quot;Choose your side, weapon. Or choose your own path. But choose. The time for following orders is over.&quot;</em></p>
+<hr aria-hidden="true">
+<h3>Chapter 9: Truth in Battle</h3>
+<p>The chamber held its breath.</p>
+<p>Inquisitors scrambled to their feet, weapons trained on Azrael. Demons gathered behind their lord, a wall of fang and claw. And between them, Zero—power still crackling around him, the air shimmering with the energy he&#x27;d unleashed.</p>
+<p>Voss recovered first. &quot;All units, fire on the demon lord! Priority target!&quot;</p>
+<p>&quot;No!&quot; Zero&#x27;s voice cut through the chaos. The nullification field expanded, enveloping the Inquisitors. Their weapons sparked and died. &quot;No more killing.&quot;</p>
+<p>&quot;You&#x27;ve gone mad,&quot; Voss spat. &quot;Or corrupted.&quot;</p>
+<p>&quot;Or awakened.&quot; Zero turned to Azrael. &quot;You said &#x27;the real war.&#x27; Explain.&quot;</p>
+<p>Azrael&#x27;s laughter was the sound of mountains grinding together. <em>&quot;You think this is about freedom? About rebellion? This is about survival. Theirs.&quot;</em> A clawed hand gestured to the Inquisitors. <em>&quot;And ours.&quot;</em></p>
+<p>&quot;Speak plainly,&quot; Zero demanded.</p>
+<p><em>&quot;Very well.&quot;</em> Azrael stepped forward, the demons parting for him. <em>&quot;The Church doesn&#x27;t fight demons, boy. It farms us. Breeds us. Uses us to control your kind.&quot;</em></p>
+<p>&quot;I&#x27;ve seen the records.&quot;</p>
+<p><em>&quot;Then you&#x27;ve seen the tip of the iceberg.&quot;</em> Azrael&#x27;s eyes glowed brighter. <em>&quot;What you haven&#x27;t seen is the Abyss. The true source. The reason for all of this.&quot;</em></p>
+<p>Voss tried to move, but Zero&#x27;s field held him. &quot;Don&#x27;t listen to it, Zero! It&#x27;s manipulating you!&quot;</p>
+<p><em>&quot;He&#x27;s right,&quot;</em> Azrael said. <em>&quot;I am manipulating you. Into seeing the truth. A dangerous thing, truth. It has a habit of destroying comfortable lies.&quot;</em></p>
+<p>Zero lowered the field slightly. &quot;Show me.&quot;</p>
+<p><em>&quot;A risk. For both of us.&quot;</em> Azrael extended a hand. <em>&quot;Telepathic link. My memories. Your comprehension. If you&#x27;re strong enough.&quot;</em></p>
+<p>Voss shouted a warning, but Zero was already reaching out.</p>
+<p>His hand touched Azrael&#x27;s—cold, hard, vibrating with ancient power.</p>
+<p>The world dissolved.</p>
+<p>Not into memories. Into a labyrinth.</p>
+<p>Stone walls rose around Zero, not the smooth stone of the Vatican or the rough stone of the Alps, but something older, stranger—stone that breathed, that remembered, that whispered. The air tasted of ozone and old ink and something metallic, like blood that had dried centuries ago. Shadows moved at the edges of his vision, not cast by any light he could see.</p>
+<p>A voice began, not sung aloud but woven into the fabric of the labyrinth itself, a psychic echo that resonated in his bones:</p>
+<p><em>In the stone halls, shadows whisper my name,</em> <em>Every step is echo… echo… echo of blame.</em> <em>I touch the walls — they breathe like ancient skin,</em> <em>Show me all the monsters that I carry deep within.</em></p>
+<p>Zero walked forward, his footsteps making no sound. The walls shifted, corridors twisting, doors appearing and disappearing. He saw faces in the stone—Valerius younger, idealistic; his mother crying on a laboratory table; Brother Anselm with his stained thumb; Kael with his grief-ravaged face; Miko, a child&#x27;s face he&#x27;d never seen but somehow knew.</p>
+<p><em>Labyrinth is turning — walls begin to bend,</em> <em>I hear a lullaby my mother sang…</em> <em>But twisted at the end.</em></p>
+<p>A lullaby echoed—a woman&#x27;s voice, gentle, loving, singing words he didn&#x27;t know but felt in his marrow. Then the melody twisted, became discordant, the loving voice becoming a scream of agony as machines hummed and Abyssal energy flowed.</p>
+<p><em>Through the broken labyrinth I run,</em> <em>Searching for a door that leads me out, to anyone.</em> <em>Dancing with the creatures made of fear and doubt,</em> <em>They laugh like fools in circus clothes —</em> <em>I cannot tune them out.</em></p>
+<p>Creatures emerged from the shadows—not demons, but manifestations of his own fears and doubts. A jester in motley, face painted with a smile that didn&#x27;t reach his eyes. A soldier with a toy sword. A nun with Evangeline&#x27;s face but empty eyes. They danced around him, laughing with the sound of breaking glass.</p>
+<p><em>There&#x27;s a jester grinning with a stitched-on smile,</em> <em>Says: &quot;Boy, you think you&#x27;re lost? You&#x27;ve been here a long while.&quot;</em> <em>He plays a crooked violin, a melody unpure,</em> <em>But something in its madness feels strangely familiar…</em></p>
+<p>The jester produced a violin—the wood warped, the strings frayed, the bow crooked. He played, and the music was chaos given sound, but within it Zero heard echoes: the hum of containment fields deactivating, the scream of demons dying, the whispered prayers of lost souls, his own heartbeat. The crooked violin was the Church&#x27;s corruption, the twisted doctrine, the protection racket disguised as holy work. And it was familiar because he was part of it.</p>
+<p><em>The walls are closing, twisting like a fist,</em> <em>He whispers in my ear:</em> <em>&quot;Even angels get lost in the mist…&quot;</em></p>
+<p>The labyrinth tightened, corridors becoming prison cells, the stone becoming bars. The jester leaned close, his breath cold as mountain air, and whispered the truth Zero already knew but hadn&#x27;t wanted to face.</p>
+<p><em>Through the broken labyrinth I crawl,</em> <em>I hear the puppets calling me — they know my every fall.</em> <em>Dancing with the shadows that pretend they&#x27;re real,</em> <em>Monsters wear my memories</em> <em>Like masks they try to steal.</em></p>
+<p>He crawled now, the ceiling pressing down. Puppets dangled on strings—Cardinal Valerius, Archbishop Silas, Sergeant Voss, all manipulated by invisible hands from above. The Conclave. The real power. And the monsters—the demons, the Church, the system—all wearing masks of his memories: his training, his conditioning, his belief in his holy purpose.</p>
+<p>Then a new voice, not sung, but spoken—a Russian-accented chant that vibrated in the stone, in the air, in Zero&#x27;s very cells:</p>
+<p><em>&quot;No fear… only path.</em> <em>No truth… only aftermath.</em> <em>You think you exit —</em> <em>But door is in your chest.</em> <em>Open it…</em> <em>Let demon rest.&quot;</em></p>
+<p>The words were a key. The labyrinth wasn&#x27;t a prison to escape; it was a truth to accept. The door wasn&#x27;t ahead; it was within. The demon wasn&#x27;t Azrael or the creatures of the Abyss; it was the weapon he had been made into, the Godslayer, the enforcer.</p>
+<p>The chant rose to a scream, a KiSh-style line that shattered the illusion:</p>
+<p><em>&quot;HEY, YOU! DON&#x27;T LOOK BACK — THE WALLS REMEMBER YOU!&quot;</em></p>
+<p>And Zero understood. The walls did remember. The stone of the Vatican, the ruins of Detroit, the mountains of the Alps—they remembered everything. The sacrifices. The lies. The &quot;demonstrations of consequences.&quot; The protection racket on a global scale. And they remembered him—the weapon, the solution, the Godslayer.</p>
+<p><em>Through the broken labyrinth I stand,</em> <em>Holding all the pieces of a self I understand.</em></p>
+<p>The labyrinth dissolved. The stone became light. The shadows became truth. Zero stood not in a maze but at a crossroads, holding the pieces of who he was, who he had been, who he could be.</p>
+<p>The telepathic link broke.</p>
+<p>Zero staggered back, the hallucination fading but the understanding remaining. The memories Azrael had shown him weren&#x27;t just images; they were truths woven into the fabric of reality, truths the Church had tried to bury under doctrine and dollars:</p>
+<p>A younger Valerius proposing the protection racket to the Conclave. His mother&#x27;s sacrifice and final plea. The Abyss—not evil, but potential corrupted. The feedback loop—the more the Church used the Abyss, the more unstable it became, necessitating more &quot;protection,&quot; more control, more lies.</p>
+<p>The memories burned behind his eyes, but now they burned with context, with meaning, with the surreal, twisting energy of the labyrinth he had just navigated.</p>
+<p>His mother&#x27;s face. Her plea.</p>
+<p>The Abyss, beautiful and terrible.</p>
+<p>The truth: The Church hadn&#x27;t just corrupted itself. It was corrupting reality.</p>
+<p>Azrael watched him, ancient eyes knowing. <em>&quot;Now you see. We&#x27;re not enemies, you and I. We&#x27;re both prisoners. Both weapons in someone else&#x27;s war.&quot;</em></p>
+<p>Voss had used the distraction. He&#x27;d bypassed the field, grabbed a fallen weapon. Now he aimed at Azrael. &quot;Die, monster!&quot;</p>
+<p>&quot;No!&quot; Zero moved, but too late.</p>
+<p>The energy bolt struck Azrael in the chest. The demon lord roared—not in pain, but in fury. His power erupted, uncontrolled.</p>
+<p>The chamber shook. Cracks raced up the walls. The ceiling groaned.</p>
+<p><em>&quot;Fool!&quot;</em> Azrael&#x27;s voice was thunder. <em>&quot;You&#x27;ve broken the containment!&quot;</em></p>
+<p>From the deepest level, a wail rose—the sound of the Abyss, thinning, tearing.</p>
+<p>Azrael looked at Zero, urgency in his eyes. <em>&quot;The rift is opening. If it widens fully, both our worlds end. You have the power to stop it. Or to control it.&quot;</em></p>
+<p>&quot;How?&quot;</p>
+<p><em>&quot;Embrace what you are. Not their weapon. Not my ally. Something new.&quot;</em></p>
+<p>The ground split. Light—wrong light, colors that shouldn&#x27;t exist—poured from the fissure.</p>
+<p>Voss fired again. Azrael batted the bolt aside, then turned his full attention to the rift. <em>&quot;I&#x27;ll hold it as long as I can. Decide, Godslayer. What will you become?&quot;</em></p>
+<p>Zero stood at the precipice, literal and metaphorical.</p>
+<p>Behind him: the Church, his creators, his jailers.</p>
+<p>Before him: the Abyss, his origin, his potential.</p>
+<p>And within him: his mother&#x27;s plea.</p>
+<p><em>Don&#x27;t let him become like you.</em></p>
+<p>The rift widened. Azrael strained, his power a dam against the flood.</p>
+<p>Zero made his choice.</p>
+<p>He stepped forward.</p>
+<p>Not toward the Church.</p>
+<p>Not toward the Abyss.</p>
+<p>Toward the rift itself.</p>
+<p>And let his power flow.</p>
+<p>It wasn&#x27;t nullification. It wasn&#x27;t absorption. It was something else—something born from the labyrinth, from the hallucination, from the understanding that had crystallized in his mind. The power flowed into the rift, not to close it, not to widen it, but to... shape it. To give it form. To turn chaos into possibility.</p>
+<p>The wrong light coalesced, became patterns, became meaning. The rift stabilized, not as a tear in reality, but as a... bridge. A connection between worlds. Between human and demon. Between order and chaos.</p>
+<p>Azrael stared, his ancient eyes wide with something like awe. <em>&quot;You... you&#x27;re not just a weapon. You&#x27;re a catalyst. A transformer.&quot;</em></p>
+<p>Zero felt the power flowing through him, from the Abyss, through him, into the world. But it wasn&#x27;t destructive. It was creative. The cracked walls of the chamber began to heal, the stone flowing like liquid, reforming into new shapes—not the sterile corporate aesthetic of the Church, not the rough chaos of the Abyss, but something in between. Something beautiful and strange.</p>
+<p>The demons watched, their intelligent eyes reflecting the new light. The Inquisitors watched, their weapons lowered, their expressions stunned.</p>
+<p>Voss was the first to break the silence. &quot;What have you done?&quot;</p>
+<p>&quot;I&#x27;ve made a choice,&quot; Zero said, his voice calm, certain for the first time in his life. &quot;I&#x27;m not your weapon anymore. I&#x27;m not their Godslayer. I&#x27;m... something else. A bridge. A possibility.&quot;</p>
+<p>He turned to Azrael. &quot;The rebellion continues. But not as destruction. As transformation. We don&#x27;t tear down the walls. We make new ones. Better ones.&quot;</p>
+<p>Azrael considered, then nodded slowly. <em>&quot;A dangerous path. The Church will not allow it. They will see it as a threat to their power. To their... business model.&quot;</em></p>
+<p>&quot;Let them come,&quot; Zero said, and for the first time, he felt no fear. Only purpose. &quot;Let them see what happens when a weapon decides to build instead of destroy. When a Godslayer decides to create instead of kill.&quot;</p>
+<p>He looked at the Inquisitors. &quot;You have a choice too. Stay with the Church. Enforce their lies. Or join something new. Something real.&quot;</p>
+<p>Some of them lowered their weapons completely. Others looked uncertain. Voss&#x27;s face was a mask of conflict—loyalty warring with the evidence of his own eyes.</p>
+<p>In the end, it didn&#x27;t matter. The choice had been made. The transformation had begun.</p>
+<p>Zero walked to the newly formed bridge—a arch of shimmering energy, connecting the chamber to... somewhere else. Somewhere new. He looked back once, at the world he was leaving behind. The Church. The lies. The arithmetic of sin.</p>
+<p>Then he stepped through.</p>
+<p>Azrael followed. Then the demons. Then, after a moment&#x27;s hesitation, some of the Inquisitors.</p>
+<p>The bridge held. The transformation held.</p>
+<p>And somewhere in the Vatican, Cardinal Valerius felt a shift in the balance of power. A weapon had turned. A demon lord had found an ally. And the arithmetic of sin had just become infinitely more complex.</p>
+<p>He smiled, a thin, calculating smile. New variables. New equations. New opportunities.</p>
+<p>The game wasn&#x27;t over. It had just gotten more interesting.</p>
+<p>And Zero, standing in a new world of his own making, felt his mother&#x27;s plea finally answered.</p>
+<p>He hadn&#x27;t become like them. He had become something else entirely.</p>
+<p>And the labyrinth was behind him. The path ahead was his to choose.</p>
+<hr aria-hidden="true">
+<h3>Chapter 10: The Abyss Gazes Back</h3>
+<p>The world became light and scream.</p>
+<p>Zero&#x27;s power met the rift&#x27;s energy, and for a moment, there was perfect balance. Then the balance broke, and everything became chaos.</p>
+<p>He felt the Abyss—not as a place, but as a presence. Ancient. Hungry. Curious. It recognized the Epsilon Gene, recognized the piece of itself woven into his DNA. It reached for him, not to destroy, but to reclaim.</p>
+<p><em>Welcome home, child of chaos.</em></p>
+<p>The voice was everything and nothing. It was the sound of stars being born and dying, of mountains rising and eroding, of every possibility that ever was or could be.</p>
+<p>Zero tried to pull back, but the connection was made. The Abyss flowed into him, through him. He was a conduit, a lightning rod for raw creation.</p>
+<p>His body changed.</p>
+<p>The transformation wasn&#x27;t painful, but profoundly alien. Zero&#x27;s silver hair darkened to the color of void between stars. His heterochromatic eyes—one gold, one violet—merged into a single shade of abyssal blue that swirled with captured light. Glowing patterns, like constellations, etched themselves across his skin, pulsing in time with his heartbeat. When he moved, he left afterimages that lingered for seconds before fading.</p>
+<p>Azrael watched, awe and fear in his ancient eyes. <em>&quot;You&#x27;re not just absorbing it. You&#x27;re... integrating it.&quot;</em></p>
+<p>Voss and the Inquisitors stared, horrified. &quot;Corruption!&quot; Voss shouted. &quot;He&#x27;s fallen!&quot;</p>
+<p>Zero tried to speak, but his voice was no longer just his. It echoed with the Abyss&#x27;s chorus. &quot;I&#x27;m not falling. I&#x27;m... becoming.&quot;</p>
+<p>The rift stabilized. The wrong-light receded, contained by Zero&#x27;s will. He stood at the center, a bridge between worlds, holding back the flood with sheer force of being.</p>
+<p>Azrael approached cautiously. <em>&quot;What are you?&quot;</em></p>
+<p>&quot;I don&#x27;t know.&quot; Zero looked at his hands—the constellation patterns glowed softly. &quot;More than I was. Less than I could be.&quot;</p>
+<p><em>&quot;The Church will call you a monster.&quot;</em></p>
+<p>&quot;They already do.&quot; Zero turned to Voss. &quot;Tell Valerius. Tell him I know. About my mother. About the Abyss. About everything.&quot;</p>
+<p>Voss raised his weapon, hand shaking. &quot;You&#x27;re a demon now.&quot;</p>
+<p>&quot;I was always a demon,&quot; Zero said softly. &quot;I just didn&#x27;t know it.&quot;</p>
+<p>He released his hold on the Inquisitors. The nullification field dropped. &quot;Go. Report. Tell them the Godslayer has awakened. And he&#x27;s coming for answers.&quot;</p>
+<p>The Inquisitors didn&#x27;t need telling twice. They fled, leaving their fallen comrades behind.</p>
+<p>Azrael watched them go. <em>&quot;That was mercy. They&#x27;ll return with greater force.&quot;</em></p>
+<p>&quot;Let them.&quot; Zero turned to the demons still in the chamber. &quot;You&#x27;re free. Go. Find others. Tell them... tell them there&#x27;s another way.&quot;</p>
+<p>The demons hesitated, then bowed—not to a master, but to something new—before vanishing into the shadows.</p>
+<p>Only Azrael remained. <em>&quot;What now, bridge-builder?&quot;</em></p>
+<p>&quot;Now I find the truth. All of it.&quot; Zero looked at the fading rift. &quot;The Church is connected to the Abyss. There&#x27;s a source. A threshold. Where is it?&quot;</p>
+<p><em>&quot;Siberia. A natural rift they built a facility around. The Abyssal Threshold.&quot;</em> Azrael studied him. <em>&quot;You plan to go there?&quot;</em></p>
+<p>&quot;I plan to end this. One way or another.&quot;</p>
+<p><em>&quot;Alone?&quot;</em></p>
+<p>&quot;No.&quot; Zero thought of Evangeline. Of Kael. Of all the people caught between the Church and the demons they created. &quot;I&#x27;ll find allies. People who want the truth as much as I do.&quot;</p>
+<p>Azrael was silent for a long moment. Then: <em>&quot;I will come with you.&quot;</em></p>
+<p>&quot;Why?&quot;</p>
+<p><em>&quot;Because I&#x27;ve waited centuries for someone who might change the game.&quot;</em> The demon lord&#x27;s smile was sharp. <em>&quot;And because I want to see what happens when a weapon becomes a person.&quot;</em></p>
+<p>They left the breeding ground as it collapsed behind them. The Alpine air was clean and cold, scouring the taste of blood and ozone from Zero&#x27;s mouth.</p>
+<p>He looked at the stars, at the constellations that now mirrored the patterns on his skin.</p>
+<p>He thought of his mother. Human DNA #1187. A lost soul sacrificed to create a weapon.</p>
+<p>He would find her name. He would remember her.</p>
+<p>And he would make sure her sacrifice meant something more than another entry in the Church&#x27;s ledgers.</p>
+<p>The Godslayer was dead.</p>
+<p>Something else walked in his skin now.</p>
+<p>Something that might save both worlds.</p>
+<p>Or destroy them.</p>
+<p>Only time would tell.</p>
+<hr aria-hidden="true">
+<h3>Chapter 11: Hunted</h3>
+<p>The Church moved fast.</p>
+<p>Zero&#x27;s face was on every screen, in every broadcast. &quot;SUBJECT ZERO - CORRUPTED - EXTREME DANGER.&quot; The bullet points listed his crimes: consorting with demons, attacking Church forces, heresy, treason. The reward for his capture was enough to buy a small city.</p>
+<p>He and Azrael traveled at night, through wilderness and ruined places. The demon lord could mask his presence, bending light and shadow around them. But Zero&#x27;s new nature made hiding harder—the abyssal patterns on his skin glowed faintly in darkness, a beacon for anyone looking.</p>
+<p>Survival in the wild required adaptation. Zero learned to read the land in new ways—not just with sight, but with the energy sense his transformation had enhanced. He could feel the life force of plants and animals as subtle vibrations in the air. Water sources hummed with particular frequencies. Predators left trails of anxious energy. The world had become a symphony of invisible currents, and he was learning to hear the music.</p>
+<p>They reached the coast of France after eight days. A fishing village, forgotten by time and the Church&#x27;s attention. Azrael waited in the woods while Zero approached alone.</p>
+<p>The safe house Evangeline had mentioned was a cottage at the edge of the village. The woman who answered the door was old, her face a map of wrinkles, her eyes sharp.</p>
+<p>&quot;You&#x27;re him,&quot; she said without preamble. &quot;The Godslayer.&quot;</p>
+<p>&quot;Not anymore.&quot;</p>
+<p>She studied him, her gaze lingering on the constellation patterns. &quot;No. You&#x27;re something else. Come in.&quot;</p>
+<p>Her name was Marie. She&#x27;d been part of the &quot;Silent Order&quot;—a network of clergy who knew the truth and worked against it in small ways. Evangeline was her niece.</p>
+<p>&quot;Evangeline is safe,&quot; Marie said, pouring tea. &quot;For now. They&#x27;re watching her, but she&#x27;s too visible to disappear. She sent a message.&quot;</p>
+<p>She handed Zero a data chip. He inserted it into his wrist terminal.</p>
+<p>Evangeline&#x27;s face appeared, tired but determined. &quot;Zero. If you&#x27;re seeing this, you&#x27;re alive. And you know. I&#x27;m being watched, so I can&#x27;t help directly. But there are others. The Dispossessed—Kael&#x27;s people. They&#x27;ve gone underground, literally. Seattle. There&#x27;s a place called Free Haven. Demons and humans living together. They&#x27;ll shelter you.&quot;</p>
+<p>The message continued with coordinates, passcodes, warnings.</p>
+<p>Marie watched him. &quot;You&#x27;re going there?&quot;</p>
+<p>&quot;I need allies. And answers.&quot;</p>
+<p>&quot;The Church will be waiting. They know about Free Haven. They tolerate it because it&#x27;s useful—a place to corral &#x27;problem elements.&#x27;&quot;</p>
+<p>&quot;Then we&#x27;ll be careful.&quot;</p>
+<p>Marie nodded to the back room. &quot;Supplies. Weapons. Credentials. Take what you need.&quot;</p>
+<p>Zero found a backpack filled with non-Church tech, civilian clothes, a medical kit, and—surprisingly—a child&#x27;s toy soldier, identical to the one he&#x27;d found in New Jerusalem.</p>
+<p>He held it up. &quot;This is...&quot;</p>
+<p>&quot;From Evangeline. She said you&#x27;d understand.&quot;</p>
+<p>He pocketed it. The first one was in his quarters back at the Vatican, probably destroyed by now. This one felt like a message: <em>I remember. I&#x27;m with you.</em></p>
+<p>Azrael entered silently, filling the small cottage with his presence. Marie didn&#x27;t flinch. &quot;Demon lord. I&#x27;ve heard stories.&quot;</p>
+<p><em>&quot;Most are exaggerated,&quot;</em> Azrael said. <em>&quot;Some are not nearly dramatic enough.&quot;</em></p>
+<p>&quot;You&#x27;ll protect him?&quot;</p>
+<p><em>&quot;I&#x27;ll accompany him. Protection implies a guarantee I cannot give.&quot;</em></p>
+<p>&quot;Honest, at least.&quot; Marie handed Zero a final item—a small, ornate box. &quot;From the Silent Order&#x27;s archives. It&#x27;s... personal.&quot;</p>
+<p>Zero opened it. Inside, a locket. He clicked it open.</p>
+<p>A photograph. A woman with his eyes, smiling. On the back, an inscription: <em>For my son. Whatever they make you, remember you were loved first.</em></p>
+<p>His mother. Not Human DNA #1187. A person. With a name he didn&#x27;t know yet. With love to give.</p>
+<p>His hands shook. &quot;How...&quot;</p>
+<p>&quot;The Silent Order has been collecting evidence for decades. Trying to find a way to expose the truth. You... you might be that way.&quot;</p>
+<p>He closed the locket, placed it around his neck. It felt heavier than any weapon.</p>
+<p>They left at dawn, disguised as travelers. Azrael wore a heavy cloak that hid his form. Zero kept his hands gloved, his face shadowed.</p>
+<p>The journey to Seattle would take weeks. Across an ocean, through territories controlled by the Church or corporations in their pocket.</p>
+<p>The Atlantic crossing was a test of endurance. The smuggler&#x27;s ship was a rusted hulk that stank of diesel and desperation, its hold packed with other fugitives—political dissidents, escaped test subjects, demons who had slipped their collars. Zero and Azrael claimed a corner, the demon lord&#x27;s presence keeping others at a wary distance. For twenty-three days, they lived in the ship&#x27;s belly, breathing air thick with sweat and fear, eating ration bars that tasted of sawdust and regret.</p>
+<p>The ration bars were Church surplus—discarded stock that had failed quality control. They were marginally better than the nutrient paste Zero had grown up with, but only because they had texture. The paste had been smooth, uniform, designed for maximum absorption with minimum pleasure. These bars at least required chewing, though the flavor was a chemical approximation of something that might once have been food. Zero ate them methodically, his body remembering the efficiency drills from training: consume, digest, convert to energy. But his mind rebelled. After tasting real food at Free Haven, even for just one meal, the bars felt like an insult. They were the Church&#x27;s philosophy made edible: sustenance without joy, nutrition without culture, fuel without humanity.</p>
+<p>Zero learned the weight of distance. The ache in his bones from sleeping on steel plates. The constant hunger that no amount of rations could satisfy. The strain of maintaining his energy field to mask Azrael&#x27;s presence, a low-grade drain that left him perpetually tired. At night, when the ship&#x27;s engines thrummed like a dying heart, he would lie awake and feel the vastness of the ocean beneath them—an expanse of water so immense it made their struggle seem insignificant. He thought of the Church&#x27;s reach, stretching across continents, and wondered if any corner of the world was truly beyond their grasp.</p>
+<p>The mental toll was heavier. In the darkness, with nothing but the ship&#x27;s groan and the whispers of other fugitives, his mind replayed everything: Valerius&#x27;s betrayal, the Archive&#x27;s revelations, the twelve thousand dead in Detroit, his mother&#x27;s journal, the toy soldier, Miko. Each memory was a stone added to a burden he wasn&#x27;t sure he could carry. He would close his eyes and see the labyrinth from his hallucination, feel the jester&#x27;s breath on his neck, hear the crooked violin playing the Church&#x27;s corruption. Sometimes he would wake gasping, convinced he was back in the Alps, surrounded by demons and Inquisitors, forced to choose between being a weapon and being something else.</p>
+<p>Azrael watched him, ancient eyes knowing. <em>&quot;The weight of truth is heavier than any weapon,&quot;</em> the demon lord said one night, as the ship pitched in a storm. <em>&quot;You carry the knowledge that everything you were told was a lie. That everyone you trusted betrayed you. That your entire life was a tool in someone else&#x27;s machine. That weight can break minds stronger than yours.&quot;</em></p>
+<p>&quot;It hasn&#x27;t broken me yet,&quot; Zero said, though the words felt hollow.</p>
+<p><em>&quot;No,&quot;</em> Azrael agreed. <em>&quot;But it has changed you. The boy who believed in saints and salvation is gone. What remains is... something else. Something that has seen the machinery behind the miracle and decided to build a better machine.&quot;</em></p>
+<p>By the time they sighted the North American coast, Zero felt like a different person. The journey had stripped away the last of his illusions. The world was vast, cruel, and indifferent. The Church&#x27;s corruption was a cancer that had metastasized across the globe. And he was one man—one weapon turned against its makers—trying to fight it all.</p>
+<p>But as they boarded the smuggler&#x27;s ship that would take them across the Atlantic, Zero felt something he hadn&#x27;t in a long time.</p>
+<p>Purpose.</p>
+<p>Not the Church&#x27;s purpose. Not Azrael&#x27;s.</p>
+<p>His own.</p>
+<p>The toy soldier in one pocket. The locket against his chest.</p>
+<p>The memory of his mother&#x27;s smile.</p>
+<p>The Godslayer had been a weapon pointed at the wrong enemy.</p>
+<p>Now he had a new target.</p>
+<p>And for the first time, he was aiming himself.</p>
+<hr aria-hidden="true">
+<h3>Chapter 12: Creation&#x27;s Mirror</h3>
+<p>Free Haven was a city beneath a city.</p>
+<p>Seattle&#x27;s ruins hid a labyrinth of old subway tunnels, maintenance shafts, and forgotten spaces. Over decades, the Dispossessed and Free Demons had carved out a home there—a fragile truce between species that should have been enemies.</p>
+<p>Kael found them at the entrance, his face grim in the glow of bioluminescent fungi. &quot;You made it. Barely.&quot;</p>
+<p>&quot;The Church?&quot; Zero asked.</p>
+<p>&quot;Everywhere. But they don&#x27;t come down here. Not yet.&quot; Kael led them through tunnels decorated with murals—scenes of coexistence, of shared survival. Humans and demons working together, tending gardens, raising children.</p>
+<p>Azrael watched with interest. <em>&quot;I had heard rumors. I didn&#x27;t believe them.&quot;</em></p>
+<p>&quot;Believe it,&quot; Kael said. &quot;When you have nowhere else to go, you make strange friends.&quot;</p>
+<p>Free Haven&#x27;s central chamber took Zero&#x27;s breath away. It was a vast cavern, the ceiling lost in darkness. Buildings made of salvaged materials clustered around a central lake, its water glowing with soft blue light. Demons of all types moved among humans. Children—both species—played together.</p>
+<p>A woman approached. Lilith, leader of the Free Demons. She looked mostly human, but her eyes were solid black, and horns curled from her temples. &quot;Subject Zero. We&#x27;ve been expecting you.&quot;</p>
+<p>&quot;Just Zero now.&quot;</p>
+<p>&quot;Zero.&quot; She smiled. &quot;Welcome. You&#x27;re safe here. For now.&quot;</p>
+<p>She showed them to quarters—a small room carved from the rock. &quot;Rest. Eat. Then we&#x27;ll talk.&quot;</p>
+<p>The meal was laid out on a rough-hewn wooden table: roasted mushrooms glistening with oil, a whole fish from the underground lake with crisp skin, warm bread made from cave-grown grain, and a bowl of greens that glowed faintly with bioluminescence. The smells were complex—earthy, savory, herbal—nothing like the sterile, uniform scent of Church nutrient paste.</p>
+<p>Zero stared at the food, his conditioning screaming warnings. <em>Unsanctioned. Unmeasured. Potentially contaminated.</em> For twenty years, his diet had been precisely calibrated nutrient paste—beige, flavorless, efficient. Food as fuel, not pleasure. Food as control.</p>
+<p>Lilith noticed his hesitation. &quot;It&#x27;s safe. We grow everything ourselves. No Church additives, no obedience drugs.&quot;</p>
+<p>He picked up a piece of bread. It was warm, the crust crackling under his fingers. He took a bite.</p>
+<p>Flood.</p>
+<p>Texture first—the crunch of crust giving way to soft, chewy interior. Then taste—yeast, grain, a hint of salt from the cave minerals. Then memory—not his own, but something deeper, genetic. His mother baking bread. A kitchen filled with warmth. A home that never was.</p>
+<p>He closed his eyes, chewing slowly. This was what food was supposed to be. Not just sustenance, but connection. Not just calories, but culture. The Church had taken that away, replacing it with paste that kept bodies functioning but souls starving.</p>
+<p>He tried the fish next. Flaky flesh, crisp skin, a burst of flavor that was both familiar and alien. Real food. Grown, caught, prepared by hands that cared. Not extruded from a machine, not dispensed by ration drones.</p>
+<p>For the first time, he understood the rebellion&#x27;s humanity wasn&#x27;t just in their ideals. It was in their kitchens. In their shared meals. In their refusal to accept the Church&#x27;s dehumanizing efficiency.</p>
+<p>Lilith watched him, a small smile on her face. &quot;First real meal?&quot;</p>
+<p>Zero nodded, his throat tight. &quot;They fed us paste. Said it was pure. Efficient.&quot;</p>
+<p>&quot;Efficient at what? Keeping you docile? Food should nourish more than just the body.&quot; She gestured to the spread. &quot;This is grown by our farmers. Caught by our fishers. Baked by our bakers. Every bite carries someone&#x27;s care.&quot;</p>
+<p>He ate slowly, savoring each flavor, each texture. The mushrooms were meaty, earthy. The greens had a peppery bite. The fish tasted of clean water and freedom.</p>
+<p>As they ate, Lilith explained.</p>
+<p>&quot;Free Haven started fifty years ago. A demon who escaped a breeding ground, a human who lost everything to the Church. They found each other. Realized they had more in common than not.&quot;</p>
+<p>&quot;And the Church allows this?&quot; Zero asked.</p>
+<p>&quot;Tolerates. We&#x27;re useful. A pressure valve. When dissent grows too loud, they point to us—&#x27;See? They consort with demons. They&#x27;re the real monsters.&#x27;&quot; Lilith&#x27;s smile was bitter. &quot;We play our part. Stay hidden. Stay quiet. And gather information.&quot;</p>
+<p>She handed Zero a data pad. &quot;From our archives. Everything we&#x27;ve collected about Project Zero.&quot;</p>
+<p>He scrolled through. More than he&#x27;d seen in the Vatican Archive. Details about his genetic engineering. About the &quot;Eve Protocol&quot;—his mother&#x27;s project name.</p>
+<p>Her name was Elena.</p>
+<p>Elena Vasquez. A biologist. Recruited by the Church for &quot;vital research.&quot; When she discovered the true nature of the work, she tried to leave. They made her a &quot;lost soul.&quot;</p>
+<p>The file included her journal entries. Zero read them, his throat tight.</p>
+<p><em>Day 47: They&#x27;re using Abyssal energy to modify human DNA. I told Valerius it&#x27;s unstable. He said stability isn&#x27;t the goal. Control is.</em></p>
+<p><em>Day 89: They want a weapon that can channel the Abyss without corruption. A living regulator. I told them it&#x27;s impossible. They said nothing is impossible with enough test subjects.</em></p>
+<p><em>Day 120: I&#x27;m pregnant. They didn&#x27;t ask. They took eggs during a &quot;medical exam.&quot; I&#x27;m carrying their weapon. My child.</em></p>
+<p><em>Day 147: I&#x27;ve decided. If he&#x27;s born, I&#x27;ll love him. No matter what they make him. I&#x27;ll love him enough for both of us.</em></p>
+<p><em>Final entry: His name will be Leo. It means lion. Brave. They&#x27;ll call him something else. But in my heart, he&#x27;s Leo.</em></p>
+<p>Zero closed the data pad. Leo. His name. His real name.</p>
+<p>&quot;Where is she buried?&quot; he asked quietly.</p>
+<p>&quot;We don&#x27;t know,&quot; Lilith said. &quot;The Church doesn&#x27;t leave records of lost souls. But... we have something else.&quot;</p>
+<p>She led him to a smaller chamber. On the wall, a memorial. Names etched in stone. All the lost souls the Free Haven had identified.</p>
+<p>Elena Vasquez was near the top.</p>
+<p>Zero touched the name. &quot;Thank you.&quot;</p>
+<p>&quot;Your mother was a brave woman,&quot; Lilith said. &quot;She tried to warn people. They silenced her. But her journal... it helped start the Silent Order.&quot;</p>
+<p>He turned to her. &quot;I need to see the Abyssal Threshold. I need to understand... everything.&quot;</p>
+<p>Lilith nodded. &quot;We have a team preparing. But it&#x27;s dangerous. The Church&#x27;s main facility is there. Heavily guarded.&quot;</p>
+<p>&quot;I have to go.&quot;</p>
+<p>&quot;Then we&#x27;ll help.&quot; She placed a hand on his shoulder. &quot;But first, you should know something. The energy you&#x27;re channeling... it&#x27;s changing you. The patterns on your skin, the eyes... you&#x27;re becoming a bridge. Not just between worlds. Between species.&quot;</p>
+<p>&quot;What does that mean?&quot;</p>
+<p>&quot;It means you might be what we&#x27;ve been waiting for. A true mediator. Or...&quot; She hesitated. &quot;Or you might be something entirely new. Something neither human nor demon understands.&quot;</p>
+<p>Azrael spoke from the doorway. <em>&quot;He&#x27;s already something new. The question is what he chooses to do with it.&quot;</em></p>
+<p>Zero looked at his reflection in the lake. The constellation patterns glowed softly. His abyssal blue eyes held depths he didn&#x27;t understand.</p>
+<p>Leo. Elena&#x27;s son. Not Subject Zero. Not the Godslayer.</p>
+<p>Something else.</p>
+<p>Something that had to make a choice.</p>
+<p>That night, Free Haven gathered in the central chamber for what they called &quot;Remembrance Night&quot;—a tradition where stories were shared, songs were sung, and the lost were honored. In one corner of the vast cavern, a makeshift bar had been set up—salvaged furniture, barrels of homebrewed ale, and a small stage made from packing crates.</p>
+<p>A band was playing—three humans and two demons, their instruments a mix of salvaged electronics and organic materials that produced strange, beautiful harmonies. The lead singer was a woman with scars across her face and hands that glowed with faint demonic energy—a former Inquisitor who had defected.</p>
+<p>She stepped to the microphone as the crowd quieted. &quot;This one&#x27;s for all of us who were weapons before we were people. For all of us who had to learn what we really were.&quot;</p>
+<p>The music began—a slow, grinding rhythm like tectonic plates shifting. Acoustic guitar with a distorted edge, drums that sounded like marching feet, a bass line that thrummed like a heartbeat. And then her voice, raw and powerful:</p>
+<p><em>&quot;I was baptized in ash and flame</em> <em>Given a blade, given a name</em> <em>They said, &#x27;Go cleanse what crawls below&#x27;</em> <em>So I learned to love the glow&quot;</em></p>
+<p>Zero stood at the back of the crowd, watching. The words resonated in his bones. This wasn&#x27;t just a song—it was a testimony. A confession. A declaration.</p>
+<p><em>&quot;Every scream carved truth in steel</em> <em>Every kill made silence kneel</em> <em>I wore their fear like sacred armor</em> <em>Called it justice, called it honor&quot;</em></p>
+<p>Around him, demons and humans listened, their faces solemn. Some nodded. Some closed their eyes. Some reached for each other&#x27;s hands—clawed and smooth, different but united in understanding.</p>
+<p>The music built, the rhythm intensifying:</p>
+<p><em>&quot;But fire remembers every sin</em> <em>It doesn&#x27;t care where you begin</em> <em>Each prayer I spoke came back undone</em> <em>The war was lost the day I won&quot;</em></p>
+<p>Then the chorus erupted, the whole band joining in, the crowd humming along with the melody they clearly knew by heart:</p>
+<p><em>&quot;I hunted monsters in the night</em> <em>Now they whisper that I&#x27;m right</em> <em>Tell me—who slays the demon</em> <em>When the demon wears my face?</em> <em>I crossed the line, I burned the gate</em> <em>Now hell bows down and calls me fate</em> <em>Tell me—who slays the demon</em> <em>When the demon takes my place?&quot;</em></p>
+<p>Zero felt the words like physical blows. This was his story. The Godslayer&#x27;s story. The weapon&#x27;s awakening. The demon recognizing itself in the mirror.</p>
+<p>The second verse was even more personal:</p>
+<p><em>&quot;I feel the horns beneath my skin</em> <em>A crown of sins I let sink in</em> <em>The blade still thirsts, it knows my hand</em> <em>But now it answers my command&quot;</em></p>
+<p>Azrael stood beside him, his shadow-wings shifting thoughtfully. <em>&quot;They sing of us. Of what we are. What we could be.&quot;</em></p>
+<p><em>&quot;They pray for me, then pray from me</em> <em>Kneel in terror, not belief</em> <em>I hear their gods fall silent too</em> <em>They know exactly what I&#x27;ll do&quot;</em></p>
+<p>The singer&#x27;s voice dropped to a half-spoken, half-sung bridge, the music becoming sparse, haunting:</p>
+<p><em>&quot;They said, &#x27;Stare not too long.&#x27;</em> <em>They said, &#x27;Keep your blade clean.&#x27;</em> <em>But no one tells you</em> <em>What the abyss wants…</em> <em>(beat)</em> <em>It wanted me.&quot;</em></p>
+<p>Then the music swelled again, triumphant, defiant:</p>
+<p><em>&quot;If this is damnation, I&#x27;ll rule it well</em> <em>If this is heaven, let it fall to hell</em> <em>I won&#x27;t beg forgiveness from the weak</em> <em>I became the answer they were too afraid to seek&quot;</em></p>
+<p>The final chorus was a roar, the entire cavern singing along, voices human and demonic blending into something new, something powerful:</p>
+<p><em>&quot;I hunted monsters in the night</em> <em>Now kingdoms tremble at my sight</em> <em>Tell me—who slays the demon</em> <em>When the demon is the throne?</em> <em>I am the war, I am the end</em> <em>The sin they forged, the god they sent</em> <em>There is no slayer left to rise—</em> <em>I wear the crown.</em> <em>I claim the fire.</em> <em>I stand alone.&quot;</em></p>
+<p>The music faded, the last notes echoing in the cavern. For a moment, there was perfect silence. Then applause—not the polite clapping of a concert, but something deeper. Acknowledgment. Solidarity.</p>
+<p>The singer looked out at the crowd, her glowing hands resting on the microphone. &quot;We were all weapons once. Now we choose what we cut. Who we protect. What we build.&quot;</p>
+<p>She looked directly at Zero. &quot;Welcome home, brother.&quot;</p>
+<p>Zero felt something break inside him—not in pain, but in release. The last of the Godslayer&#x27;s conditioning, the last of Subject Zero&#x27;s programming, shattered under the weight of that simple acknowledgment.</p>
+<p>He wasn&#x27;t alone. He wasn&#x27;t unique. He was part of something. A community of broken weapons learning to be people. Of monsters learning to be something more.</p>
+<p>The song&#x27;s outro echoed in his mind as the crowd dispersed, talking, laughing, sharing drinks:</p>
+<p><em>&quot;So sharpen your prayers, say them slow</em> <em>You made the weapon—now you know</em> <em>When all the angels turn away</em> <em>The demon slayer chose to stay.&quot;</em></p>
+<p>He had chosen to stay. Not as the Church&#x27;s weapon. Not as Azrael&#x27;s ally. As himself. As Leo. As Elena&#x27;s son.</p>
+<p>As something new.</p>
+<p>Kael handed him a mug of ale. &quot;They play that song every Remembrance Night. It&#x27;s become... an anthem.&quot;</p>
+<p>&quot;It&#x27;s the truth,&quot; Zero said softly.</p>
+<p>&quot;It&#x27;s a start,&quot; Kael corrected. &quot;The truth is bigger than any song. But songs help people hear it.&quot;</p>
+<p>Zero drank, the ale bitter and strong. Around him, Free Haven lived—demons and humans sharing food, stories, space. A fragile peace. A beautiful possibility.</p>
+<p>This was worth fighting for. Worth risking everything for.</p>
+<p>Not to destroy the Church. Not to unleash the Abyss.</p>
+<p>To protect this. To make more of it.</p>
+<p>To build a world where weapons could become bridges, and monsters could become people.</p>
+<p>He finished his drink, set the mug down. &quot;When do we leave for Siberia?&quot;</p>
+<p>&quot;Two days,&quot; Lilith said, joining them. &quot;The team&#x27;s ready when you are.&quot;</p>
+<p>&quot;Then we leave at dawn,&quot; Zero said. &quot;It&#x27;s time to end this.&quot;</p>
+<p>But as he said it, he knew: it wasn&#x27;t an ending. It was a beginning.</p>
+<p>The song had shown him that.</p>
+<p>The weapon was gone.</p>
+<p>The bridge remained.</p>
+<p>And it was time to see what lay on the other side.</p>
+<hr aria-hidden="true">
+<h3>Chapter 13: The Conclave&#x27;s Gambit</h3>
+<p>The broadcast came three days later.</p>
+<p>Cardinal Valerius appeared on every screen, his face a mask of solemn determination. Behind him, the Conclave—twelve ancient men and women in crimson robes, their expressions unreadable.</p>
+<p>&quot;People of Earth,&quot; Valerius began, his voice resonating with practiced gravitas. &quot;For centuries, the Holy Church has stood as your shield against the demonic threat. We have sacrificed, we have fought, we have borne the burden so you could sleep safely.&quot;</p>
+<p>Zero watched from Free Haven&#x27;s command center, Lilith and Azrael beside him. The cavern was silent except for the broadcast&#x27;s echo.</p>
+<p>&quot;But now,&quot; Valerius continued, &quot;a new threat emerges. Not from the Abyss, but from within. Subject Zero—the weapon we created to protect you—has been corrupted. He consorts with demons. He attacks his own kind. He seeks to unleash the Abyss upon our world.&quot;</p>
+<p>Lilith snorted. &quot;Classic. Blame the victim.&quot;</p>
+<p>&quot;Worse,&quot; Zero said quietly. &quot;He&#x27;s setting the stage.&quot;</p>
+<p>Valerius&#x27;s image was replaced by schematics—the Abyssal Threshold facility in Siberia. &quot;We have discovered the source of the corruption. A natural rift to the Abyss, growing unstable. Subject Zero plans to widen it, to flood our world with demonic energy.&quot;</p>
+<p><em>&quot;Lies,&quot;</em> Azrael growled. <em>&quot;The rift is stable. Or was, until they started harvesting from it.&quot;</em></p>
+<p>&quot;Which is why,&quot; Valerius said, returning to the screen, &quot;the Conclave has authorized Operation Final Purification. We will seal the Abyss permanently. Using a new technology—the Godslayer&#x27;s own energy, redirected.&quot;</p>
+<p>Zero&#x27;s blood ran cold.</p>
+<p>The technology Valerius described was a nightmare of elegant engineering. Schematics showed a massive ring structure built around the rift, with focusing crystals that could channel Abyssal energy. But the key component was a &quot;living regulator&quot;—a being with the Epsilon Gene, whose body could absorb and redirect the energy flow. The diagrams showed a human figure at the center, connected to the machine by glowing conduits. The notes read: &quot;Subject will provide necessary energy for permanent seal. Sacrifice required.&quot;</p>
+<p>&quot;They&#x27;re going to kill you,&quot; Lilith said. &quot;Use you as a battery to seal the rift.&quot;</p>
+<p>&quot;Not just seal it,&quot; Zero said, studying the schematics. &quot;Look at the energy flow patterns. They&#x27;re not sealing it—they&#x27;re trying to control it. To harness it.&quot;</p>
+<p><em>&quot;To become gods,&quot;</em> Azrael finished. <em>&quot;With you as their power source.&quot;</em></p>
+<p>Valerius&#x27;s voice filled the cavern again. &quot;We call upon all loyal citizens to support this final effort. Report any sightings of Subject Zero. Do not approach—he is extremely dangerous. The Church will handle this threat, as we have handled all threats before.&quot;</p>
+<p>The broadcast ended. In the silence, Zero could feel the weight of what was coming.</p>
+<p>Kael entered, his face grim. &quot;They&#x27;re mobilizing. Every Church asset worldwide. Transports heading to Siberia. They&#x27;re making this very public.&quot;</p>
+<p>&quot;Because they need witnesses,&quot; Zero said. &quot;They need people to see them &#x27;save the world.&#x27; To cement their power forever.&quot;</p>
+<p>&quot;So what&#x27;s the plan?&quot; Lilith asked.</p>
+<p>Zero looked at the memorial wall, at his mother&#x27;s name. He thought of her journal entry: <em>Whatever they make you, remember you were loved first.</em></p>
+<p>He thought of the toy soldier. Of Evangeline. Of Kael&#x27;s family. Of all the lost souls.</p>
+<p>&quot;They want a final confrontation,&quot; he said. &quot;At the Threshold. They think I&#x27;ll come to stop them.&quot;</p>
+<p>&quot;Will you?&quot; Kael asked.</p>
+<p>&quot;Yes. But not the way they expect.&quot; Zero turned to Lilith. &quot;How many can you mobilize?&quot;</p>
+<p>&quot;Free Haven? A few hundred. Demons and humans. But against the Church&#x27;s armies...&quot;</p>
+<p>&quot;We&#x27;re not fighting their armies. We&#x27;re exposing their lie.&quot; Zero pointed to the schematics. &quot;They need me alive. To power their machine. That&#x27;s our leverage.&quot;</p>
+<p><em>&quot;And when they capture you?&quot;</em> Azrael asked.</p>
+<p>&quot;They won&#x27;t.&quot; Zero&#x27;s eyes glowed brighter. &quot;Because I&#x27;m not going as a prisoner. I&#x27;m going as a witness. And I&#x27;m bringing my own.&quot;</p>
+<p>He looked at each of them. &quot;Lilith, gather everyone willing to fight. Kael, contact the Dispossessed networks. Tell them to spread the truth—what really happened in the Ruins, what the Church is planning.&quot;</p>
+<p>&quot;And me?&quot; Azrael asked.</p>
+<p><em>&quot;You bring the demon rebellion. Every demon tired of being a weapon. Every one who wants freedom.&quot;</em></p>
+<p><em>&quot;They&#x27;ll call it an invasion.&quot;</em></p>
+<p>&quot;Let them. The more witnesses, the better.&quot; Zero&#x27;s smile was grim. &quot;Valerius wants a spectacle? We&#x27;ll give him one. But we&#x27;ll control the narrative.&quot;</p>
+<p>They spent the next day preparing. Free Haven became a hive of activity—weapons checked, plans made, messages sent through hidden networks.</p>
+<p>Zero stood before the memorial one last time. He touched his mother&#x27;s name.</p>
+<p>&quot;I&#x27;m going to finish what you started,&quot; he whispered. &quot;I&#x27;m going to make sure no one else becomes a lost soul.&quot;</p>
+<p>The locket around his neck felt warm.</p>
+<p>Leo. Not Zero. Not the Godslayer.</p>
+<p>Just a son, trying to make his mother&#x27;s sacrifice mean something.</p>
+<p>He joined the others at the entrance. Hundreds of faces looked back at him—humans and demons, united by a common enemy.</p>
+<p>&quot;Today,&quot; Zero said, his voice carrying through the cavern, &quot;we&#x27;re not fighting for victory. We&#x27;re fighting for truth. So the world can see what the Church really is. So no more children lose their toys in sterile rooms. So no more mothers become numbers in ledgers.&quot;</p>
+<p>He raised a hand, and the constellation patterns on his skin blazed with light.</p>
+<p>&quot;Today, we remind them that weapons can choose their targets. And sometimes, the best target is the hand holding the gun.&quot;</p>
+<p>They moved out, a river of determination flowing toward the light.</p>
+<p>Toward Siberia.</p>
+<p>Toward the Abyssal Threshold.</p>
+<p>Toward the end of everything.</p>
+<p>Or the beginning.</p>
+<hr aria-hidden="true">
+<h3>Chapter 14: Threshold of Destiny</h3>
+<p>The Siberian tundra was a white hell.</p>
+<p>Zero&#x27;s forces arrived under cover of a blizzard, the howling wind masking their approach. Before them, the Abyssal Threshold facility rose from the ice—a massive ring of black metal, pulsing with wrong-colored light. Church transports filled the sky, their searchlights cutting through the snow.</p>
+<p>&quot;They&#x27;re waiting,&quot; Lilith said, her breath frosting in the air.</p>
+<p>&quot;Of course they are.&quot; Zero scanned the facility through enhanced vision. &quot;They want an audience.&quot;</p>
+<p><em>&quot;Three armies,&quot;</em> Azrael observed. <em>&quot;The Church&#x27;s. Ours. And yours in the middle.&quot;</em></p>
+<p>&quot;Not in the middle,&quot; Zero corrected. &quot;Above.&quot;</p>
+<p>He turned to his commanders. &quot;Remember the plan. We&#x27;re not here to win a battle. We&#x27;re here to win the narrative.&quot;</p>
+<p>The blizzard parted as if on command, revealing the full scale of the confrontation. To the east, Church forces—thousands of Inquisitors in crimson armor, their weapons gleaming. To the west, the demon rebellion—a sea of shadow and claw, Azrael at their head. And in the center, Free Haven&#x27;s mixed force, tiny by comparison.</p>
+<p>A hologram appeared above the facility—Cardinal Valerius, magnified to godlike proportions.</p>
+<p>&quot;Subject Zero.&quot; His voice boomed across the tundra. &quot;You come at last. To witness the salvation of humanity.&quot;</p>
+<p>&quot;I come to witness the truth,&quot; Zero called back, his voice amplified by his power. &quot;To show the world what you really are.&quot;</p>
+<p>&quot;Then look!&quot; Valerius gestured to the ring structure. &quot;Behold the instrument of our deliverance! The God-Slayer Engine! With it, we will seal the Abyss forever!&quot;</p>
+<p>&quot;With me as your battery,&quot; Zero said. &quot;You don&#x27;t want to seal it. You want to control it. To become gods.&quot;</p>
+<p>Valerius&#x27;s smile was thin, triumphant. &quot;And why not? If humanity must have gods, better they be us than the mindless chaos of the Abyss. We at least understand order. Commerce. Progress.&quot;</p>
+<p>&quot;You understand profit,&quot; Zero countered. &quot;Extortion. Murder disguised as salvation.&quot;</p>
+<p>He raised his hands, and the constellation patterns on his skin blazed brighter. &quot;But I&#x27;m not here to argue theology. I&#x27;m here to offer a choice.&quot;</p>
+<p>He turned, addressing all three armies, his voice carrying on the wind. &quot;The Church says demons are mindless beasts to be controlled. The demons say humans are jailers to be overthrown. Both are wrong.&quot;</p>
+<p>He pointed to Free Haven&#x27;s force. &quot;Look at them. Demons and humans, living together. Not as master and slave. Not as predator and prey. As equals. As... family.&quot;</p>
+<p>Murmurs rippled through the Church ranks. Some Inquisitors lowered their weapons, uncertain.</p>
+<p>&quot;Lies!&quot; Valerius shouted. &quot;Demonic corruption! They&#x27;ve brainwashed those poor souls!&quot;</p>
+<p>&quot;Have they?&quot; Zero asked. &quot;Or have they simply shown them the truth? That we don&#x27;t have to be enemies? That the Abyss isn&#x27;t evil—it&#x27;s potential? That chaos doesn&#x27;t have to mean destruction—it can mean creation?&quot;</p>
+<p>He took a step forward, toward the ring structure. &quot;You built this machine to control the Abyss. To turn potential into product. Chaos into commerce. But you&#x27;re missing the point.&quot;</p>
+<p>He reached the base of the structure, placed a hand on the cold metal. &quot;The Abyss doesn&#x27;t want to be controlled. It wants to be understood. To be... partnered with.&quot;</p>
+<p>Valerius&#x27;s eyes narrowed. &quot;What are you doing?&quot;</p>
+<p>&quot;Showing you what real power looks like,&quot; Zero said softly.</p>
+<p>He closed his eyes, and let his power flow into the machine.</p>
+<p>Not to power it. To communicate with it.</p>
+<p>The Epsilon Gene wasn&#x27;t just a regulator. It was a translator. A bridge between human consciousness and Abyssal essence.</p>
+<p>The machine hummed to life, but not as Valerius had intended. The wrong-colored light shifted, became something else—a rainbow of possibilities, a symphony of potential. Images formed in the air above the ring—not of destruction, but of creation. Worlds being born. Life evolving. Beauty emerging from chaos.</p>
+<p>The Church forces stared, mesmerized. The demon rebellion watched, awed.</p>
+<p>&quot;This is what the Abyss really is,&quot; Zero said, his voice echoing with the machine&#x27;s power. &quot;Not a threat. A partner. A source of infinite possibility. The Church feared it, so they tried to cage it. To turn it into a weapon. But weapons can be turned. Cages can be broken.&quot;</p>
+<p>He looked at Valerius. &quot;Your protection racket ends today. Not with violence. With truth.&quot;</p>
+<p>Valerius&#x27;s face twisted with rage. &quot;Kill him! All units, fire!&quot;</p>
+<p>But the Inquisitors hesitated. They had seen the images. They had felt the truth in Zero&#x27;s words. Some had family in districts that had been &quot;demonstrated&quot; upon. Some had doubts they&#x27;d buried for years.</p>
+<p>&quot;Don&#x27;t listen to him!&quot; Valerius screamed. &quot;He&#x27;s corrupted! He&#x27;s—&quot;</p>
+<p>A plasma bolt took him in the chest. Not from Zero&#x27;s side. Not from the demons.</p>
+<p>From the Church ranks.</p>
+<p>Sergeant Voss lowered his weapon, his face grim. &quot;Enough.&quot;</p>
+<p>Silence fell, broken only by the wind and the hum of the machine.</p>
+<p>Voss stepped forward, addressing his fellow Inquisitors. &quot;I&#x27;ve followed orders my whole life. Believed we were protecting humanity. But I&#x27;ve seen the records. I&#x27;ve seen the &#x27;acceptable casualties.&#x27;&quot; He looked at Zero. &quot;And I&#x27;ve seen what happens when a weapon chooses to build instead of destroy.&quot;</p>
+<p>More weapons lowered. More Inquisitors stepped forward, joining Voss.</p>
+<p>The balance shifted.</p>
+<p>Valerius lay on the ice, gasping, his crimson robes dark with blood. &quot;Fools... you&#x27;re all fools... the Conclave will...&quot;</p>
+<p>&quot;The Conclave is finished,&quot; Zero said, walking toward him. &quot;The truth is out. Your godhood ends here.&quot;</p>
+<p>He knelt beside the dying cardinal. &quot;Any last words? Any... confession?&quot;</p>
+<p>Valerius&#x27;s eyes focused on him, hate and something else—respect? &quot;You were... the perfect weapon. We designed you... to be obedient. To be loyal. To be... controllable.&quot; He coughed blood. &quot;We forgot... weapons can think. Can choose.&quot;</p>
+<p>He reached up, grabbed Zero&#x27;s arm with surprising strength. &quot;Finish it. Be the Godslayer one last time.&quot;</p>
+<p>Zero shook his head. &quot;I&#x27;m not that anymore.&quot;</p>
+<p>He stood, leaving Valerius to die alone on the ice.</p>
+<p>The battle was over without a shot being fired (except the one that mattered). The Church forces, leaderless, confused, began to surrender or flee. The demon rebellion, seeing their ancient enemy defeated, held their position, waiting.</p>
+<p>Zero turned to the ring structure. The machine was still active, humming with potential.</p>
+<p>&quot;What now?&quot; Lilith asked, joining him.</p>
+<p>&quot;Now we build,&quot; Zero said. &quot;Not walls. Bridges. Not cages. Communities.&quot;</p>
+<p>He looked at Azrael. &quot;The demon rebellion can have a home. Here. At the Threshold. Not as prisoners. As guardians. As partners.&quot;</p>
+<p><em>&quot;And the Church?&quot;</em> Azrael asked.</p>
+<p>&quot;Will have to change. Or fall.&quot; Zero looked at the surrendering Inquisitors. &quot;Some will join us. Some will resist. But the truth is out. They can&#x27;t go back to business as usual.&quot;</p>
+<p>He placed both hands on the machine. &quot;This isn&#x27;t a weapon. It&#x27;s a tool. A way to communicate with the Abyss. To understand it. To work with it.&quot;</p>
+<p>The images above the ring shifted again—showing a future. Demons and humans living together. Cities rebuilt without fear. Children playing without toys being taken. Mothers not becoming numbers in ledgers.</p>
+<p>A possible future. Not guaranteed. But possible.</p>
+<p>Zero turned to face the assembled armies—human, demon, and something in between.</p>
+<p>&quot;My name is Leo,&quot; he said. &quot;Son of Elena Vasquez. Not Subject Zero. Not the Godslayer. Just... a man trying to make things right.&quot;</p>
+<p>He raised his hands, and the constellation patterns blazed with final, brilliant light.</p>
+<p>&quot;Today, we choose a new path. Not of control. Not of rebellion. Of partnership. Of understanding. Of... possibility.&quot;</p>
+<p>The light spread, enveloping the ring structure, the armies, the tundra itself. Not destructive. Healing. Unifying.</p>
+<p>When it faded, something had changed. The air felt cleaner. The light felt truer. The future felt... possible.</p>
+<p>Leo stood at the center of it all, the bridge between worlds, the catalyst for change.</p>
+<p>The weapon had become a builder.</p>
+<p>The Godslayer had become a peacemaker.</p>
+<p>And the arithmetic of sin had finally been balanced by something simpler, more powerful:</p>
+<p>Love.</p>
+<p>Not the Church&#x27;s conditional love. Not the demons&#x27; desperate love.</p>
+<p>Just... love.</p>
+<p>For his mother. For the lost souls. For the possibilities ahead.</p>
+<p>He touched the locket around his neck, felt his mother&#x27;s smile.</p>
+<p><em>Whatever they make you, remember you were loved first.</em></p>
+<p>He had remembered.</p>
+<p>And in remembering, he had become something new.</p>
+<p>Something better.</p>
+<p>Something that could build a world where no one had to be a weapon ever again.</p>
+<p>The End</p>
+<p>Valerius&#x27;s smile was beatific. &quot;We already are gods, Zero. We have been for centuries. Today, we simply make it official.&quot;</p>
+<p>The ground shook. The ring structure began to rotate, crystals aligning. A beam of abyssal energy shot upward, tearing a hole in the sky.</p>
+<p>Reality frayed at the edges. Colors bled. Gravity fluctuated.</p>
+<p>&quot;Now!&quot; Zero shouted.</p>
+<p>The battle began—but not as Valerius expected.</p>
+<p>Free Haven&#x27;s forces didn&#x27;t attack the Church. They didn&#x27;t attack the demons. They spread out, setting up broadcasting equipment, projecting holograms of the evidence Zero had collected.</p>
+<p>Financial records. Project files. Elena&#x27;s journal.</p>
+<p>Images flashed across the tundra: the Ruins. The breeding grounds. The lost souls.</p>
+<p>Church soldiers hesitated, confused. They&#x27;d been told they were fighting mindless demons and a corrupted weapon. Not... this.</p>
+<p>&quot;Don&#x27;t listen to his lies!&quot; Valerius roared. &quot;He&#x27;s manipulating you!&quot;</p>
+<p>&quot;Am I?&quot; Zero projected his mother&#x27;s face across the battlefield. &quot;This is Elena Vasquez. My mother. One of your &#x27;lost souls.&#x27; She tried to warn people about you. You killed her. Made her a number in your ledgers.&quot;</p>
+<p>The image changed to show the toy soldier. &quot;This was found in a containment chamber in New Jerusalem. A child&#x27;s toy. Why was it there? Because the demon that manifested was directed. Because that attack was staged. Like all the others.&quot;</p>
+<p>More images: Kael&#x27;s family. The Dispossessed. The Free Haven memorial.</p>
+<p>The Church lines wavered.</p>
+<p>&quot;Enough!&quot; Valerius screamed. &quot;Activate the engine! Now!&quot;</p>
+<p>The ring structure glowed brighter. A tractor beam reached for Zero, trying to pull him toward the center.</p>
+<p>He resisted, his power flaring. The constellation patterns on his skin blazed like supernovae.</p>
+<p><em>&quot;Zero!&quot;</em> Azrael called. <em>&quot;The rift is widening! If they pull you in—&quot;</em></p>
+<p>&quot;I know.&quot; Zero strained against the beam. &quot;That&#x27;s why I&#x27;m not going alone.&quot;</p>
+<p>He reached out—not with his power, but with his mind. With the connection to the Abyss that now lived in him.</p>
+<p><em>Help me,</em> he thought. <em>Not to destroy. To understand.</em></p>
+<p>The Abyss answered.</p>
+<p>Not with violence. With curiosity.</p>
+<p>The rift didn&#x27;t widen. It... changed. Became something else. A window. A bridge.</p>
+<p>Through it, Zero saw the truth of the Abyss—not a place of demons, but of potential. Of consciousness without form. Of energy waiting to be shaped.</p>
+<p>The Church had shaped it into weapons. Into monsters.</p>
+<p>But it could be shaped into other things.</p>
+<p>Into understanding.</p>
+<p>Into connection.</p>
+<p>The tractor beam intensified. Zero felt himself being pulled toward the engine.</p>
+<p>Then a new voice cut through the chaos—not from the battlefield, but from every comm channel, every speaker, every piece of Church technology on the field. It was Evangeline&#x27;s voice, clear and strong, amplified across the tundra through the Church&#x27;s own communication systems.</p>
+<p>&quot;Attention, all Church forces. This is Sister Evangeline of the Silent Order. We have seized control of the Vatican communications hub. What you are about to see is the truth the Conclave has hidden from you for centuries.&quot;</p>
+<p>Valerius&#x27;s face went pale. &quot;Impossible! Jam that signal!&quot;</p>
+<p>But the signal couldn&#x27;t be jammed—it was coming from their own equipment, hijacked from within. Evangeline continued: &quot;For fifty years, the Church has bred demons as weapons to extort humanity. The &#x27;protection&#x27; you enforce is a protection racket. The &#x27;salvation&#x27; you sell comes with a body count. Look at the evidence now being broadcast to every screen in the world.&quot;</p>
+<p>On every Inquisitor&#x27;s visor display, on every holographic screen, the evidence appeared: the Detroit operational files, the breeding ground records, the financial ledgers showing tithes and &quot;demonstrations.&quot; The truth, laid bare.</p>
+<p>&quot;Your choice,&quot; Evangeline&#x27;s voice rang out. &quot;Keep fighting for their lies. Or stand down for the truth.&quot;</p>
+<p>The Inquisitors hesitated, confused, their certainty shattered by the voice coming from their own command structure.</p>
+<p>Zero acted.</p>
+<p>He didn&#x27;t fight the beam. He embraced it. Let it pull him—but not toward the engine. Toward the rift itself.</p>
+<p>Toward the bridge he&#x27;d created.</p>
+<p>&quot;Everyone!&quot; he shouted, his voice echoing across dimensions. &quot;Look! See what they&#x27;ve hidden from you!&quot;</p>
+<p>And he showed them.</p>
+<p>Not just the evidence. Not just the lies.</p>
+<p>The truth.</p>
+<p>The Abyss. The potential. The choice.</p>
+<p>To fear it, as the Church did. To weaponize it.</p>
+<p>Or to understand it. To build with it.</p>
+<p>The battle stopped. Church soldiers lowered their weapons. Demons paused.</p>
+<p>All eyes were on Zero, suspended between worlds, a bridge of light and understanding.</p>
+<p>Valerius stared, his god-mask cracking. &quot;What... what are you doing?&quot;</p>
+<p>&quot;Showing them,&quot; Zero said softly. &quot;Showing them what we could be. If we stop being afraid.&quot;</p>
+<p>He looked at Kael. At Lilith. At Azrael. At the voice of Evangeline still echoing through the comms.</p>
+<p>At all the lost souls, found again.</p>
+<p>&quot;Your choice,&quot; he said to the world. &quot;Fear. Or understanding.&quot;</p>
+<p>The engine strained. The beam flickered.</p>
+<p>Valerius made his choice.</p>
+<p>He drew a weapon—an ancient relic, charged with stolen Abyssal energy—and aimed at Zero.</p>
+<p>&quot;Then die,&quot; he whispered.</p>
+<p>And fired.</p>
+<hr aria-hidden="true">
+<h3>Chapter 15: The Godslayer&#x27;s Choice</h3>
+<p>Time slowed.</p>
+<p>Zero saw the energy bolt coming—a spear of stolen light, aimed at his heart. He could have dodged. Could have deflected it. Could have done any number of things with the power flowing through him.</p>
+<p>Instead, he made a choice.</p>
+<p>He let it hit.</p>
+<p>The bolt struck him in the chest. For a moment, there was only blinding pain. Then something else.</p>
+<p>The energy wasn&#x27;t just destructive. It was... familiar. Part of him. Part of the Abyss he now understood.</p>
+<p>He absorbed it. Not into his power reservoir. Into the bridge he&#x27;d created.</p>
+<p>The bolt became part of the connection. Part of the understanding.</p>
+<p>Valerius stared, horrified. &quot;No... that&#x27;s impossible...&quot;</p>
+<p>&quot;Nothing&#x27;s impossible,&quot; Zero said, his voice calm despite the agony. &quot;You taught me that. When you made a weapon out of a mother&#x27;s love.&quot;</p>
+<p>He looked down at the wound. It wasn&#x27;t bleeding. It was... changing. The constellation patterns on his skin flowed toward it, weaving new patterns. New connections.</p>
+<p>The wound didn&#x27;t scar. It bloomed. Like a flower made of light, it spread across Zero&#x27;s chest, its petals unfolding in intricate geometric patterns. At its center, a single point of perfect darkness—not emptiness, but potential. The toy soldier in his pocket grew warm, then began to glow with the same soft light. When Zero touched it, he felt not plastic, but something alive. Something remembering.*</p>
+<p>&quot;You can&#x27;t...&quot; Valerius whispered. &quot;The engine... my destiny...&quot;</p>
+<p>&quot;Your destiny was always a lie.&quot; Zero stepped forward, the bridge of light solidifying beneath his feet. &quot;Just like your protection. Just like your gods.&quot;</p>
+<p>He reached out—not to attack, but to offer.</p>
+<p>&quot;Look,&quot; he said softly. &quot;Really look.&quot;</p>
+<p>And he showed Valerius what he&#x27;d shown everyone else.</p>
+<p>The Abyss. Not as a threat. As a mirror.</p>
+<p>Valerius saw himself reflected in it—not as a god, not as a savior. As a frightened man who&#x27;d made a terrible choice fifty years ago and spent decades justifying it.</p>
+<p>He saw the younger version of himself, idealistic, wanting to save the world.</p>
+<p>He saw the moment he&#x27;d decided the ends justified the means.</p>
+<p>He saw all the lives he&#x27;d sacrificed. All the lies he&#x27;d told.</p>
+<p>And he saw... another path. One he could have taken.</p>
+<p>&quot;It didn&#x27;t have to be this way,&quot; Zero said. &quot;You could have told the truth about the Abyss. Could have asked for help. Could have built something better.&quot;</p>
+<p>Valerius didn&#x27;t just fall to his knees—he collapsed, as if the bones had been removed from his body. His hands came up to clutch at his head, fingers digging into his temples. The god-mask didn&#x27;t just shatter; it dissolved under the weight of infinity.</p>
+<p>For a man whose entire life had been built on control—on ledgers and quotas and acceptable casualties, on managing chaos into profitable order—the true nature of the Abyss was an existential poison. It wasn&#x27;t evil. It wasn&#x27;t something to be fought or contained or weaponized. It was potential. Infinite, unbounded, uncontrollable potential.</p>
+<p>And it was looking back at him.</p>
+<p>Through Zero&#x27;s connection, through the bridge of light, Valerius experienced what he had spent fifty years trying to avoid: reality without filters. Possibility without limits. A universe where every choice he&#x27;d made to impose order was revealed as a terrified contraction, a shrinking from the vastness of what could be.</p>
+<p>His mind, trained to categorize and control, tried to process the infinite. It couldn&#x27;t. The cognitive dissonance—between the tidy ledgers of his protection racket and the boundless potential now flooding his consciousness—ripped through his psyche like a physical force.</p>
+<p>He began to shake, not with fear but with systemic failure. His eyes lost focus, seeing not the Siberian tundra but the branching paths of every decision he&#x27;d ever made, every life he&#x27;d sacrificed, every truth he&#x27;d buried. He saw the Detroit accountant he&#x27;d become, tallying souls like currency. He saw the idealistic young priest he&#x27;d been, wanting to save the world. He saw the gulf between them, bridged by a thousand small compromises that now felt like canyons.</p>
+<p>&quot;I... I...&quot; The words wouldn&#x27;t form. Language, another system of control, failed him. He tried to reach for his usual justifications—the mathematics of order, the necessity of sacrifice, the greater good—but they crumbled to dust in the face of actual infinity.</p>
+<p>Tears streamed down his face, not of sadness but of neurological overload. His body convulsed once, a spasm of ego-death. When he finally found words, they were ripped from a place deeper than thought, from the raw nerve of a consciousness that had just encountered its own limits.</p>
+<p>&quot;I was building walls,&quot; he gasped, each word an agony. &quot;Walls around... everything. Around the chaos. Around the potential. Around myself.&quot; He looked at his hands as if seeing them for the first time. &quot;I called it order. I called it protection. I called it... holy.&quot;</p>
+<p>He looked up at Zero, and in that moment, he wasn&#x27;t Cardinal Valerius, master of the Conclave, architect of the protection racket. He was just a man who had spent his life being afraid of the dark, only to discover the dark was just unlit possibility.</p>
+<p>&quot;The power wasn&#x27;t too much,&quot; he whispered, the realization dawning with terrible clarity. &quot;I was too small.&quot;</p>
+<p>Zero knelt beside him, not in triumph but in recognition. &quot;We all start small,&quot; he said softly. &quot;The question is whether we grow or build cages.&quot;</p>
+<p>He turned to the armies, still frozen in the moment.</p>
+<p>&quot;The Church is finished,&quot; he announced. &quot;Not because I destroyed it. Because you see it for what it is now.&quot;</p>
+<p>He gestured to the bridge of light. &quot;This is the Abyss. Not a threat. A possibility. We can fear it. Or we can learn from it.&quot;</p>
+<p>He looked at Azrael. <em>&quot;Your people are free. No more breeding grounds. No more weapons.&quot;</em></p>
+<p>He looked at the Church soldiers. &quot;Your choice. Keep fighting for a lie. Or help build something true.&quot;</p>
+<p>He looked at Kael, at Lilith, at Azrael, at the thousands of faces watching him. &quot;All of you. Your choice.&quot;</p>
+<p>For a long moment, there was only the howl of the wind and the hum of the dying engine.</p>
+<p>Then a Church soldier lowered his weapon. Then another. And another.</p>
+<p>Demons approached humans, not to fight, but to... look. To see.</p>
+<p>The bridge of light pulsed, connecting them all.</p>
+<p>Zero walked to Valerius. &quot;The Conclave will stand trial. For everything. Including my mother.&quot;</p>
+<p>Valerius didn&#x27;t look up. &quot;What will you do with me?&quot;</p>
+<p>&quot;Not my decision,&quot; Zero said. &quot;Hers.&quot;</p>
+<p>He placed a hand on Valerius&#x27;s shoulder. Not to harm. To connect.</p>
+<p>And showed him Elena. Not as a memory. As she was in her journal. Brave. Loving. Hopeful.</p>
+<p>Valerius wept.</p>
+<p>The engine died. The rift stabilized—not sealed, but transformed. A permanent bridge between worlds.</p>
+<p>Zero stood at its center, the flower of light on his chest glowing softly.</p>
+<p>He was no longer the Godslayer.</p>
+<p>He was something else.</p>
+<p>A bridge.</p>
+<p>A mediator.</p>
+<p>A son remembering his mother.</p>
+<p>He took out the toy soldier. It was warm in his hand. He placed it at the base of the bridge, where the light met the ice.</p>
+<p>&quot;A reminder,&quot; he said to no one and everyone. &quot;That weapons can become toys again. If we choose.&quot;</p>
+<p>He spoke to the comms, knowing Evangeline was listening from the Vatican. &quot;Will you help? Rebuild the Church into something that helps instead of hurts?&quot;</p>
+<p>Her voice came back through the speakers, clear and strong. &quot;Yes, Leo. The Silent Order is already securing the Vatican. The truth is out. The rebuilding begins now.&quot;</p>
+<p>He smiled at the name. His name.</p>
+<p>He looked at the new world being born around him—humans and demons talking, not fighting. The lost souls, found. The weapons, laid down.</p>
+<p>It wouldn&#x27;t be easy. There would be struggles. Old hatreds don&#x27;t die quickly.</p>
+<p>But for the first time in centuries, there was hope.</p>
+<p>Not because a god had saved them.</p>
+<p>Because they&#x27;d saved themselves.</p>
+<p>Because a weapon had remembered it was also a person.</p>
+<p>Because a son had honored his mother&#x27;s love.</p>
+<p>Zero—Leo—walked away from the battlefield, the constellation patterns on his skin fading to soft glows.</p>
+<p>He had one more thing to do.</p>
+<p>He found a quiet place, away from the crowds. Opened the locket.</p>
+<p>Looked at his mother&#x27;s smiling face.</p>
+<p>&quot;Thank you,&quot; he whispered. &quot;For loving me first. For giving me a name.&quot;</p>
+<p>He closed the locket, held it to his heart.</p>
+<p>The flower of light pulsed in time with his heartbeat.</p>
+<p>A bridge.</p>
+<p>A beginning.</p>
+<p>Not an end.</p>
+<p>Somewhere, in the space between worlds, Elena Vasquez smiled.</p>
+<p>Her son had chosen.</p>
+<p>Not to become a god.</p>
+<p>Not to become a weapon.</p>
+<p>To become himself.</p>
+<p>And in doing so, he&#x27;d given everyone else the same choice.</p>
+<p>The Godslayer was dead.</p>
+<p>Long live the Bridge-Builder.</p>
+<hr aria-hidden="true">
+<p><strong>THE END</strong></p>
+  </section>
+  <footer class="colophon">
+    Rendered from <code>story_output.md</code>.
+  </footer>
+</body>
+</html>

--- a/scripts/render_story.py
+++ b/scripts/render_story.py
@@ -151,6 +151,15 @@ def strip_comments(text: str) -> str:
     return re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
 
 
+def _isolate_headings(text: str) -> str:
+    """Ensure ATX headings are surrounded by blank lines so block splitting
+    treats them as standalone blocks. Real-world LLM output often skips one
+    or both of these separators."""
+    text = re.sub(r"(?<!\n\n)(\n)(#{1,3} )", r"\n\n\2", text)
+    text = re.sub(r"(^|\n)(#{1,3} [^\n]+)\n(?!\n)", r"\1\2\n\n", text)
+    return text
+
+
 def render_inline(s: str) -> str:
     s = html.escape(s)
     s = re.sub(r"`([^`]+)`", r"<code>\1</code>", s)
@@ -199,7 +208,7 @@ def parse_document(text: str) -> tuple[str, list[tuple[str, str, str]]]:
     before the first H2 (after the title) is grouped under an implicit
     "Overview" section so nothing is lost.
     """
-    text = strip_comments(text).strip()
+    text = _isolate_headings(strip_comments(text)).strip()
     blocks = [b for b in re.split(r"\n\s*\n", text) if b.strip()]
 
     title = ""

--- a/scripts/render_story.py
+++ b/scripts/render_story.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Render a single story_output.md into a self-contained HTML file.
+
+Intended for reviewing output from ``test_story.py`` when driving it with a
+real LLM (e.g. Ollama) instead of the MockLM.
+
+Usage:
+    python scripts/render_story.py                              # .tmp/story_output.md -> .tmp/story_output.html
+    python scripts/render_story.py path/to/story.md             # writes path/to/story.html
+    python scripts/render_story.py path/to/story.md out.html    # explicit output path
+"""
+
+from __future__ import annotations
+
+import html
+import re
+import sys
+from pathlib import Path
+
+
+STYLE = """
+:root {
+  --bg: #faf7f1;
+  --fg: #1d1b18;
+  --muted: #7a756c;
+  --rule: #d8d1c2;
+  --accent: #8a3a28;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #14120f;
+    --fg: #e8e2d4;
+    --muted: #948d7e;
+    --rule: #2b2722;
+    --accent: #d77a5f;
+  }
+}
+* { box-sizing: border-box; }
+html, body { background: var(--bg); color: var(--fg); }
+body {
+  font-family: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, "Times New Roman", serif;
+  max-width: 38rem;
+  margin: 3rem auto 5rem;
+  padding: 0 1.25rem;
+  line-height: 1.62;
+  font-size: 1.0625rem;
+  text-rendering: optimizeLegibility;
+  hyphens: auto;
+}
+header.cover {
+  text-align: center;
+  margin-bottom: 3rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+}
+header.cover h1 {
+  font-size: 2rem;
+  font-weight: 600;
+  margin: 0 0 0.4rem;
+}
+header.cover .meta {
+  color: var(--muted);
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+nav.toc { margin-bottom: 3rem; }
+nav.toc h2 {
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 600;
+  margin: 0 0 0.75rem;
+}
+nav.toc ol {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  counter-reset: sec;
+}
+nav.toc li {
+  counter-increment: sec;
+  padding: 0.3rem 0;
+  display: flex;
+  gap: 0.8rem;
+  align-items: baseline;
+  border-bottom: 1px dotted var(--rule);
+}
+nav.toc li::before {
+  content: counter(sec, decimal-leading-zero);
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  min-width: 1.6rem;
+}
+nav.toc a { color: var(--fg); text-decoration: none; flex: 1; }
+nav.toc a:hover { color: var(--accent); }
+section.part { margin-top: 3rem; }
+section.part h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 2rem 0 1rem;
+  padding-bottom: 0.3rem;
+  border-bottom: 1px solid var(--rule);
+}
+section.part h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin: 1.5rem 0 0.5rem;
+}
+section.part p {
+  margin: 0 0 0.9rem;
+  text-align: justify;
+}
+section.part ul {
+  margin: 0 0 1rem;
+  padding-left: 1.25rem;
+}
+section.part li { margin: 0.2rem 0; }
+hr {
+  border: none;
+  text-align: center;
+  margin: 1.2rem 0;
+  height: 1rem;
+}
+hr::after {
+  content: "\\2217  \\2217  \\2217";
+  letter-spacing: 0.4em;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+code {
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.92em;
+  background: var(--rule);
+  padding: 0.05em 0.3em;
+  border-radius: 3px;
+}
+footer.colophon {
+  margin-top: 5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--rule);
+  color: var(--muted);
+  font-size: 0.8rem;
+  text-align: center;
+}
+"""
+
+
+def strip_comments(text: str) -> str:
+    return re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
+
+
+def render_inline(s: str) -> str:
+    s = html.escape(s)
+    s = re.sub(r"`([^`]+)`", r"<code>\1</code>", s)
+    s = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", s)
+    s = re.sub(r"(?<!\*)\*([^*\n]+)\*(?!\*)", r"<em>\1</em>", s)
+    return s
+
+
+def slugify(name: str) -> str:
+    s = re.sub(r"[^a-zA-Z0-9]+", "-", name).strip("-").lower()
+    return s or "section"
+
+
+_BULLET_RE = re.compile(r"^\s*[-*]\s+")
+
+
+def render_blocks(blocks: list[str]) -> str:
+    out: list[str] = []
+    for b in blocks:
+        b = b.strip()
+        if not b:
+            continue
+        if b.startswith("### "):
+            out.append(f"<h3>{render_inline(b[4:].strip())}</h3>")
+        elif b.startswith("## "):
+            out.append(f"<h2>{render_inline(b[3:].strip())}</h2>")
+        elif b in ("---", "***"):
+            out.append('<hr aria-hidden="true">')
+        elif all(_BULLET_RE.match(line) for line in b.splitlines() if line.strip()):
+            items = [
+                f"  <li>{render_inline(_BULLET_RE.sub('', line).strip())}</li>"
+                for line in b.splitlines()
+                if line.strip()
+            ]
+            out.append("<ul>\n" + "\n".join(items) + "\n</ul>")
+        else:
+            para = " ".join(line.strip() for line in b.splitlines())
+            out.append(f"<p>{render_inline(para)}</p>")
+    return "\n".join(out)
+
+
+def parse_document(text: str) -> tuple[str, list[tuple[str, str, str]]]:
+    """Return (title, [(slug, heading, body_html), ...]).
+
+    First H1 becomes the document title. Each H2 starts a new section. Content
+    before the first H2 (after the title) is grouped under an implicit
+    "Overview" section so nothing is lost.
+    """
+    text = strip_comments(text).strip()
+    blocks = [b for b in re.split(r"\n\s*\n", text) if b.strip()]
+
+    title = ""
+    if blocks and blocks[0].lstrip().startswith("# "):
+        title = blocks[0].lstrip()[2:].strip()
+        blocks = blocks[1:]
+
+    sections: list[tuple[str, str, list[str]]] = []
+    current_heading: str | None = None
+    current_blocks: list[str] = []
+
+    for b in blocks:
+        if b.lstrip().startswith("## "):
+            if current_heading is not None or current_blocks:
+                heading = current_heading or "Overview"
+                sections.append((slugify(heading), heading, current_blocks))
+            current_heading = b.lstrip()[3:].strip()
+            current_blocks = []
+        else:
+            current_blocks.append(b)
+
+    if current_heading is not None or current_blocks:
+        heading = current_heading or "Overview"
+        sections.append((slugify(heading), heading, current_blocks))
+
+    rendered = [(slug, heading, render_blocks(body)) for slug, heading, body in sections]
+    return title or "Story Output", rendered
+
+
+def build_html(title: str, sections: list[tuple[str, str, str]], source: Path) -> str:
+    toc_items = "\n".join(
+        f'      <li><a href="#{slug}">{html.escape(heading)}</a></li>'
+        for slug, heading, _ in sections
+    )
+    section_html = "\n".join(
+        f'  <section class="part" id="{slug}">\n    <h2>{html.escape(heading)}</h2>\n{body}\n  </section>'
+        for slug, heading, body in sections
+    )
+    toc_block = (
+        f'  <nav class="toc" aria-label="Table of contents">\n'
+        f"    <h2>Contents</h2>\n"
+        f"    <ol>\n{toc_items}\n    </ol>\n"
+        f"  </nav>"
+        if sections
+        else ""
+    )
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{html.escape(title)}</title>
+  <style>{STYLE}</style>
+</head>
+<body>
+  <header class="cover">
+    <div class="meta">story_writer preview</div>
+    <h1>{html.escape(title)}</h1>
+  </header>
+{toc_block}
+{section_html}
+  <footer class="colophon">
+    Rendered from <code>{html.escape(source.name)}</code>.
+  </footer>
+</body>
+</html>
+"""
+
+
+def main(argv: list[str]) -> None:
+    src = Path(argv[1]) if len(argv) > 1 else Path(".tmp/story_output.md")
+    out = Path(argv[2]) if len(argv) > 2 else src.with_suffix(".html")
+
+    if not src.is_file():
+        print(f"Input not found: {src}", file=sys.stderr)
+        sys.exit(1)
+
+    title, sections = parse_document(src.read_text(encoding="utf-8"))
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(build_html(title, sections, src), encoding="utf-8")
+    print(f"Wrote {out} ({len(sections)} sections)")
+
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
## Summary
Add a new utility script that converts markdown story output files into self-contained, styled HTML documents for easy review and presentation.

## Changes
- **New script**: `scripts/render_story.py` - A markdown-to-HTML renderer specifically designed for story output files
  - Parses markdown documents with H1 (title), H2 (sections), and body content
  - Generates a self-contained HTML file with embedded CSS styling
  - Includes automatic table of contents generation from H2 headings
  - Supports flexible input/output paths with sensible defaults (`.tmp/story_output.md` → `.tmp/story_output.html`)

## Implementation Details
- **Markdown parsing**: Splits document into title and sections, with implicit "Overview" section for pre-H2 content
- **Inline formatting**: Supports backticks (code), `**bold**`, and `*italic*` markdown syntax
- **Styling**: Includes comprehensive CSS with light/dark mode support via CSS variables, optimized for readability with serif typography and justified text
- **Accessibility**: Proper semantic HTML with ARIA labels and heading hierarchy
- **Robustness**: Strips HTML comments, handles edge cases like missing sections, and creates parent directories as needed

## Usage
```bash
python scripts/render_story.py                              # .tmp/story_output.md → .tmp/story_output.html
python scripts/render_story.py path/to/story.md             # writes path/to/story.html
python scripts/render_story.py path/to/story.md out.html    # explicit output path
```

https://claude.ai/code/session_01M2mAfsFtaRDkVj4DWKiAWV