### PR TITLE
Fix duplicate chapters across acts + add per-call token usage logging (#53)

### DIFF
--- a/logging_config.py
+++ b/logging_config.py
@@ -29,7 +29,9 @@ See ADR-003 in think_tank for the full standard.
 import logging
 import os
 import sys
+import time
 from datetime import datetime, timezone
+from typing import Any
 
 
 # ---------------------------------------------------------------------------
@@ -260,3 +262,76 @@ def log_llm_call(
             "latency_ms": latency_ms,
         },
     )
+
+
+# ---------------------------------------------------------------------------
+# DSPy callback: automatic token-usage logging for every LM call
+# ---------------------------------------------------------------------------
+
+try:
+    from dspy.utils.callback import BaseCallback
+except ImportError:
+    BaseCallback = None
+
+
+if BaseCallback is not None:
+
+    class TokenUsageCallback(BaseCallback):
+        """Log token usage after every DSPy LM call.
+
+        Register via ``dspy.configure(callbacks=[TokenUsageCallback()])``.
+        Works with any real LM backend (litellm/Ollama/OpenAI). MockLM
+        bypasses the ``@with_callbacks`` decorator so this callback will
+        not fire during mock-only test runs — that is expected.
+        """
+
+        def __init__(self) -> None:
+            self._calls: dict[str, dict[str, Any]] = {}
+            self._logger = logging.getLogger("token_usage")
+
+        def on_lm_start(
+            self,
+            call_id: str,
+            instance: Any,
+            inputs: dict[str, Any],
+        ) -> None:
+            self._calls[call_id] = {
+                "instance": instance,
+                "t0": time.perf_counter(),
+            }
+
+        def on_lm_end(
+            self,
+            call_id: str,
+            outputs: dict[str, Any] | None,
+            exception: Exception | None = None,
+        ) -> None:
+            call_info = self._calls.pop(call_id, None)
+            if exception or call_info is None:
+                return
+
+            instance = call_info["instance"]
+            elapsed_ms = (time.perf_counter() - call_info["t0"]) * 1000
+
+            if not getattr(instance, "history", None):
+                return
+
+            entry = instance.history[-1]
+            usage = entry.get("usage") or {}
+            model = entry.get("model", getattr(instance, "model", "unknown"))
+
+            tokens_in = usage.get("prompt_tokens", 0)
+            tokens_out = usage.get("completion_tokens", 0)
+            cost = entry.get("cost")
+
+            log_llm_call(
+                self._logger,
+                model=model,
+                tokens_in=tokens_in,
+                tokens_out=tokens_out,
+                cost=cost,
+                latency_ms=elapsed_ms,
+            )
+
+else:
+    TokenUsageCallback = None  # type: ignore[assignment,misc]

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ from rich.prompt import Confirm, Prompt
 
 from dspy_optimization import try_load_optimized_module
 from image_gen import ImageGenerator
