### PR TITLE
Implement structured world bible flow

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ from story_modules import (
     SpineTemplateGenerator,
     StoryGenerator,
 )
+from world_bible import WorldBible
 from world_bible_modules import WorldBibleGenerator, WorldBibleQuestionGenerator
 
 try:
@@ -433,7 +434,7 @@ def generate_world_bible(
     spine_template: str,
     world_bible_question_generator: Any,
     world_bible_generator: Any,
-) -> str:
+) -> WorldBible:
     """Generate world-bible follow-up QA and final world bible."""
     console.print(
         "\n[italic]Generating follow-up questions to help flesh out "
@@ -451,10 +452,10 @@ def generate_world_bible(
         spine_template=spine_template,
         user_additions=wb_qa_text,
     )
-    world_bible = wb_result.world_bible
+    world_bible = wb_result.world_bible_structured
 
     console.print("\n[bold green]--- World Bible ---[/bold green]")
-    console.print(world_bible)
+    console.print(world_bible.full_text)
     console.print("[bold green]-------------------[/bold green]")
     return world_bible
 
@@ -495,7 +496,10 @@ def _generate_character_portraits(
     return portrait_paths
 
 
-def maybe_generate_character_assets(args: Namespace, world_bible: str) -> ImageArtifacts:
+def maybe_generate_character_assets(
+    args: Namespace,
+    world_bible: WorldBible,
+) -> ImageArtifacts:
     """Generate character descriptions and portraits when image mode is enabled."""
     if not args.enable_images:
         return ImageArtifacts([], {}, "", None)
@@ -511,7 +515,7 @@ def maybe_generate_character_assets(args: Namespace, world_bible: str) -> ImageA
 
     console.print("\n[italic]Generating character visual descriptions...[/italic]")
     cv_describer = CharacterVisualDescriber()
-    cv_result = cv_describer(world_bible=world_bible)
+    cv_result = cv_describer(world_bible=world_bible.full_text)
     character_visuals = cv_result.character_visuals
     character_visuals_summary = _summarize_character_visuals(character_visuals)
     character_portrait_paths = _generate_character_portraits(
@@ -575,7 +579,7 @@ class StoryFoundation:
 
     core_premise: str
     spine_template: str
-    world_bible: str
+    world_bible: WorldBible
 
 
 def generate_story_text(
@@ -599,7 +603,7 @@ def generate_story_text(
         parser=parser,
         chapter_inpainting_generator=generators["ChapterInpaintingGenerator"],
         story_result=story_result,
-        world_bible=foundation.world_bible,
+        world_bible=foundation.world_bible.full_text,
     )
     return story_result, final_story_text
 
@@ -715,7 +719,7 @@ def save_story_output(output_dir: str, artifacts: "StoryRunArtifacts") -> str:
         file_handle.write("## Spine Template\n")
         file_handle.write(f"{artifacts.spine_template}\n\n")
         file_handle.write("## World Bible\n")
-        file_handle.write(f"{artifacts.world_bible}\n\n")
+        file_handle.write(f"{artifacts.world_bible.full_text}\n\n")
         _write_character_visuals_section(file_handle, artifacts.image_artifacts)
         _write_story_metadata_section(file_handle, artifacts.story_result)
         _write_final_story_section(
@@ -733,7 +737,7 @@ class StoryRunArtifacts:
 
     core_premise: str
     spine_template: str
-    world_bible: str
+    world_bible: WorldBible
     image_artifacts: ImageArtifacts
     story_result: Any
     final_story_text: str
@@ -743,7 +747,7 @@ class StoryRunArtifacts:
 def _build_story_foundation(
     generators: dict[str, Any],
     idea: str,
-) -> tuple[str, str, str]:
+) -> StoryFoundation:
     """Run premise, spine, and world bible stages."""
     idea, core_premise, qa_text = run_core_premise_flow(
         idea=idea,

--- a/story_modules.py
+++ b/story_modules.py
@@ -9,6 +9,7 @@ import dspy
 from pydantic import BaseModel, Field, model_validator
 
 from _compat import observe
+from world_bible import WorldBible
 
 # Probability that a chapter receives a random creative flourish (0.0 – 1.0).
 RANDOM_DETAIL_PROBABILITY = 0.35
@@ -339,7 +340,15 @@ class GenerateChapterPlanSignature(dspy.Signature):
             "Until finally). Use it to anchor the act boundary."
         ),
     )
-    world_bible: str = dspy.InputField(desc="The comprehensive World Bible.")
+    characters: str = dspy.InputField(
+        desc="Character bios and relationship context most relevant to chapter planning.",
+    )
+    plot_timeline: str = dspy.InputField(
+        desc="Plot beats and act progression for the story.",
+    )
+    rules: str = dspy.InputField(
+        desc="Rules of the world that constrain or enable plot events.",
+    )
     previous_chapters: str = dspy.InputField(
         desc=(
             "Chapters already planned in earlier acts, one per line. "
@@ -399,7 +408,15 @@ class GenerateRandomDetailSignature(dspy.Signature):
 
 class GenerateSingleChapterSignature(dspy.Signature):
     """Writes a full, detailed chapter based on the world bible and the specific chapter goal."""
-    world_bible: str = dspy.InputField()
+    characters: str = dspy.InputField(
+        desc="Character bios and relationship context to keep names and motivations specific.",
+    )
+    rules: str = dspy.InputField(
+        desc="Rules of the world that govern what can happen in the chapter.",
+    )
+    locations: str = dspy.InputField(
+        desc="Relevant location details to ground setting and scene description.",
+    )
     chapter_plan: str = dspy.InputField(desc="The full plan for context.")
     current_chapter_description: str = dspy.InputField(
         desc="The specific event to write now.",
@@ -556,7 +573,7 @@ class StoryGenerator(dspy.Module):
         self,
         core_premise: str,
         spine_template: str,
-        world_bible: str,
+        world_bible: WorldBible,
     ) -> list[str]:
         chapter_entries: list[str] = []
         for act in _ACT_SEQUENCE:
@@ -569,7 +586,9 @@ class StoryGenerator(dspy.Module):
             chapter_plan_result = self.generate_chapter_plan(
                 core_premise=core_premise,
                 spine_template=spine_template,
-                world_bible=world_bible,
+                characters=world_bible.characters,
+                plot_timeline=world_bible.plot_timeline,
+                rules=world_bible.rules,
                 previous_chapters=previous_chapters_text,
                 act=act,
             )
@@ -580,18 +599,18 @@ class StoryGenerator(dspy.Module):
 
     def _generate_enhancers_guide(
         self,
-        world_bible: str,
+        world_bible: WorldBible,
         chapter_plan_text: str,
     ) -> str:
         enhancers_result = self.generate_enhancers(
-            world_bible=world_bible,
+            world_bible=world_bible.full_text,
             chapter_plan=chapter_plan_text,
         )
         return enhancers_result.enhancers_guide
 
     def _write_story_chapters(
         self,
-        world_bible: str,
+        world_bible: WorldBible,
         chapter_plan_text: str,
         chapters_to_write: list[str],
         enhancers_guide: str,
@@ -601,7 +620,10 @@ class StoryGenerator(dspy.Module):
 
         for index, chapter_desc in enumerate(chapters_to_write, start=1):
             try:
-                random_detail = self._maybe_generate_random_detail(world_bible, chapter_desc)
+                random_detail = self._maybe_generate_random_detail(
+                    world_bible.full_text,
+                    chapter_desc,
+                )
                 if random_detail:
                     logger.info(
                         "Chapter %d: injecting probabilistic detail: %.300s",
@@ -610,7 +632,9 @@ class StoryGenerator(dspy.Module):
                     )
 
                 result = self.write_chapter(
-                    world_bible=world_bible,
+                    characters=world_bible.characters,
+                    rules=world_bible.rules,
+                    locations=world_bible.locations,
                     chapter_plan=chapter_plan_text,
                     current_chapter_description=chapter_desc,
                     previous_chapters_summary=previous_chapters_summary,
@@ -632,7 +656,12 @@ class StoryGenerator(dspy.Module):
         return full_story
 
     @observe()
-    def forward(self, core_premise: str, spine_template: str, world_bible: str):
+    def forward(
+        self,
+        core_premise: str,
+        spine_template: str,
+        world_bible: WorldBible,
+    ):
         """Run the end-to-end chapter planning and drafting workflow."""
         logger.debug("StoryGenerator received spine template of %d chars", len(spine_template))
         chapters_to_write = self._generate_chapter_plan_entries(

--- a/story_modules.py
+++ b/story_modules.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from _compat import observe
 from exceptions import RECOVERABLE_MODEL_EXCEPTIONS
+from world_bible import WorldBible
 
 # Probability that a chapter receives a random creative flourish (0.0 – 1.0).
 RANDOM_DETAIL_PROBABILITY = 0.35

--- a/test_story.py
+++ b/test_story.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import os
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import coloredlogs
@@ -21,6 +22,7 @@ from story_modules import (
     SpineTemplateGenerator,
     StoryGenerator,
 )
+from world_bible import WorldBible
 from world_bible_modules import WorldBibleGenerator
 
 load_dotenv()
@@ -242,10 +244,11 @@ def test_pipeline(
     wb_result = wb_gen(core_premise=cp_result.core_premise, spine_template=st_result.spine_template)
     logger.info("World Bible generated.")
     logger.debug("World bible preview: %.300s", wb_result.world_bible)
+    world_bible = wb_result.world_bible_structured
 
     # 5. Character Visual Descriptions
     cv_describer = CharacterVisualDescriber()
-    cv_result = cv_describer(world_bible=wb_result.world_bible)
+    cv_result = cv_describer(world_bible=world_bible.full_text)
     print(f"Generated visuals for {len(cv_result.character_visuals)} characters.")
     for cv in cv_result.character_visuals:
         print(f"  - {cv.name}: {cv.reference_mix}")
@@ -268,7 +271,11 @@ def test_pipeline(
 
     # 7. Story — use real randomness so probabilistic detail behavior matches production.
     story_gen = StoryGenerator()
-    story_result = story_gen(core_premise=cp_result.core_premise, spine_template=st_result.spine_template, world_bible=wb_result.world_bible)
+    story_result = story_gen(
+        core_premise=cp_result.core_premise,
+        spine_template=st_result.spine_template,
+        world_bible=world_bible,
+    )
     logger.info("Story generated.")
     logger.debug("Chapter plan preview: %.500s", story_result.chapter_plan)
     logger.debug("Story preview: %.500s", story_result.story)
@@ -295,7 +302,7 @@ def test_pipeline(
         f.write("## Spine Template\n")
         f.write(f"{st_result.spine_template}\n\n")
         f.write("## World Bible\n")
-        f.write(f"{wb_result.world_bible}\n\n")
+        f.write(f"{world_bible.full_text}\n\n")
 
         if cv_result.character_visuals:
             f.write("## Character Visuals\n\n")
@@ -395,6 +402,96 @@ def test_normalize_plot_timeline_keeps_noncontiguous_repeated_act_headings():
 
     normalized = _normalize_plot_timeline(raw_timeline)
     assert normalized == raw_timeline
+
+
+def test_world_bible_full_text_matches_legacy_markdown():
+    world_bible = WorldBible(
+        rules="Magic exacts a memory toll.",
+        characters="Mira, a reluctant archivist.",
+        locations="The glass citadel above the dunes.",
+        plot_timeline="Act 1 - Discovery",
+    )
+
+    assert world_bible.full_text == (
+        "### Rules of the World\n"
+        "Magic exacts a memory toll.\n\n"
+        "### Characters\n"
+        "Mira, a reluctant archivist.\n\n"
+        "### Locations\n"
+        "The glass citadel above the dunes.\n\n"
+        "### Plot Timeline\n"
+        "Act 1 - Discovery"
+    )
+
+
+def test_world_bible_generator_returns_structured_world_bible():
+    dspy.configure(lm=MockLM())
+    generator = WorldBibleGenerator()
+
+    result = generator(
+        core_premise="Mock premise",
+        spine_template="Mock spine",
+    )
+
+    assert isinstance(result.world_bible_structured, WorldBible)
+    assert result.world_bible_structured.rules == "Mock rules"
+    assert result.world_bible_structured.characters == "Mock characters"
+    assert result.world_bible_structured.locations == "Mock locations"
+    assert result.world_bible_structured.plot_timeline == "Mock timeline"
+    assert result.world_bible == result.world_bible_structured.full_text
+
+
+def test_story_generator_uses_structured_world_bible_fields():
+    world_bible = WorldBible(
+        rules="No one may cross salt circles after dusk.",
+        characters="Tarin the courier; Sel the exiled prince.",
+        locations="Moonwell market; the ruined observatory.",
+        plot_timeline="Act 1 - Theft\nAct 2 - Exile",
+    )
+    story_generator = StoryGenerator(random_detail_probability=0.0)
+    story_generator.generate_chapter_plan = MagicMock(
+        side_effect=[
+            SimpleNamespace(chapter_plan=["Discovery"]),
+            SimpleNamespace(chapter_plan=["Pursuit"]),
+            SimpleNamespace(chapter_plan=["Return"]),
+        ],
+    )
+    story_generator.generate_enhancers = MagicMock(
+        return_value=SimpleNamespace(enhancers_guide="Use mounting dread."),
+    )
+    story_generator.write_chapter = MagicMock(
+        side_effect=[
+            SimpleNamespace(title="Discovery", chapter_text="Chapter one text."),
+            SimpleNamespace(title="Pursuit", chapter_text="Chapter two text."),
+            SimpleNamespace(title="Return", chapter_text="Chapter three text."),
+        ],
+    )
+
+    result = story_generator(
+        core_premise="A courier steals a crown of weather.",
+        spine_template="Once upon a time...",
+        world_bible=world_bible,
+    )
+
+    assert result.chapter_plan == (
+        "Chapter 1: Discovery\n"
+        "Chapter 2: Pursuit\n"
+        "Chapter 3: Return"
+    )
+    first_plan_call = story_generator.generate_chapter_plan.call_args_list[0].kwargs
+    assert first_plan_call["characters"] == world_bible.characters
+    assert first_plan_call["plot_timeline"] == world_bible.plot_timeline
+    assert first_plan_call["rules"] == world_bible.rules
+
+    first_write_call = story_generator.write_chapter.call_args_list[0].kwargs
+    assert first_write_call["characters"] == world_bible.characters
+    assert first_write_call["rules"] == world_bible.rules
+    assert first_write_call["locations"] == world_bible.locations
+
+    enhancer_call = story_generator.generate_enhancers.call_args.kwargs
+    assert enhancer_call["world_bible"] == world_bible.full_text
+    assert "### Chapter 1: Discovery" in result.story
+    assert "### Chapter 3: Return" in result.story
 
 
 def test_question_with_answer_does_not_promote_unrelated_fields():

--- a/world_bible.py
+++ b/world_bible.py
@@ -1,0 +1,22 @@
+"""Structured world-bible model shared across the pipeline."""
+
+from pydantic import BaseModel, Field
+
+
+class WorldBible(BaseModel):
+    """Discrete world-bible sections plus a markdown rendering helper."""
+
+    rules: str = Field(description="Rules of the world and its governing systems.")
+    characters: str = Field(description="Character bios and relationship context.")
+    locations: str = Field(description="Key places and setting details.")
+    plot_timeline: str = Field(description="Plot beats organized across the story arc.")
+
+    @property
+    def full_text(self) -> str:
+        """Render the legacy markdown format used for display and export."""
+        return (
+            f"### Rules of the World\n{self.rules}\n\n"
+            f"### Characters\n{self.characters}\n\n"
+            f"### Locations\n{self.locations}\n\n"
+            f"### Plot Timeline\n{self.plot_timeline}"
+        )

--- a/world_bible_modules.py
+++ b/world_bible_modules.py
@@ -7,6 +7,7 @@ import dspy
 
 from _compat import observe
 from story_modules import QuestionWithAnswer
+from world_bible import WorldBible
 
 
 _act_heading_re = re.compile(
@@ -151,19 +152,21 @@ class WorldBibleGenerator(dspy.Module):
             locations=locations_result.locations,
         )
 
-        normalized_plot_timeline = _normalize_plot_timeline(timeline_result.plot_timeline)
-
-        world_bible = (
-            f"### Rules of the World\n{rules_result.world_rules}\n\n"
-            f"### Characters\n{characters_result.characters}\n\n"
-            f"### Locations\n{locations_result.locations}\n\n"
-            f"### Plot Timeline\n{normalized_plot_timeline}"
+        normalized_plot_timeline = _normalize_plot_timeline(
+            timeline_result.plot_timeline,
         )
-
-        return dspy.Prediction(
-            world_bible=world_bible,
-            world_rules=rules_result.world_rules,
+        world_bible = WorldBible(
+            rules=rules_result.world_rules,
             characters=characters_result.characters,
             locations=locations_result.locations,
             plot_timeline=normalized_plot_timeline,
+        )
+
+        return dspy.Prediction(
+            world_bible=world_bible.full_text,
+            world_bible_structured=world_bible,
+            world_rules=world_bible.rules,
+            characters=world_bible.characters,
+            locations=world_bible.locations,
+            plot_timeline=world_bible.plot_timeline,
         )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a shared `WorldBible` model with discrete sections and a legacy `full_text` markdown projection
- update `WorldBibleGenerator` and CLI orchestration to carry the structured world bible as the canonical artifact
- pass structured world-bible sections directly into chapter planning and chapter writing, while keeping combined text for enhancers, visuals, inpainting, and output export
- add focused tests for world-bible rendering, structured generator output, and story-generator field threading

## Testing
- `python3 -m pytest -q test_story.py`
- `python3 -m ruff check world_bible.py world_bible_modules.py main.py story_modules.py test_story.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05bf3736-4892-41bd-81b3-0a38561f57c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05bf3736-4892-41bd-81b3-0a38561f57c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

