### PR TITLE
Fix CI lint: dedupe recoverable-exception tuples

### DIFF
--- a/exceptions.py
+++ b/exceptions.py
@@ -1,0 +1,19 @@
+"""Shared exception tuples for narrowly-scoped recoverable error handling.
+
+These tuples are used to catch a defined set of "expected" runtime errors
+across pipeline modules without resorting to bare ``except Exception``.
+"""
+
+RECOVERABLE_MODEL_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    AttributeError,
+    TypeError,
+    ValueError,
+    RuntimeError,
+    KeyError,
+    IndexError,
+)
+
+RECOVERABLE_RUNTIME_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    *RECOVERABLE_MODEL_EXCEPTIONS,
+    OSError,
+)

--- a/logging_config.py
+++ b/logging_config.py
@@ -295,6 +295,7 @@ if BaseCallback is not None:
             instance: Any,
             inputs: dict[str, Any],
         ) -> None:
+            del inputs
             self._calls[call_id] = {
                 "instance": instance,
                 "t0": time.perf_counter(),
@@ -306,6 +307,7 @@ if BaseCallback is not None:
             outputs: dict[str, Any] | None,
             exception: Exception | None = None,
         ) -> None:
+            del outputs
             call_info = self._calls.pop(call_id, None)
             if exception or call_info is None:
                 return

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ from rich.console import Console
 from rich.prompt import Confirm, Prompt
 
 from dspy_optimization import try_load_optimized_module
+from exceptions import RECOVERABLE_RUNTIME_EXCEPTIONS
 from image_gen import ImageGenerator
 from logging_config import TokenUsageCallback, setup_logging
 from postprocessing import find_similar_sentences, format_report
@@ -38,17 +39,6 @@ load_dotenv()
 logger = logging.getLogger(__name__)
 
 console = Console()
-
-_RECOVERABLE_RUNTIME_EXCEPTIONS = (
-    AttributeError,
-    TypeError,
-    ValueError,
-    RuntimeError,
-    KeyError,
-    IndexError,
-    OSError,
-)
-
 
 @dataclass
 class DSPyConfig:
@@ -128,7 +118,7 @@ def configure_dspy(config: DSPyConfig) -> None:
     if os.environ.get("LANGFUSE_PUBLIC_KEY") and DSPyInstrumentor is not None:
         try:
             DSPyInstrumentor().instrument()
-        except _RECOVERABLE_RUNTIME_EXCEPTIONS as exc:
+        except RECOVERABLE_RUNTIME_EXCEPTIONS as exc:
             logger.warning("Langfuse DSPy callback handler unavailable: %s", exc)
 
     callbacks = [TokenUsageCallback()] if TokenUsageCallback is not None else []
@@ -487,7 +477,7 @@ def _generate_character_portraits(
             )
             portrait_paths[visual.name] = path
             console.print(f"  [green]Saved portrait:[/green] {path}")