-from logging_config import setup_logging
+from logging_config import TokenUsageCallback, setup_logging
 from postprocessing import find_similar_sentences, format_report
 from story_modules import (
     ChapterInpaintingGenerator,
@@ -131,7 +131,8 @@ def configure_dspy(config: DSPyConfig) -> None:
         except _RECOVERABLE_RUNTIME_EXCEPTIONS as exc:
             logger.warning("Langfuse DSPy callback handler unavailable: %s", exc)
 
-    dspy.configure(lm=lm)
+    callbacks = [TokenUsageCallback()] if TokenUsageCallback is not None else []
+    dspy.configure(lm=lm, callbacks=callbacks)
 
 
 def initialize_text_generators(

--- a/story_modules.py
+++ b/story_modules.py
@@ -325,13 +325,35 @@ class SceneImagePromptGenerator(dspy.Module):
 
 
 class GenerateChapterPlanSignature(dspy.Signature):
-    """Generates Level 2: Chapter Plan (Each arc broken into chapters)."""
+    """Generates Level 2: Chapter Plan for one act, continuing from prior acts.
+
+    Plan only the current act. Previously planned chapters from earlier acts are
+    provided as context — continue the narrative from where they leave off,
+    without repeating beats, scenes, or chapter titles.
+    """
     core_premise: str = dspy.InputField(desc="The Core Premise of the story.")
+    spine_template: str = dspy.InputField(
+        desc=(
+            "The Spine Template describing the overall narrative shape "
+            "(Once upon a time / Every day / One day / Because of that / "
+            "Until finally). Use it to anchor the act boundary."
+        ),
+    )
     world_bible: str = dspy.InputField(desc="The comprehensive World Bible.")
-    act: str = dspy.InputField(desc="The act of the story.")
-    #arc: str = dspy.InputField(desc="The arc of the story.")
+    previous_chapters: str = dspy.InputField(
+        desc=(
+            "Chapters already planned in earlier acts, one per line. "
+            "Continue from these — do not repeat or restate any beat, scene, "
+            "or chapter title. Empty string means this is the first act."
+        ),
+    )
+    act: str = dspy.InputField(desc="The act of the story to plan chapters for.")
     chapter_plan: list[str] = dspy.OutputField(
-        desc="Chapter Plan for the arc (5-10 major events of the act)",
+        desc=(
+            "Chapter Plan for this act (5-10 major events). Each entry must "
+            "advance the story past previous_chapters and must not duplicate "
+            "any prior beat or chapter title."
+        ),
     )
 
 class GenerateEnhancersSignature(dspy.Signature):
@@ -533,14 +555,22 @@ class StoryGenerator(dspy.Module):
     def _generate_chapter_plan_entries(
         self,
         core_premise: str,
+        spine_template: str,
         world_bible: str,
     ) -> list[str]:
         chapter_entries: list[str] = []
         for act in _ACT_SEQUENCE:
-            logger.debug("Generating chapter plan for %s...", act)
+            previous_chapters_text = "\n".join(chapter_entries)
+            logger.debug(
+                "Generating chapter plan for %s (continuing from %d prior chapters)...",
+                act,
+                len(chapter_entries),
+            )
             chapter_plan_result = self.generate_chapter_plan(
                 core_premise=core_premise,
+                spine_template=spine_template,
                 world_bible=world_bible,
+                previous_chapters=previous_chapters_text,
                 act=act,
             )
             chapter_entries.extend(chapter_plan_result.chapter_plan)
@@ -607,6 +637,7 @@ class StoryGenerator(dspy.Module):
         logger.debug("StoryGenerator received spine template of %d chars", len(spine_template))
         chapters_to_write = self._generate_chapter_plan_entries(
             core_premise=core_premise,
+            spine_template=spine_template,
             world_bible=world_bible,
         )
         chapter_plan_text = "\n".join(chapters_to_write)

--- a/test_story.py
+++ b/test_story.py
@@ -480,6 +480,80 @@ def test_chapter_inpainting_generator_rejects_invalid_ratio():
             expansion_ratio=1.0,
         )
 
+class TestTokenUsageCallback:
+    """Tests for the TokenUsageCallback DSPy callback."""
+
+    def test_instantiation(self):
+        assert TokenUsageCallback is not None
+        cb = TokenUsageCallback()
+        assert cb._calls == {}
+
+    def test_on_lm_start_stores_call_info(self):
+        cb = TokenUsageCallback()
+        mock_instance = MagicMock()
+        cb.on_lm_start(call_id="abc", instance=mock_instance, inputs={"prompt": "hi"})
+        assert "abc" in cb._calls
+        assert cb._calls["abc"]["instance"] is mock_instance
+        assert "t0" in cb._calls["abc"]
+
+    def test_on_lm_end_logs_usage_from_history(self):
+        cb = TokenUsageCallback()
+        mock_instance = MagicMock()
+        mock_instance.model = "ollama/gemma2:27b"
+        mock_instance.history = [
+            {
+                "model": "ollama/gemma2:27b",
+                "usage": {"prompt_tokens": 1200, "completion_tokens": 350, "total_tokens": 1550},
+                "cost": None,
+            }
+        ]
+        cb.on_lm_start(call_id="abc", instance=mock_instance, inputs={})
+        with patch.object(cb._logger, "info") as mock_log:
+            cb.on_lm_end(call_id="abc", outputs={"text": "response"})
+            mock_log.assert_called_once()
+            extra = mock_log.call_args[1]["extra"]
+            assert extra["tokens_in"] == 1200
+            assert extra["tokens_out"] == 350
+            assert extra["model"] == "ollama/gemma2:27b"
+
+    def test_on_lm_end_skips_on_exception(self):
+        cb = TokenUsageCallback()
+        mock_instance = MagicMock()
+        cb.on_lm_start(call_id="abc", instance=mock_instance, inputs={})
+        with patch.object(cb._logger, "info") as mock_log:
+            cb.on_lm_end(call_id="abc", outputs=None, exception=RuntimeError("fail"))
+            mock_log.assert_not_called()
+        assert "abc" not in cb._calls
+
+    def test_on_lm_end_handles_empty_history(self):
+        cb = TokenUsageCallback()
+        mock_instance = MagicMock()
+        mock_instance.history = []
+        cb.on_lm_start(call_id="abc", instance=mock_instance, inputs={})
+        with patch.object(cb._logger, "info") as mock_log:
+            cb.on_lm_end(call_id="abc", outputs={"text": "response"})
+            mock_log.assert_not_called()
+
+    def test_on_lm_end_handles_missing_usage(self):
+        cb = TokenUsageCallback()
+        mock_instance = MagicMock()
+        mock_instance.model = "mock"
+        mock_instance.history = [{"model": "mock", "usage": {}, "cost": None}]
+        cb.on_lm_start(call_id="abc", instance=mock_instance, inputs={})
+        with patch.object(cb._logger, "info") as mock_log:
+            cb.on_lm_end(call_id="abc", outputs={"text": "response"})
+            mock_log.assert_called_once()
+            extra = mock_log.call_args[1]["extra"]
+            assert extra["tokens_in"] == 0
+            assert extra["tokens_out"] == 0
+
+    def test_on_lm_end_unknown_call_id_is_noop(self):
+        cb = TokenUsageCallback()
+        with patch.object(cb._logger, "info") as mock_log:
+            cb.on_lm_end(call_id="unknown", outputs={"text": "response"})
+            mock_log.assert_not_called()
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Test AI DSPy Story Writer")
     parser.add_argument("--model", type=str, default=os.environ.get("MODEL", "mock"), help="The language model to use (e.g., openai/gpt-4o-mini, ollama_chat/llama3). Defaults to MODEL env var or mock.")

--- a/test_story.py
+++ b/test_story.py
@@ -8,6 +8,7 @@ import dspy
 import pytest
 from dotenv import load_dotenv
 
+from logging_config import TokenUsageCallback
 from main import initialize_text_generators
 from story_modules import (
     ChapterInpaintingGenerator,
@@ -198,9 +199,10 @@ def test_pipeline(
     # For testing in an environment where no actual LLM API is reachable, use the MockLM.
     # To run actual integration tests, you'd provide an active OPENAI_API_KEY or local Ollama running.
     # If the user requested the mock model, or if we want to ensure tests always pass in CI, use MockLM.
+    callbacks = [TokenUsageCallback()] if TokenUsageCallback is not None else []
     if model_name == "mock" or model_name == "test_mock":
         lm = MockLM()
-        dspy.configure(lm=lm)
+        dspy.configure(lm=lm, callbacks=callbacks)
     else:
         # We assume OPENAI_API_KEY is available in the run_in_bash_session, if not, we skip the actual test
         if "openai" in model_name.lower() and not kwargs.get("api_key"):
@@ -208,7 +210,7 @@ def test_pipeline(
             return
 
         lm = dspy.LM(model_name, cache=cache, **kwargs)
-        dspy.configure(lm=lm)
+        dspy.configure(lm=lm, callbacks=callbacks)
 
     idea = "An unnamed child is raised by the Church as the ultimate weapon against demons. As child grows he learns that the church itself is corrupt and breeds demons for controlled chaos. The church recieves funding for protection and as such decides who should recieve help. The child eventually becomes overpowered and turns back on the Church"
 

--- a/test_story.py
+++ b/test_story.py
@@ -63,7 +63,7 @@ class MockLM(dspy.LM):
             return ['```json\n{"story": "Mock final story"}\n```']
         if "[[ ## enhancers_guide ## ]]" in content or ('"enhancers_guide"' in content and "evaluating which story enhancers" in content):
             return ['```json\n{"reasoning": "Mock reasoning", "enhancers_guide": "Mock enhancers guide"}\n```']
-        if "[[ ## chapter_plan ## ]]" in content or ('"chapter_plan"' in content and "Each arc broken into chapters" in content):
+        if "[[ ## chapter_plan ## ]]" in content or ('"chapter_plan"' in content and "Chapter Plan for this act" in content):
             return ['```json\n{"reasoning": "Mock reasoning", "chapter_plan": ["Chapter 1: Discovery", "Chapter 2: Training", "Chapter 3: Revelation", "Chapter 4: Escape"]}\n```']
         if "[[ ## world_bible ## ]]" in content or ('"world_bible"' in content and "setting, lore, and characters" in content):
             return ['```json\n{"world_bible": "Mock world bible"}\n```']


### PR DESCRIPTION
## Summary

- **Fix duplicate chapters across acts (#53):** Each act's chapter plan was generated independently — Act 3 had no knowledge of Act 2's output, so boundary beats (siege, Malachai confrontation) were planned twice, producing duplicate/overlapping chapters. `GenerateChapterPlanSignature` now receives `previous_chapters` (accumulated from prior acts) and `spine_template` (was passed to `StoryGenerator` but never forwarded) so each act continues from where the last left off.
- **Add per-call token usage logging:** New `TokenUsageCallback` (DSPy `BaseCallback`) automatically logs model, prompt_tokens, completion_tokens, cost, and latency after every LM call. Registered in both `main.py` and `test_story.py`. Uses the existing `log_llm_call` helper so output respects configured log format. MockLM bypasses `@with_callbacks` so the callback is a no-op during mock CI runs.

## Changed files

| File | What changed |
|---|---|
| `story_modules.py` | Added `spine_template` and `previous_chapters` InputFields to `GenerateChapterPlanSignature`; updated docstring and OutputField desc to make no-duplication contract explicit; `_generate_chapter_plan_entries` now accumulates entries and feeds them back per act; `forward()` threads `spine_template` through |
| `logging_config.py` | Added `TokenUsageCallback` class using DSPy's `BaseCallback` — `on_lm_start` captures instance + timer, `on_lm_end` reads usage from LM history and logs via `log_llm_call` |
| `main.py` | Imports and registers `TokenUsageCallback` via `dspy.configure(callbacks=...)` |
| `test_story.py` | Imports and registers `TokenUsageCallback`; updated mock matcher to key off new signature description; added 7 unit tests for `TokenUsageCallback` (instantiation, call tracking, usage extraction, exception/empty/missing-usage/unknown-id edge cases) |

## Context

Identified while reviewing Gemma 26B output — the model produced chapters 15 and 17 both titled "The Siege of Eternal Vigil", and Malachai was killed in both chapter 16 and chapter 19. Root cause was the independent per-act planner calls with no shared context. Issue #53 documented the diagnosis; this PR implements the fix.

Token logging added to monitor context window usage now that `previous_chapters` accumulates — Act 3's planner call will show noticeably higher `tokens_in` than Act 1, useful for verifying local models stay within context limits.

## Test plan

- [x] All 29 tests pass (22 existing + 7 new callback tests)
- [x] Ruff clean
- [ ] Run `test_story.py` with Gemma 26B and verify no duplicate chapter titles or repeated narrative beats across acts
- [ ] Verify token usage logs appear in `-v` output for real model runs

https://claude.ai/code/session_013ebY85YPjXpyjaUev74oZd