### PR TITLE
Wire ChapterSummarizer into rolling previous_chapters_summary (#54)

### DIFF
--- a/story_modules.py
+++ b/story_modules.py
@@ -15,6 +15,14 @@ from world_bible import WorldBible
 # Probability that a chapter receives a random creative flourish (0.0 – 1.0).
 RANDOM_DETAIL_PROBABILITY = 0.35
 
+# Max characters kept when the chapter-summary LLM call fails and we fall back
+# to a simple truncation of the chapter text.
+SUMMARY_FALLBACK_MAX_CHARS = 600
+
+# Default number of paragraphs from the immediately prior chapter kept verbatim
+# in the rolling context. 0 disables the verbatim tail entirely.
+DEFAULT_VERBATIM_TAIL_PARAGRAPHS = 0
+
 # The kinds of random detail the LLM can be asked to invent.
 _RANDOM_DETAIL_TYPES = [
     "an unusually long and vivid description of a piece of scenery or environment",
@@ -91,6 +99,37 @@ def _split_story_into_chapters(story_text: str) -> list[tuple[str, str]]:
         chapters.append((header, body))
 
     return chapters
+
+
+def _truncate_chapter_for_summary(
+    chapter_text: str,
+    max_chars: int = SUMMARY_FALLBACK_MAX_CHARS,
+) -> str:
+    """Build a short fallback summary by truncating chapter prose at a word boundary."""
+    text = (chapter_text or "").strip()
+    if not text:
+        return ""
+    if len(text) <= max_chars:
+        return text
+    snippet = text[:max_chars]
+    cut = snippet.rfind(" ")
+    if cut > 0:
+        snippet = snippet[:cut]
+    return snippet.rstrip() + "…"
+
+
+def _extract_trailing_paragraphs(chapter_text: str, paragraphs: int) -> str:
+    """Return the last ``paragraphs`` paragraphs of ``chapter_text`` verbatim."""
+    if paragraphs <= 0:
+        return ""
+    text = (chapter_text or "").strip()
+    if not text:
+        return ""
+    parts = [p.strip() for p in re.split(r"\n\s*\n", text) if p.strip()]
+    if not parts:
+        return ""
+    tail = parts[-paragraphs:]
+    return "\n\n".join(tail)
 
 
 def _compose_story_from_chapters(chapters: list[tuple[str, str]]) -> str:
@@ -398,6 +437,40 @@ class GenerateRandomDetailSignature(dspy.Signature):
     )
 
 
+class GenerateChapterSummarySignature(dspy.Signature):
+    """Summarize a written chapter in 2-3 sentences for rolling context."""
+
+    current_chapter_description: str = dspy.InputField(
+        desc="The chapter plan bullet that the chapter was written from.",
+    )
+    chapter_text: str = dspy.InputField(
+        desc="The full prose of the chapter that was just written.",
+    )
+    chapter_summary: str = dspy.OutputField(
+        desc=(
+            "A 2-3 sentence factual summary of what actually happened in this "
+            "chapter. Prefer concrete events, named characters, and state "
+            "changes over theme or tone. No spoilers beyond this chapter."
+        ),
+    )
+
+
+class ChapterSummarizer(dspy.Module):
+    """Produce a short factual summary of a written chapter."""
+
+    def __init__(self):
+        super().__init__()
+        self.summarize = dspy.Predict(GenerateChapterSummarySignature)
+
+    @observe()
+    def forward(self, current_chapter_description: str, chapter_text: str):
+        """Summarize a written chapter in 2-3 sentences."""
+        return self.summarize(
+            current_chapter_description=current_chapter_description,
+            chapter_text=chapter_text,
+        )
+
+
 class GenerateSingleChapterSignature(dspy.Signature):
     """Writes a full, detailed chapter based on the world bible and the specific chapter goal."""
     characters: str = dspy.InputField(
@@ -523,17 +596,75 @@ class ChapterInpaintingGenerator(dspy.Module):
 class StoryGenerator(dspy.Module):
     """Generate chapter plans, enhancer guidance, and full story chapters."""
 
-    def __init__(self, random_detail_probability: float = RANDOM_DETAIL_PROBABILITY):
+    def __init__(
+        self,
+        random_detail_probability: float = RANDOM_DETAIL_PROBABILITY,
+        verbatim_tail_paragraphs: int = DEFAULT_VERBATIM_TAIL_PARAGRAPHS,
+    ):
         if not 0.0 <= random_detail_probability <= 1.0:
             raise ValueError(
                 f"random_detail_probability must be in [0.0, 1.0], got {random_detail_probability}"
             )
+        if verbatim_tail_paragraphs < 0:
+            raise ValueError(
+                f"verbatim_tail_paragraphs must be >= 0, got {verbatim_tail_paragraphs}"
+            )
         super().__init__()
         self.random_detail_probability = random_detail_probability
+        self.verbatim_tail_paragraphs = verbatim_tail_paragraphs
         self.generate_chapter_plan = dspy.ChainOfThought(GenerateChapterPlanSignature)
         self.generate_enhancers = dspy.ChainOfThought(GenerateEnhancersSignature)
         self.generate_random_detail = dspy.Predict(GenerateRandomDetailSignature)
         self.write_chapter = dspy.ChainOfThought(GenerateSingleChapterSignature)
+        self.summarize_chapter = ChapterSummarizer()
+
+    def _summarize_written_chapter(
+        self,
+        current_chapter_description: str,
+        chapter_text: str,
+    ) -> str:
+        """Summarize a written chapter; fall back to truncation on recoverable LLM errors."""
+        try:
+            result = self.summarize_chapter(
+                current_chapter_description=current_chapter_description,
+                chapter_text=chapter_text,
+            )
+            summary = (getattr(result, "chapter_summary", "") or "").strip()
+            if summary:
+                return summary
+            logger.warning(
+                "Chapter summarizer returned empty output; falling back to truncation."
+            )
+        except RECOVERABLE_MODEL_EXCEPTIONS as exc:
+            logger.warning(
+                "Chapter summarizer failed (%s); falling back to truncation.",
+                exc,
+            )
+        return _truncate_chapter_for_summary(chapter_text)
+
+    def _compose_rolling_summary(
+        self,
+        previous_summary_entries: list[str],
+        latest_entry: str,
+        latest_chapter_text: str,
+    ) -> str:
+        """Build the rolling previous-chapters summary, optionally with a verbatim tail."""
+        entries = [*previous_summary_entries, latest_entry]
+        summary_block = "\n".join(entry for entry in entries if entry).strip()
+
+        tail = _extract_trailing_paragraphs(
+            latest_chapter_text,
+            self.verbatim_tail_paragraphs,
+        )
+        if not tail:
+            return summary_block + ("\n" if summary_block else "")
+
+        verbatim_block = (
+            "Verbatim ending of previous chapter (for tone/continuity):\n"
+            f"{tail}"
+        )
+        combined = "\n\n".join(part for part in (summary_block, verbatim_block) if part)
+        return combined + "\n"
 
     def _maybe_generate_random_detail(self, world_bible: str, chapter_desc: str) -> str:
         """Roll the dice and, if triggered, generate a contextual creative flourish."""
@@ -609,6 +740,7 @@ class StoryGenerator(dspy.Module):
     ) -> str:
         full_story = ""
         previous_chapters_summary = ""
+        previous_summary_entries: list[str] = []
 
         for index, chapter_desc in enumerate(chapters_to_write, start=1):
             try:
@@ -640,7 +772,18 @@ class StoryGenerator(dspy.Module):
                     clean_title = _clean_chapter_title(chapter_desc)
 
                 full_story += f"\n\n### Chapter {index}: {clean_title}\n\n{result.chapter_text}"
-                previous_chapters_summary += f"Chapter {index}: {chapter_desc}\n"
+
+                chapter_summary = self._summarize_written_chapter(
+                    current_chapter_description=chapter_desc,
+                    chapter_text=result.chapter_text,
+                )
+                summary_block = f"Chapter {index} ({chapter_desc}): {chapter_summary}".rstrip()
+                previous_chapters_summary = self._compose_rolling_summary(
+                    previous_summary_entries=previous_summary_entries,
+                    latest_entry=summary_block,
+                    latest_chapter_text=result.chapter_text,
+                )
+                previous_summary_entries.append(summary_block)
             except RECOVERABLE_MODEL_EXCEPTIONS as exc:
                 logger.error("Error writing chapter %d: %s", index, exc, exc_info=True)
                 break

--- a/test_story.py
+++ b/test_story.py
@@ -12,6 +12,7 @@ from logging_config import TokenUsageCallback, setup_logging
 from main import initialize_text_generators
 from story_modules import (
     ChapterInpaintingGenerator,
+    ChapterSummarizer,
     CharacterVisual,
     CharacterVisualDescriber,
     CorePremiseGenerator,
@@ -20,6 +21,8 @@ from story_modules import (
     SceneImagePromptGenerator,
     SpineTemplateGenerator,
     StoryGenerator,
+    _extract_trailing_paragraphs,
+    _truncate_chapter_for_summary,
 )
 from world_bible import WorldBible
 from world_bible_modules import WorldBibleGenerator
@@ -52,6 +55,12 @@ class MockLM(dspy.LM):
             return ['```json\n{"character_visuals": [{"name": "Mock Hero", "reference_mix": "a mix of Guts from Berserk and Zuko from Avatar", "distinguishing_features": "short black hair, amber eyes, burn scar on left cheek, dark leather armor", "full_prompt": "anime portrait, a mix of Guts from Berserk and Zuko from Avatar, short black hair, amber eyes, burn scar on left cheek, dark leather armor"}]}\n```']
         if "[[ ## image_prompt ## ]]" in content or ('"image_prompt"' in content and "anime scene" in content):
             return ['```json\n{"image_prompt": "anime scene, a warrior with short black hair and amber eyes standing in a dark cathedral, dramatic lighting"}\n```']
+        if "[[ ## chapter_summary ## ]]" in content or (
+            '"chapter_summary"' in content and "factual summary" in content
+        ):
+            return [
+                '```json\n{"chapter_summary": "Mock chapter summary covering events and named characters."}\n```'
+            ]
         if (
             "[[ ## chapter_text ## ]]" in content
             or ('"chapter_text"' in content and "immersive chapter" in content)
@@ -432,6 +441,13 @@ def test_story_generator_uses_structured_world_bible_fields():
             SimpleNamespace(title="Return", chapter_text="Chapter three text."),
         ],
     )
+    story_generator.summarize_chapter = MagicMock(
+        side_effect=[
+            SimpleNamespace(chapter_summary="Discovery summary."),
+            SimpleNamespace(chapter_summary="Pursuit summary."),
+            SimpleNamespace(chapter_summary="Return summary."),
+        ],
+    )
 
     result = story_generator(
         core_premise="A courier steals a crown of weather.",
@@ -458,6 +474,195 @@ def test_story_generator_uses_structured_world_bible_fields():
     assert enhancer_call["world_bible"] == world_bible.full_text
     assert "### Chapter 1: Discovery" in result.story
     assert "### Chapter 3: Return" in result.story
+
+
+def test_chapter_summarizer_instantiates():
+    summarizer = ChapterSummarizer()
+    assert summarizer is not None
+
+
+def test_chapter_summarizer_forward_returns_chapter_summary():
+    dspy.configure(lm=MockLM())
+    summarizer = ChapterSummarizer()
+
+    result = summarizer(
+        current_chapter_description="Chapter 7: Kael infiltrates the cathedral archive.",
+        chapter_text=(
+            "Kael entered the cathedral archive before dawn and found the reliquary key. "
+            "Sister Mara confronted him and admitted the Church orchestrated the recent attacks. "
+            "After a fight in the nave, Mara escaped with a fragment while Kael kept the key."
+        ),
+    )
+
+    assert hasattr(result, "chapter_summary")
+    assert isinstance(result.chapter_summary, str)
+    assert result.chapter_summary.strip()
+
+
+def test_truncate_chapter_for_summary_word_boundary():
+    text = "alpha bravo charlie delta echo foxtrot golf hotel india juliet"
+    out = _truncate_chapter_for_summary(text, max_chars=20)
+    assert out.endswith("…")
+    assert " " not in out[-2:]
+    assert len(out) <= 21
+
+
+def test_truncate_chapter_for_summary_short_text_unchanged():
+    assert _truncate_chapter_for_summary("short text", max_chars=100) == "short text"
+
+
+def test_extract_trailing_paragraphs_returns_last_n():
+    text = "Para one line.\n\nPara two line.\n\nPara three line."
+    out = _extract_trailing_paragraphs(text, 2)
+    assert out == "Para two line.\n\nPara three line."
+
+
+def test_extract_trailing_paragraphs_zero_disables():
+    assert _extract_trailing_paragraphs("anything here", 0) == ""
+
+
+def test_story_generator_wires_summarizer_into_previous_chapters_summary():
+    world_bible = WorldBible(
+        rules="Rules.",
+        characters="Tarin; Sel.",
+        locations="Moonwell; observatory.",
+        plot_timeline="Act 1 - Theft",
+    )
+    story_generator = StoryGenerator(random_detail_probability=0.0)
+    story_generator.generate_chapter_plan = MagicMock(
+        side_effect=[
+            SimpleNamespace(chapter_plan=["Discovery"]),
+            SimpleNamespace(chapter_plan=["Pursuit"]),
+            SimpleNamespace(chapter_plan=[]),
+        ],
+    )
+    story_generator.generate_enhancers = MagicMock(
+        return_value=SimpleNamespace(enhancers_guide="guide"),
+    )
+    story_generator.write_chapter = MagicMock(
+        side_effect=[
+            SimpleNamespace(title="Discovery", chapter_text="Chapter one prose."),
+            SimpleNamespace(title="Pursuit", chapter_text="Chapter two prose."),
+        ],
+    )
+    story_generator.summarize_chapter = MagicMock(
+        side_effect=[
+            SimpleNamespace(chapter_summary="Tarin finds the reliquary."),
+            SimpleNamespace(chapter_summary="Sel pursues Tarin across the dunes."),
+        ],
+    )
+
+    story_generator(
+        core_premise="premise",
+        spine_template="spine",
+        world_bible=world_bible,
+    )
+
+    assert story_generator.summarize_chapter.call_count == 2
+    first_summary_call = story_generator.summarize_chapter.call_args_list[0].kwargs
+    assert first_summary_call["chapter_text"] == "Chapter one prose."
+
+    second_write_call = story_generator.write_chapter.call_args_list[1].kwargs
+    prior = second_write_call["previous_chapters_summary"]
+    assert "Tarin finds the reliquary." in prior
+    assert "Chapter one prose." not in prior
+
+
+def test_story_generator_summary_falls_back_on_recoverable_error():
+    world_bible = WorldBible(
+        rules="Rules.",
+        characters="Tarin.",
+        locations="Moonwell.",
+        plot_timeline="Act 1 - Theft",
+    )
+    story_generator = StoryGenerator(random_detail_probability=0.0)
+    story_generator.generate_chapter_plan = MagicMock(
+        side_effect=[
+            SimpleNamespace(chapter_plan=["Discovery"]),
+            SimpleNamespace(chapter_plan=[]),
+            SimpleNamespace(chapter_plan=[]),
+        ],
+    )
+    story_generator.generate_enhancers = MagicMock(
+        return_value=SimpleNamespace(enhancers_guide="guide"),
+    )
+    long_text = "word " * 400
+    story_generator.write_chapter = MagicMock(
+        side_effect=[
+            SimpleNamespace(title="Discovery", chapter_text=long_text),
+            SimpleNamespace(title="Next", chapter_text="Second chapter prose."),
+        ],
+    )
+    story_generator.summarize_chapter = MagicMock(side_effect=RuntimeError("LM blew up"))
+
+    # Add a second chapter plan entry so we can inspect the next write_chapter call's
+    # previous_chapters_summary.
+    story_generator.generate_chapter_plan = MagicMock(
+        side_effect=[
+            SimpleNamespace(chapter_plan=["Discovery", "Next"]),
+            SimpleNamespace(chapter_plan=[]),
+            SimpleNamespace(chapter_plan=[]),
+        ],
+    )
+
+    story_generator(
+        core_premise="premise",
+        spine_template="spine",
+        world_bible=world_bible,
+    )
+
+    assert story_generator.summarize_chapter.call_count >= 1
+    second_write_call = story_generator.write_chapter.call_args_list[1].kwargs
+    prior = second_write_call["previous_chapters_summary"]
+    assert prior.strip()
+    assert prior.endswith("…\n") or prior.rstrip().endswith("…")
+
+
+def test_story_generator_verbatim_tail_prepends_previous_chapter_ending():
+    world_bible = WorldBible(
+        rules="Rules.",
+        characters="Tarin.",
+        locations="Moonwell.",
+        plot_timeline="Act 1",
+    )
+    story_generator = StoryGenerator(
+        random_detail_probability=0.0,
+        verbatim_tail_paragraphs=1,
+    )
+    story_generator.generate_chapter_plan = MagicMock(
+        side_effect=[
+            SimpleNamespace(chapter_plan=["Discovery", "Next"]),
+            SimpleNamespace(chapter_plan=[]),
+            SimpleNamespace(chapter_plan=[]),
+        ],
+    )
+    story_generator.generate_enhancers = MagicMock(
+        return_value=SimpleNamespace(enhancers_guide="guide"),
+    )
+    story_generator.write_chapter = MagicMock(
+        side_effect=[
+            SimpleNamespace(
+                title="Discovery",
+                chapter_text="First paragraph.\n\nSecond paragraph ends the chapter.",
+            ),
+            SimpleNamespace(title="Next", chapter_text="Second chapter prose."),
+        ],
+    )
+    story_generator.summarize_chapter = MagicMock(
+        return_value=SimpleNamespace(chapter_summary="Discovery summary."),
+    )
+
+    story_generator(
+        core_premise="premise",
+        spine_template="spine",
+        world_bible=world_bible,
+    )
+
+    second_write_call = story_generator.write_chapter.call_args_list[1].kwargs
+    prior = second_write_call["previous_chapters_summary"]
+    assert "Discovery summary." in prior
+    assert "Second paragraph ends the chapter." in prior
+    assert "First paragraph." not in prior
 
 
 def test_question_with_answer_does_not_promote_unrelated_fields():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the misleading `previous_chapters_summary += f"Chapter {index}: {chapter_desc}\n"` line in `StoryGenerator._write_story_chapters` with a real per-chapter LLM summary of the *written* prose, threaded back into the next chapter's rolling context.

Addresses the "real rolling summary" bullet in #54.

## Changes

- `story_modules.py`
  - Add `GenerateChapterSummarySignature` + `ChapterSummarizer` module (`dspy.Predict`-based, `@observe()`-instrumented).
  - `StoryGenerator.__init__` now owns a `ChapterSummarizer` instance (`self.summarize_chapter`) and accepts an optional `verbatim_tail_paragraphs: int = 0`.
  - New `_summarize_written_chapter(...)` helper: calls the summarizer, and on `RECOVERABLE_MODEL_EXCEPTIONS` (or empty output) falls back to a word-boundary truncation of the chapter text (`SUMMARY_FALLBACK_MAX_CHARS = 600`). Chapter writing never hard-fails because summarization failed.
  - New `_compose_rolling_summary(...)` helper: joins prior summary entries with the latest, and optionally appends the last *N* paragraphs of the immediately prior chapter verbatim under a clearly labeled block (for tone / cliffhanger continuity).
  - Module-level helpers `_truncate_chapter_for_summary` and `_extract_trailing_paragraphs` for easy unit testing.
  - `_write_story_chapters` now builds `previous_chapters_summary` from real summaries instead of replaying plan descriptions.

- `test_story.py`
  - `MockLM` gets a `chapter_summary` branch.
  - `test_story_generator_uses_structured_world_bible_fields` mocks the new `summarize_chapter` alongside the existing `write_chapter` mock.
  - New tests:
    - `test_chapter_summarizer_instantiates`
    - `test_chapter_summarizer_forward_returns_chapter_summary`
    - `test_truncate_chapter_for_summary_word_boundary`
    - `test_truncate_chapter_for_summary_short_text_unchanged`
    - `test_extract_trailing_paragraphs_returns_last_n`
    - `test_extract_trailing_paragraphs_zero_disables`
    - `test_story_generator_wires_summarizer_into_previous_chapters_summary`
    - `test_story_generator_summary_falls_back_on_recoverable_error`
    - `test_story_generator_verbatim_tail_prepends_previous_chapter_ending`

## Overlap with #75

PR #75 ("Add ChapterSummarizer DSPy module (partial #54)") adds the same `GenerateChapterSummarySignature` / `ChapterSummarizer` classes but explicitly leaves `_write_story_chapters` untouched. This PR adds the pipeline wiring plus the truncation fallback and optional verbatim-tail features that #75 scoped out.

The signature/module shapes here match #75 byte-for-byte (same field names, same `dspy.Predict` usage, same `@observe()` decorator, same `forward(current_chapter_description, chapter_text)` signature), so whichever PR lands first the other should merge cleanly after dropping the duplicate class definitions. The matching `ChapterSummarizer` unit tests (`test_chapter_summarizer_instantiates`, `test_chapter_summarizer_forward_returns_chapter_summary`) are also intentionally identical.

## Validation

- `pytest -q` → 55 passed (was 46 on main, +9 new tests).
- `ruff check story_modules.py test_story.py` → clean.
- `ruff format --check` preexisting drift on `story_modules.py` / `test_story.py` is unchanged (not reformatting here to keep the diff minimal and avoid conflicts with #75).

Relates to #54.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e087a78-9f14-4be6-ba74-1c831f5ccdcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e087a78-9f14-4be6-ba74-1c831f5ccdcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