-        except _RECOVERABLE_RUNTIME_EXCEPTIONS as exc:
+        except RECOVERABLE_RUNTIME_EXCEPTIONS as exc:
             logger.warning("Failed to generate portrait for %s: %s", visual.name, exc)
             console.print(
                 f"  [red]Failed to generate portrait for {visual.name}: {exc}[/red]"
@@ -633,7 +623,7 @@ def maybe_generate_scene_images(
             )
             scene_image_paths[i] = path
             console.print(f"  [green]Chapter {i} scene:[/green] {path}")
-        except _RECOVERABLE_RUNTIME_EXCEPTIONS as exc:
+        except RECOVERABLE_RUNTIME_EXCEPTIONS as exc:
             console.print(f"  [red]Failed to generate scene for chapter {i}: {exc}[/red]")
     return scene_image_paths
 

--- a/story_modules.py
+++ b/story_modules.py
@@ -9,6 +9,7 @@ import dspy
 from pydantic import BaseModel, Field, model_validator
 
 from _compat import observe
+from exceptions import RECOVERABLE_MODEL_EXCEPTIONS
 
 # Probability that a chapter receives a random creative flourish (0.0 – 1.0).
 RANDOM_DETAIL_PROBABILITY = 0.35
@@ -34,15 +35,6 @@ _ACT_SEQUENCE = [
 _chapter_heading_re = re.compile(r"^###\s+Chapter\s+\d+:.*$", re.MULTILINE)
 
 logger = logging.getLogger(__name__)
-
-_RECOVERABLE_MODEL_EXCEPTIONS = (
-    AttributeError,
-    TypeError,
-    ValueError,
-    RuntimeError,
-    KeyError,
-    IndexError,
-)
 
 # Regex to strip leading "Chapter <number>:" / "Chapter <number> -" from LLM-generated titles
 _chapter_prefix_re = re.compile(
@@ -497,7 +489,7 @@ class ChapterInpaintingGenerator(dspy.Module):
                     expanded_chapters.append((chapter_header, expanded_chapter_text))
                 else:
                     expanded_chapters.append((chapter_header, chapter_text))
-            except _RECOVERABLE_MODEL_EXCEPTIONS as exc:
+            except RECOVERABLE_MODEL_EXCEPTIONS as exc:
                 logger.warning(
                     "Chapter inpainting failed for %s: %s",
                     chapter_header,
@@ -548,7 +540,7 @@ class StoryGenerator(dspy.Module):
                 detail_type=detail_type,
             )
             return result.random_detail
-        except _RECOVERABLE_MODEL_EXCEPTIONS as exc:
+        except RECOVERABLE_MODEL_EXCEPTIONS as exc:
             logger.warning("Failed to generate random detail: %s", exc)
             return ""
 
@@ -625,7 +617,7 @@ class StoryGenerator(dspy.Module):
 
                 full_story += f"\n\n### Chapter {index}: {clean_title}\n\n{result.chapter_text}"
                 previous_chapters_summary += f"Chapter {index}: {chapter_desc}\n"
-            except _RECOVERABLE_MODEL_EXCEPTIONS as exc:
+            except RECOVERABLE_MODEL_EXCEPTIONS as exc:
                 logger.error("Error writing chapter %d: %s", index, exc, exc_info=True)
                 break
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

CI on `main` is failing in the **Pylint (design smells)** step:

```
postprocessing.py:1:0: R0801: Similar lines in 2 files
==main:[42:48]
==story_modules:[38:44]
    AttributeError,
    TypeError,
    ValueError,
    RuntimeError,
    KeyError,
    IndexError, (duplicate-code)
Your code has been rated at 9.99/10
##[error]Process completed with exit code 8.
```

The 6-line `_RECOVERABLE_*_EXCEPTIONS` tuple was declared verbatim in both `main.py` (as `_RECOVERABLE_RUNTIME_EXCEPTIONS`, with an extra trailing `OSError`) and `story_modules.py` (as `_RECOVERABLE_MODEL_EXCEPTIONS`). Pylint's `R0801` (duplicate-code) checker detected the identical 6-line block and dropped the score below `10.00`, which the CI `pylint` invocation treats as failure.

Because pylint failed, the subsequent CI steps (radon, vulture) were skipped — but vulture would also have failed on two unused-but-required DSPy callback parameters (`inputs`, `outputs`) introduced by the recent `TokenUsageCallback` change.

## Changes

1. **New module `exceptions.py`** holds both shared tuples in one place:
   - `RECOVERABLE_MODEL_EXCEPTIONS` — the base set used by `story_modules`.
   - `RECOVERABLE_RUNTIME_EXCEPTIONS` — `RECOVERABLE_MODEL_EXCEPTIONS + (OSError,)`, used by `main` for I/O-bearing pipeline phases.

2. **`main.py`** imports `RECOVERABLE_RUNTIME_EXCEPTIONS` and the local definition is removed; all three `except` sites updated.

3. **`story_modules.py`** imports `RECOVERABLE_MODEL_EXCEPTIONS` and the local definition is removed; all three `except` sites updated.

4. **`logging_config.py`** — silence the (then-newly-reachable) vulture warnings on `TokenUsageCallback.on_lm_start.inputs` and `on_lm_end.outputs`. Both parameters are part of the DSPy `BaseCallback` signature and must be accepted as keyword arguments, but neither was being read — added `del inputs` / `del outputs` to make the intent explicit.

## Verification

All four CI lint steps now pass locally (Python 3.11 / requirements-dev.txt):

```
ruff check .                                                    # All checks passed!
pylint main.py story_modules.py world_bible_modules.py postprocessing.py
                                                                # Your code has been rated at 10.00/10
radon cc . -s -n C --exclude ".venv/*" --no-assert              # exit 0
vulture . --min-confidence 80 --exclude .venv                   # exit 0
pytest -q                                                       # 43 passed
```

No behavioural changes — the exception tuples and callback semantics are identical, only their location moved.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-663bbc97-5182-4f99-9e9a-65434c9de2a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-663bbc97-5182-4f99-9e9a-65434c9de2a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

