### PR TITLE
Add multi-agent story simulation engine (TRPG-style)

### DIFF
--- a/sim_main.py
+++ b/sim_main.py
@@ -11,8 +11,7 @@ from dotenv import load_dotenv
 from rich.console import Console
 from rich.prompt import Confirm, Prompt
 
-from logging_config import setup_logging
-from main import DSPyConfig, configure_dspy
+from story_sim.config import DSPyConfig, configure_dspy, setup_logging
 from story_sim.engine import SimulationEngine
 from story_sim.models import RoundRecord, SimulationState
 

--- a/sim_main.py
+++ b/sim_main.py
@@ -1,0 +1,242 @@
+"""CLI entry point for the multi-agent story simulation."""
+
+import argparse
+import logging
+import os
+from argparse import Namespace
+from collections.abc import Sequence
+from typing import Any
+
+from dotenv import load_dotenv
+from rich.console import Console
+from rich.prompt import Confirm, Prompt
+
+from logging_config import setup_logging
+from main import DSPyConfig, configure_dspy
+from story_sim.engine import SimulationEngine
+from story_sim.models import RoundRecord, SimulationState
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+MAX_CHARACTERS = 4
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser for simulation mode."""
+    parser = argparse.ArgumentParser(
+        description="Multi-Agent Story Simulation (TRPG-style)",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=os.environ.get("MODEL", "openai/gpt-4o-mini"),
+        help="The language model to use. Defaults to MODEL env var.",
+    )
+    parser.add_argument(
+        "--llm-url",
+        type=str,
+        default=os.environ.get("LLM_URL"),
+        help="Custom API base URL. Defaults to LLM_URL env var.",
+    )
+    parser.add_argument(
+        "--api-key",
+        type=str,
+        default=os.environ.get("API_KEY"),
+        help="API key for the model. Defaults to API_KEY env var.",
+    )
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=8000,
+        help="Maximum tokens per LLM call. Defaults to 8000.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=".tmp",
+        help="Directory to save generated content. Defaults to '.tmp'.",
+    )
+    parser.add_argument(
+        "--cache",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable/disable DSPy disk cache.",
+    )
+    parser.add_argument(
+        "--memory-cache",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable/disable DSPy in-memory cache.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=str,
+        default=os.environ.get("DSPY_CACHE_DIR"),
+        help="Override DSPy disk cache directory.",
+    )
+    parser.add_argument(
+        "--log-file",
+        type=str,
+        default=os.environ.get("LOG_FILE", ".tmp/sim_debug.log"),
+        help="Path to write detailed logs.",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Logging verbosity: -v INFO, -vv LLM debug, -vvv firehose.",
+    )
+    return parser
+
+
+def setup_runtime(args: Namespace) -> None:
+    """Configure logging and DSPy runtime from CLI arguments."""
+    setup_logging(verbosity=args.verbose, log_file=args.log_file)
+    config = DSPyConfig(
+        model_name=args.model,
+        api_base=args.llm_url,
+        api_key=args.api_key,
+        max_tokens=args.max_tokens,
+        cache=args.cache,
+        memory_cache=args.memory_cache,
+        cache_dir=args.cache_dir,
+    )
+    configure_dspy(config)
+
+
+def get_answers_for_questions(questions: Sequence[Any]) -> str:
+    """Collect accepted or user-edited answers for GM questions."""
+    qa_pairs = []
+    for i, qa in enumerate(questions):
+        console.print(f"\n[bold cyan]Question {i + 1}:[/bold cyan] {qa.question}")
+        console.print(
+            f"[bold green]Proposed Answer:[/bold green] {qa.proposed_answer}",
+        )
+        accept = Confirm.ask("Accept this proposed answer?")
+        answer = qa.proposed_answer if accept else Prompt.ask("Enter your answer")
+        qa_pairs.append(f"Q: {qa.question}\nA: {answer}")
+    return "\n\n".join(qa_pairs)
+
+
+def collect_user_input() -> tuple[str, int]:
+    """Collect the story idea and character count from the user."""
+    idea = Prompt.ask(
+        "\n[bold yellow]What is your story idea?[/bold yellow]",
+    )
+    num_characters = int(
+        Prompt.ask(
+            "[bold yellow]How many characters? (2-4)[/bold yellow]",
+            default="3",
+        ),
+    )
+    num_characters = max(2, min(num_characters, MAX_CHARACTERS))
+    return idea, num_characters
+
+
+def run_setup_phase(
+    engine: SimulationEngine,
+    idea: str,
+    num_characters: int,
+) -> SimulationState:
+    """Run GM setup: questions -> world -> characters -> plot outline."""
+    console.print("\n[italic]GM is preparing clarifying questions...[/italic]")
+    q_result = engine.gm_setup.generate_questions(
+        idea=idea,
+        num_characters=num_characters,
+    )
+    qa_context = get_answers_for_questions(q_result.questions)
+
+    console.print("\n[italic]GM is building the world...[/italic]")
+    state = engine.setup(
+        idea=idea,
+        qa_context=qa_context,
+        num_characters=num_characters,
+    )
+
+    console.print("\n[bold green]--- World ---[/bold green]")
+    console.print(f"[bold]Setting:[/bold] {state.world.setting}")
+    console.print(f"[bold]Genre:[/bold] {state.world.genre}")
+    console.print(f"[bold]Tone:[/bold] {state.world.tone}")
+
+    console.print("\n[bold cyan]--- Characters ---[/bold cyan]")
+    for char in state.characters:
+        console.print(f"\n[bold]{char.name}[/bold] ({char.role})")
+        console.print(f"  {char.personality}")
+        console.print(f"  Goals: {', '.join(char.goals)}")
+
+    console.print("\n[dim]Plot outline generated (GM-private).[/dim]")
+    return state
+
+
+def print_round_progress(record: RoundRecord) -> None:
+    """Print a brief progress line for each completed round."""
+    console.print(
+        f"  [dim]Round {record.round_number} (Ch.{record.chapter_number}): "
+        f"{record.resolution.pacing.value}[/dim]",
+    )
+
+
+def save_simulation_output(
+    output_dir: str,
+    story: str,
+    state: SimulationState,
+) -> str:
+    """Write the generated story to a markdown file."""
+    os.makedirs(output_dir, exist_ok=True)
+    output_path = os.path.join(output_dir, "sim_story_output.md")
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write("# Simulated Story\n\n")
+        f.write(f"**Genre:** {state.world.genre}\n")
+        f.write(f"**Tone:** {state.world.tone}\n")
+        f.write(f"**Setting:** {state.world.setting}\n\n")
+        f.write("## Characters\n\n")
+        for char in state.characters:
+            f.write(f"- **{char.name}** ({char.role}): {char.personality}\n")
+        f.write(f"\n---\n\n{story}\n")
+
+    return output_path
+
+
+def main() -> None:
+    """Run the multi-agent story simulation CLI."""
+    parser = build_arg_parser()
+    args = parser.parse_args()
+    setup_runtime(args)
+
+    console.print(
+        "[bold magenta]Multi-Agent Story Simulation[/bold magenta]",
+    )
+    console.print(
+        "[dim]TRPG-style story generation with GM, Characters, and Narrator[/dim]\n"
+    )
+
+    idea, num_characters = collect_user_input()
+    engine = SimulationEngine()
+    state = run_setup_phase(engine, idea, num_characters)
+
+    Confirm.ask(
+        "\nReady to begin the simulation? Press Enter to start",
+        default=True,
+        show_default=False,
+    )
+
+    console.print("\n[bold magenta]--- Simulation Running ---[/bold magenta]")
+    story = engine.run(state, on_round=print_round_progress)
+
+    console.print("\n[bold red]--- Generated Story ---[/bold red]")
+    console.print(story)
+
+    output_path = save_simulation_output(args.output_dir, story, state)
+    console.print(
+        f"\n[bold magenta]Simulation complete! "
+        f"Story saved to {output_path}[/bold magenta]",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/story_sim/__init__.py
+++ b/story_sim/__init__.py
@@ -1,0 +1,17 @@
+"""Multi-agent story simulation through TRPG-style role-based generation."""
+
+from story_sim.engine import SimulationEngine
+from story_sim.models import (
+    CharacterSheet,
+    SimulationConfig,
+    SimulationState,
+    WorldState,
+)
+
+__all__ = [
+    "CharacterSheet",
+    "SimulationConfig",
+    "SimulationEngine",
+    "SimulationState",
+    "WorldState",
+]

--- a/story_sim/_compat.py
+++ b/story_sim/_compat.py
@@ -1,0 +1,11 @@
+"""Compatibility shims for optional dependencies."""
+
+try:
+    from langfuse import observe
+except ImportError:
+
+    def observe():  # type: ignore[misc]
+        def decorator(fn):  # type: ignore[no-untyped-def]
+            return fn
+
+        return decorator

--- a/story_sim/agents.py
+++ b/story_sim/agents.py
@@ -1,0 +1,373 @@
+"""DSPy agent modules for GM, Character, and Narrator roles."""
+
+import logging
+from typing import List
+
+import dspy
+
+from _compat import observe
+from story_sim.models import (
+    CharacterAction,
+    CharacterSheet,
+    ClarifyingQuestion,
+    RoundResolution,
+    SceneContext,
+    WorldState,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# GM Setup Signatures
+# ---------------------------------------------------------------------------
+
+
+class GenerateClarifyingQuestionsSignature(dspy.Signature):
+    """Generate clarifying questions to understand the user's story idea.
+
+    You are a Game Master preparing a TRPG-style story simulation.
+    Ask questions about genre, tone, themes, scope, and character dynamics.
+    """
+
+    idea: str = dspy.InputField(desc="The user's initial story idea.")
+    num_characters: int = dspy.InputField(
+        desc="How many player characters the user wants.",
+    )
+    questions: List[ClarifyingQuestion] = dspy.OutputField(
+        desc="3-5 clarifying questions about genre, tone, themes, and scope.",
+    )
+
+
+class GenerateWorldStateSignature(dspy.Signature):
+    """Create the initial world state for a TRPG-style story simulation.
+
+    Build a coherent world with locations, factions, and rules that
+    support the story idea and the number of characters involved.
+    """
+
+    idea: str = dspy.InputField(desc="The user's story idea.")
+    qa_context: str = dspy.InputField(
+        desc="Answers to clarifying questions.",
+    )
+    num_characters: int = dspy.InputField(
+        desc="Number of player characters to create.",
+    )
+    world: WorldState = dspy.OutputField(desc="The initial world state.")
+
+
+class GenerateCharactersSignature(dspy.Signature):
+    """Create character sheets for the story simulation.
+
+    Each character must have distinct personality, goals, and at least one
+    secret. Relationships between characters should create natural tension
+    and potential for interesting interactions.
+    """
+
+    idea: str = dspy.InputField(desc="The user's story idea.")
+    qa_context: str = dspy.InputField(
+        desc="Answers to clarifying questions.",
+    )
+    world: str = dspy.InputField(desc="The world state description.")
+    num_characters: int = dspy.InputField(
+        desc="Number of characters to create.",
+    )
+    characters: List[CharacterSheet] = dspy.OutputField(
+        desc="Character sheets with distinct personalities, goals, and relationships.",
+    )
+
+
+class GeneratePlotOutlineSignature(dspy.Signature):
+    """Create a private plot compass for the GM to guide pacing.
+
+    This outline is flexible — a compass, not a railroad. Include an
+    inciting incident, key tension points, conditions that should trigger
+    the climax, and a general resolution direction.
+    """
+
+    idea: str = dspy.InputField(desc="The user's story idea.")
+    world: str = dspy.InputField(desc="The world state.")
+    characters: str = dspy.InputField(desc="Summary of all characters.")
+    plot_outline: str = dspy.OutputField(
+        desc=(
+            "A loose plot outline: inciting incident, rising action beats, "
+            "climax trigger conditions, and resolution direction."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Simulation Round Signatures
+# ---------------------------------------------------------------------------
+
+
+class SetSceneSignature(dspy.Signature):
+    """GM sets the scene for the next round of the simulation.
+
+    Consider the plot outline and pacing hint to decide what scene would
+    best advance the story. Include which characters are present and what
+    tensions or opportunities exist.
+    """
+
+    world_state: str = dspy.InputField(desc="Current world state.")
+    plot_outline: str = dspy.InputField(desc="GM's private plot compass.")
+    recent_events: str = dspy.InputField(desc="Summary of recent rounds.")
+    current_chapter: int = dspy.InputField(desc="Current chapter number.")
+    pacing_hint: str = dspy.InputField(
+        desc="Current story phase (setup, rising, climax, etc.).",
+    )
+    scene: SceneContext = dspy.OutputField(
+        desc="The scene description for this round.",
+    )
+
+
+class CharacterActSignature(dspy.Signature):
+    """A character decides their action in the current scene.
+
+    Stay in character. Act based on your personality, goals, and what you
+    know. You may not know everything that's happening — act on your own
+    knowledge and perspective only.
+    """
+
+    character_sheet: str = dspy.InputField(
+        desc="This character's full sheet.",
+    )
+    scene_description: str = dspy.InputField(
+        desc="The current scene as described by the GM.",
+    )
+    personal_memory: str = dspy.InputField(
+        desc="This character's memory of recent events they witnessed.",
+    )
+    other_characters_actions: str = dspy.InputField(
+        desc=(
+            "Actions already taken by other characters this round "
+            "(empty if acting first)."
+        ),
+    )
+    action: CharacterAction = dspy.OutputField(
+        desc="The character's action, dialogue, and thoughts.",
+    )
+
+
+class ResolveRoundSignature(dspy.Signature):
+    """GM resolves all character actions and determines outcomes.
+
+    Consider the world rules, character capabilities, and plot compass.
+    Determine what actually happens, any world state changes, and whether
+    the story should continue the current scene, start a new scene or
+    chapter, or end the story.
+    """
+
+    world_state: str = dspy.InputField(desc="Current world state.")
+    plot_outline: str = dspy.InputField(desc="GM's private plot compass.")
+    scene: str = dspy.InputField(desc="The current scene description.")
+    character_actions: str = dspy.InputField(
+        desc="All character actions this round.",
+    )
+    story_progress: str = dspy.InputField(
+        desc="Brief summary of story progress (chapter count, key events).",
+    )
+    resolution: RoundResolution = dspy.OutputField(
+        desc="Outcome of the round, world changes, and pacing decision.",
+    )
+
+
+class NarrateRoundSignature(dspy.Signature):
+    """Render a simulation round into polished story prose.
+
+    Write rich, immersive narrative with natural dialogue, character
+    interiority, and vivid description. Match the genre and tone.
+    If this is a chapter start, set the scene. If a chapter end,
+    provide closure or a hook.
+    """
+
+    genre: str = dspy.InputField(desc="Story genre for tone matching.")
+    tone: str = dspy.InputField(desc="Desired narrative tone.")
+    scene_description: str = dspy.InputField(
+        desc="The scene as set by the GM.",
+    )
+    character_actions: str = dspy.InputField(
+        desc="What each character did and said.",
+    )
+    resolution: str = dspy.InputField(
+        desc="How the GM resolved the round.",
+    )
+    is_chapter_start: bool = dspy.InputField(
+        desc="Whether this is the first round of a new chapter.",
+    )
+    is_chapter_end: bool = dspy.InputField(
+        desc="Whether this is the last round of the current chapter.",
+    )
+    prose: str = dspy.OutputField(
+        desc=(
+            "Polished narrative prose for this round. Rich description, "
+            "natural dialogue, character interiority."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Agent Modules
+# ---------------------------------------------------------------------------
+
+
+class GameMasterSetup(dspy.Module):
+    """GM agent for the setup phase: questions, world, characters, plot."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.ask_questions = dspy.Predict(GenerateClarifyingQuestionsSignature)
+        self.create_world = dspy.ChainOfThought(GenerateWorldStateSignature)
+        self.create_characters = dspy.ChainOfThought(
+            GenerateCharactersSignature,
+        )
+        self.create_plot = dspy.ChainOfThought(GeneratePlotOutlineSignature)
+
+    @observe()
+    def generate_questions(
+        self,
+        idea: str,
+        num_characters: int,
+    ) -> dspy.Prediction:
+        """Ask clarifying questions about the user's story idea."""
+        return self.ask_questions(idea=idea, num_characters=num_characters)
+
+    @observe()
+    def generate_world(
+        self,
+        idea: str,
+        qa_context: str,
+        num_characters: int,
+    ) -> dspy.Prediction:
+        """Create the initial world state."""
+        return self.create_world(
+            idea=idea,
+            qa_context=qa_context,
+            num_characters=num_characters,
+        )
+
+    @observe()
+    def generate_characters(
+        self,
+        idea: str,
+        qa_context: str,
+        world: str,
+        num_characters: int,
+    ) -> dspy.Prediction:
+        """Create character sheets."""
+        return self.create_characters(
+            idea=idea,
+            qa_context=qa_context,
+            world=world,
+            num_characters=num_characters,
+        )
+
+    @observe()
+    def generate_plot_outline(
+        self,
+        idea: str,
+        world: str,
+        characters: str,
+    ) -> dspy.Prediction:
+        """Create the GM's private plot compass."""
+        return self.create_plot(idea=idea, world=world, characters=characters)
+
+
+class GameMasterRound(dspy.Module):
+    """GM agent for running a simulation round."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.set_scene = dspy.ChainOfThought(SetSceneSignature)
+        self.resolve = dspy.ChainOfThought(ResolveRoundSignature)
+
+    @observe()
+    def create_scene(
+        self,
+        world_state: str,
+        plot_outline: str,
+        recent_events: str,
+        current_chapter: int,
+        pacing_hint: str,
+    ) -> dspy.Prediction:
+        """Set the scene for the next round."""
+        return self.set_scene(
+            world_state=world_state,
+            plot_outline=plot_outline,
+            recent_events=recent_events,
+            current_chapter=current_chapter,
+            pacing_hint=pacing_hint,
+        )
+
+    @observe()
+    def resolve_round(
+        self,
+        world_state: str,
+        plot_outline: str,
+        scene: str,
+        character_actions: str,
+        story_progress: str,
+    ) -> dspy.Prediction:
+        """Resolve a round's character actions."""
+        return self.resolve(
+            world_state=world_state,
+            plot_outline=plot_outline,
+            scene=scene,
+            character_actions=character_actions,
+            story_progress=story_progress,
+        )
+
+
+class CharacterAgent(dspy.Module):
+    """A character agent that decides actions in-character."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.act = dspy.ChainOfThought(CharacterActSignature)
+
+    @observe()
+    def take_action(
+        self,
+        character_sheet: str,
+        scene_description: str,
+        personal_memory: str,
+        other_characters_actions: str,
+    ) -> dspy.Prediction:
+        """Decide an in-character action for the current scene."""
+        return self.act(
+            character_sheet=character_sheet,
+            scene_description=scene_description,
+            personal_memory=personal_memory,
+            other_characters_actions=other_characters_actions,
+        )
+
+
+class NarratorAgent(dspy.Module):
+    """Narrator agent that renders rounds into polished prose."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.narrate = dspy.ChainOfThought(NarrateRoundSignature)
+
+    @observe()
+    def render_round(
+        self,
+        genre: str,
+        tone: str,
+        scene_description: str,
+        character_actions: str,
+        resolution: str,
+        *,
+        is_chapter_start: bool,
+        is_chapter_end: bool,
+    ) -> dspy.Prediction:
+        """Render a round into polished narrative prose."""
+        return self.narrate(
+            genre=genre,
+            tone=tone,
+            scene_description=scene_description,
+            character_actions=character_actions,
+            resolution=resolution,
+            is_chapter_start=is_chapter_start,
+            is_chapter_end=is_chapter_end,
+        )

--- a/story_sim/agents.py
+++ b/story_sim/agents.py
@@ -5,7 +5,7 @@ from typing import List
 
 import dspy
 
-from _compat import observe
+from story_sim._compat import observe
 from story_sim.models import (
     CharacterAction,
     CharacterSheet,

--- a/story_sim/config.py
+++ b/story_sim/config.py
@@ -1,0 +1,341 @@
+"""DSPy and logging configuration for the simulation package.
+
+Self-contained — no imports from the parent story_writer project.
+"""
+
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+import dspy
+
+try:
+    from openinference.instrumentation.dspy import DSPyInstrumentor
+except ImportError:
+    DSPyInstrumentor = None
+
+logger = logging.getLogger(__name__)
+
+_RECOVERABLE_RUNTIME_EXCEPTIONS = (
+    AttributeError,
+    TypeError,
+    ValueError,
+    RuntimeError,
+    KeyError,
+    IndexError,
+    OSError,
+)
+
+
+# ---------------------------------------------------------------------------
+# DSPy Configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DSPyConfig:
+    """Runtime configuration for DSPy language model setup."""
+
+    model_name: str
+    api_base: str | None = None
+    api_key: str | None = None
+    max_tokens: int = 2000
+    cache: bool = True
+    memory_cache: bool = True
+    cache_dir: str | None = None
+
+
+def configure_dspy(config: DSPyConfig) -> None:
+    """Configure DSPy LM and optional instrumentation."""
+    model_name = config.model_name
+    kwargs: dict[str, Any] = {}
+    if config.api_base:
+        kwargs["api_base"] = config.api_base
+    if config.api_key is not None:
+        kwargs["api_key"] = config.api_key
+    elif "openai" in model_name.lower():
+        env_key = os.environ.get("OPENAI_API_KEY")
+        if not env_key:
+            logger.warning(
+                "OPENAI_API_KEY not found in environment variables. "
+                "Assuming mock or alternative setup.",
+            )
+        else:
+            kwargs["api_key"] = env_key
+
+    dspy.configure_cache(
+        enable_disk_cache=config.cache,
+        enable_memory_cache=config.memory_cache,
+        disk_cache_dir=config.cache_dir,
+    )
+
+    logger.info(
+        "Configuring DSPy model=%r max_tokens=%s cache=%s",
+        model_name,
+        config.max_tokens,
+        config.cache,
+    )
+    lm = dspy.LM(
+        model_name,
+        max_tokens=config.max_tokens,
+        cache=config.cache,
+        **kwargs,
+    )
+
+    if os.environ.get("LANGFUSE_PUBLIC_KEY") and DSPyInstrumentor is not None:
+        try:
+            DSPyInstrumentor().instrument()
+        except _RECOVERABLE_RUNTIME_EXCEPTIONS as exc:
+            logger.warning("Langfuse DSPy instrumentation unavailable: %s", exc)
+
+    callbacks = [TokenUsageCallback()] if TokenUsageCallback is not None else []
+    dspy.configure(lm=lm, callbacks=callbacks)
+
+
+# ---------------------------------------------------------------------------
+# Logging Formatters
+# ---------------------------------------------------------------------------
+
+
+class HumanFormatter(logging.Formatter):
+    """Concise, readable format for terminal output."""
+
+    LEVEL_COLORS = {
+        "DEBUG": "\033[36m",
+        "INFO": "\033[32m",
+        "WARNING": "\033[33m",
+        "ERROR": "\033[31m",
+        "CRITICAL": "\033[1;31m",
+    }
+    RESET = "\033[0m"
+
+    def __init__(self, use_color: bool = True) -> None:
+        super().__init__()
+        self.use_color = use_color
+
+    def format(self, record: logging.LogRecord) -> str:
+        ts = datetime.fromtimestamp(record.created, tz=timezone.utc).strftime(
+            "%Y-%m-%d %H:%M:%S",
+        )
+        level = record.levelname
+        if self.use_color:
+            color = self.LEVEL_COLORS.get(level, "")
+            level = f"{color}{level:<8}{self.RESET}"
+        else:
+            level = f"{level:<8}"
+
+        msg = record.getMessage()
+        extras = self._format_extras(record)
+        if extras:
+            msg = f"{msg} {extras}"
+
+        base = f"{ts} [{level}] {record.name}: {msg}"
+        if record.exc_info and not record.exc_text:
+            record.exc_text = self.formatException(record.exc_info)
+        if record.exc_text:
+            base = f"{base}\n{record.exc_text}"
+        return base
+
+    @staticmethod
+    def _format_extras(record: logging.LogRecord) -> str:
+        known = ("model", "tokens_in", "tokens_out", "cost", "latency_ms")
+        parts = []
+        for key in known:
+            val = getattr(record, key, None)
+            if val is not None:
+                if key == "cost":
+                    parts.append(f"cost=${val:.4f}")
+                elif key == "latency_ms":
+                    parts.append(f"latency={val / 1000:.1f}s")
+                else:
+                    parts.append(f"{key}={val}")
+        return " ".join(parts)
+
+
+class JSONFormatter(logging.Formatter):
+    """Structured JSON format for production / piped output."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        import json
+
+        ts = datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat()
+        entry: dict[str, Any] = {
+            "ts": ts,
+            "level": record.levelname,
+            "logger": record.name,
+            "msg": record.getMessage(),
+        }
+        for key in ("model", "tokens_in", "tokens_out", "cost", "latency_ms"):
+            val = getattr(record, key, None)
+            if val is not None:
+                entry[key] = val
+        if record.exc_info:
+            entry["exception"] = self.formatException(record.exc_info)
+        return json.dumps(entry, default=str)
+
+
+# ---------------------------------------------------------------------------
+# Logging Setup
+# ---------------------------------------------------------------------------
+
+
+def setup_logging(
+    verbosity: int = 0,
+    log_level: str | None = None,
+    log_format: str | None = None,
+    log_file: str | None = None,
+) -> None:
+    """Configure logging for the application.
+
+    Args:
+        verbosity: 0=WARNING, 1=INFO, 2=DEBUG (LLM debug), 3=DEBUG (firehose).
+        log_level: Override level by name. Env var LOG_LEVEL also works.
+        log_format: "json" or "text". Env var LOG_FORMAT also works.
+        log_file: Optional file path for log output.
+    """
+    level_str = log_level or os.environ.get("LOG_LEVEL")
+    if level_str:
+        level = getattr(logging, level_str.upper(), logging.WARNING)
+    else:
+        level_map = {
+            0: logging.WARNING,
+            1: logging.INFO,
+            2: logging.DEBUG,
+            3: logging.DEBUG,
+        }
+        level = level_map.get(verbosity, logging.DEBUG)
+
+    fmt = log_format or os.environ.get("LOG_FORMAT")
+    if fmt is None:
+        fmt = "text" if sys.stderr.isatty() else "json"
+
+    formatter: logging.Formatter
+    if fmt == "json":
+        formatter = JSONFormatter()
+    else:
+        formatter = HumanFormatter(use_color=sys.stderr.isatty())
+
+    root = logging.getLogger()
+    root.setLevel(level)
+    root.handlers.clear()
+
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setFormatter(formatter)
+    root.addHandler(stderr_handler)
+
+    file_path = log_file if log_file is not None else os.environ.get("LOG_FILE")
+    if file_path:
+        dir_name = os.path.dirname(file_path)
+        if dir_name:
+            os.makedirs(dir_name, exist_ok=True)
+        file_handler = logging.FileHandler(file_path)
+        file_handler.setFormatter(JSONFormatter())
+        root.addHandler(file_handler)
+
+    if level_str:
+        return
+
+    _http_loggers = ("httpx", "httpcore", "urllib3", "requests", "langfuse")
+    _llm_loggers = ("litellm", "dspy", "langfuse", "openai", "anthropic")
+
+    if verbosity <= 1:
+        for name in _http_loggers + _llm_loggers:
+            logging.getLogger(name).setLevel(logging.WARNING)
+    elif verbosity == 2:
+        for name in _llm_loggers:
+            logging.getLogger(name).setLevel(logging.DEBUG)
+        for name in _http_loggers:
+            logging.getLogger(name).setLevel(logging.WARNING)
+    else:
+        for name in _llm_loggers + _http_loggers:
+            logging.getLogger(name).setLevel(logging.DEBUG)
+
+
+# ---------------------------------------------------------------------------
+# Token Usage Callback
+# ---------------------------------------------------------------------------
+
+
+def _log_llm_call(
+    target_logger: logging.Logger,
+    *,
+    model: str,
+    tokens_in: int,
+    tokens_out: int,
+    cost: float | None = None,
+    latency_ms: float | None = None,
+) -> None:
+    """Log an LLM call with structured fields."""
+    target_logger.info(
+        "llm call",
+        extra={
+            "model": model,
+            "tokens_in": tokens_in,
+            "tokens_out": tokens_out,
+            "cost": cost,
+            "latency_ms": latency_ms,
+        },
+    )
+
+
+try:
+    from dspy.utils.callback import BaseCallback
+except ImportError:
+    BaseCallback = None
+
+
+if BaseCallback is not None:
+
+    class TokenUsageCallback(BaseCallback):
+        """Log token usage after every DSPy LM call."""
+
+        def __init__(self) -> None:
+            self._calls: dict[str, dict[str, Any]] = {}
+            self._logger = logging.getLogger("token_usage")
+
+        def on_lm_start(
+            self,
+            call_id: str,
+            instance: Any,
+            inputs: dict[str, Any],
+        ) -> None:
+            self._calls[call_id] = {
+                "instance": instance,
+                "t0": time.perf_counter(),
+            }
+
+        def on_lm_end(
+            self,
+            call_id: str,
+            outputs: dict[str, Any] | None,
+            exception: Exception | None = None,
+        ) -> None:
+            call_info = self._calls.pop(call_id, None)
+            if exception or call_info is None:
+                return
+
+            instance = call_info["instance"]
+            elapsed_ms = (time.perf_counter() - call_info["t0"]) * 1000
+
+            if not getattr(instance, "history", None):
+                return
+
+            entry = instance.history[-1]
+            usage = entry.get("usage") or {}
+            model = entry.get("model", getattr(instance, "model", "unknown"))
+
+            _log_llm_call(
+                self._logger,
+                model=model,
+                tokens_in=usage.get("prompt_tokens", 0),
+                tokens_out=usage.get("completion_tokens", 0),
+                cost=entry.get("cost"),
+                latency_ms=elapsed_ms,
+            )
+
+else:
+    TokenUsageCallback = None  # type: ignore[assignment,misc]

--- a/story_sim/engine.py
+++ b/story_sim/engine.py
@@ -1,0 +1,351 @@
+"""Simulation engine — coordinates GM, Character, and Narrator agents."""
+
+import logging
+
+from story_sim.agents import (
+    CharacterAgent,
+    GameMasterRound,
+    GameMasterSetup,
+    NarratorAgent,
+)
+from story_sim.models import (
+    CharacterAction,
+    CharacterSheet,
+    PacingDecision,
+    RoundRecord,
+    SimulationState,
+    WorldState,
+)
+
+logger = logging.getLogger(__name__)
+
+MAX_ROUNDS = 50
+MAX_ROUNDS_PER_CHAPTER = 12
+
+_RECOVERABLE_EXCEPTIONS = (
+    AttributeError,
+    TypeError,
+    ValueError,
+    RuntimeError,
+    KeyError,
+    IndexError,
+)
+
+
+def format_character_sheet(char: CharacterSheet) -> str:
+    """Serialize a character sheet into a prompt-friendly string."""
+    lines = [
+        f"Name: {char.name}",
+        f"Role: {char.role}",
+        f"Backstory: {char.backstory}",
+        f"Personality: {char.personality}",
+        f"Goals: {', '.join(char.goals)}",
+    ]
+    if char.secrets:
+        lines.append(f"Secrets: {', '.join(char.secrets)}")
+    if char.relationships:
+        rels = "; ".join(f"{k}: {v}" for k, v in char.relationships.items())
+        lines.append(f"Relationships: {rels}")
+    return "\n".join(lines)
+
+
+def format_characters_summary(characters: list[CharacterSheet]) -> str:
+    """Serialize all character sheets for prompt use."""
+    return "\n\n".join(format_character_sheet(c) for c in characters)
+
+
+def get_recent_events_summary(
+    rounds: list[RoundRecord],
+    limit: int = 5,
+) -> str:
+    """Summarize recent rounds for the GM's context."""
+    if not rounds:
+        return "Story has just begun. No prior events."
+    recent = rounds[-limit:]
+    summaries = []
+    for r in recent:
+        actions = "; ".join(f"{a.character_name}: {a.action}" for a in r.actions)
+        summaries.append(
+            f"Round {r.round_number} (Ch.{r.chapter_number}): "
+            f"{r.scene.situation} | Actions: {actions} | "
+            f"Outcome: {r.resolution.outcome}",
+        )
+    return "\n".join(summaries)
+
+
+def get_personal_memory(
+    character_name: str,
+    rounds: list[RoundRecord],
+    limit: int = 5,
+) -> str:
+    """Get events from this character's perspective only."""
+    relevant = [r for r in rounds if character_name in r.scene.characters_present]
+    if not relevant:
+        return "No prior events witnessed."
+    recent = relevant[-limit:]
+    memories = []
+    for r in recent:
+        own_action = next(
+            (a for a in r.actions if a.character_name == character_name),
+            None,
+        )
+        others = [a for a in r.actions if a.character_name != character_name]
+        others_text = "; ".join(f"{a.character_name} {a.action}" for a in others)
+        own_text = f"You {own_action.action}" if own_action else "You observed"
+        memories.append(
+            f"Round {r.round_number}: {r.scene.situation}. "
+            f"{own_text}. Others: {others_text}. "
+            f"Result: {r.resolution.outcome}",
+        )
+    return "\n".join(memories)
+
+
+def format_actions(actions: list[CharacterAction]) -> str:
+    """Format character actions for prompt injection."""
+    parts = []
+    for a in actions:
+        text = f"{a.character_name}: {a.action}"
+        if a.dialogue:
+            text += f' Says: "{a.dialogue}"'
+        parts.append(text)
+    return "\n".join(parts)
+
+
+def get_story_progress(state: SimulationState) -> str:
+    """Summarize story progress for the GM's pacing decisions."""
+    return (
+        f"Chapter {state.current_chapter}, Round {state.current_round}. "
+        f"Chapters completed: {len(state.chapters)}. "
+        f"Total rounds so far: {len(state.rounds)}."
+    )
+
+
+def get_pacing_hint(state: SimulationState) -> str:
+    """Suggest a pacing phase based on how far the story has progressed."""
+    total_rounds = len(state.rounds)
+    if total_rounds < 3:
+        return "setup — establish characters and initial situation"
+    if total_rounds < 10:
+        return "rising action — develop conflicts and deepen stakes"
+    if total_rounds < 20:
+        return "mid-story — complications, twists, character development"
+    if total_rounds < 30:
+        return "approaching climax — tensions should peak soon"
+    return "late story — drive toward resolution"
+
+
+def finalize_chapter(state: SimulationState, title: str) -> None:
+    """Collect narrator prose from current chapter rounds into a chapter."""
+    chapter_rounds = [
+        r for r in state.rounds if r.chapter_number == state.current_chapter
+    ]
+    prose = "\n\n".join(r.narrator_prose for r in chapter_rounds if r.narrator_prose)
+    chapter_title = title or f"Chapter {state.current_chapter}"
+    state.chapters.append((chapter_title, prose))
+    logger.info(
+        "Finalized chapter %d: %s (%d rounds)",
+        state.current_chapter,
+        chapter_title,
+        len(chapter_rounds),
+    )
+    state.current_chapter += 1
+
+
+def compile_story(state: SimulationState) -> str:
+    """Compile all chapters into final story text."""
+    parts = []
+    for i, (title, prose) in enumerate(state.chapters, start=1):
+        clean_title = title if title else f"Chapter {i}"
+        parts.append(f"### {clean_title}\n\n{prose}")
+    return "\n\n".join(parts)
+
+
+class SimulationEngine:
+    """Orchestrates the multi-agent story simulation loop."""
+
+    def __init__(self) -> None:
+        self.gm_setup = GameMasterSetup()
+        self.gm_round = GameMasterRound()
+        self.character_agent = CharacterAgent()
+        self.narrator = NarratorAgent()
+
+    def setup(
+        self,
+        idea: str,
+        qa_context: str,
+        num_characters: int,
+    ) -> SimulationState:
+        """Run the GM setup phase and return initial simulation state."""
+        world_result = self.gm_setup.generate_world(
+            idea=idea,
+            qa_context=qa_context,
+            num_characters=num_characters,
+        )
+        world: WorldState = world_result.world
+
+        chars_result = self.gm_setup.generate_characters(
+            idea=idea,
+            qa_context=qa_context,
+            world=world.model_dump_json(),
+            num_characters=num_characters,
+        )
+        characters: list[CharacterSheet] = chars_result.characters
+
+        plot_result = self.gm_setup.generate_plot_outline(
+            idea=idea,
+            world=world.model_dump_json(),
+            characters=format_characters_summary(characters),
+        )
+
+        return SimulationState(
+            world=world,
+            characters=characters,
+            plot_outline=plot_result.plot_outline,
+        )
+
+    def _collect_character_actions(
+        self,
+        state: SimulationState,
+        scene_situation: str,
+        characters_present: list[str],
+    ) -> list[CharacterAction]:
+        """Have each present character take their turn."""
+        actions: list[CharacterAction] = []
+        for char in state.characters:
+            if char.name not in characters_present:
+                continue
+            try:
+                action_result = self.character_agent.take_action(
+                    character_sheet=format_character_sheet(char),
+                    scene_description=scene_situation,
+                    personal_memory=get_personal_memory(
+                        char.name,
+                        state.rounds,
+                    ),
+                    other_characters_actions=format_actions(actions),
+                )
+                action = action_result.action
+                action.character_name = char.name
+                actions.append(action)
+            except _RECOVERABLE_EXCEPTIONS as exc:
+                logger.warning(
+                    "Character %s failed to act: %s",
+                    char.name,
+                    exc,
+                )
+        return actions
+
+    def run_round(self, state: SimulationState) -> RoundRecord:
+        """Execute one simulation round: scene -> actions -> resolve -> narrate."""
+        state.current_round += 1
+        is_chapter_start = not any(
+            r.chapter_number == state.current_chapter for r in state.rounds
+        )
+
+        scene_result = self.gm_round.create_scene(
+            world_state=state.world.model_dump_json(),
+            plot_outline=state.plot_outline,
+            recent_events=get_recent_events_summary(state.rounds),
+            current_chapter=state.current_chapter,
+            pacing_hint=get_pacing_hint(state),
+        )
+        scene = scene_result.scene
+
+        actions = self._collect_character_actions(
+            state,
+            scene.situation,
+            scene.characters_present,
+        )
+
+        resolve_result = self.gm_round.resolve_round(
+            world_state=state.world.model_dump_json(),
+            plot_outline=state.plot_outline,
+            scene=scene.situation,
+            character_actions=format_actions(actions),
+            story_progress=get_story_progress(state),
+        )
+        resolution = resolve_result.resolution
+
+        is_chapter_end = resolution.pacing in (
+            PacingDecision.NEW_CHAPTER,
+            PacingDecision.END_STORY,
+        )
+
+        narrate_result = self.narrator.render_round(
+            genre=state.world.genre,
+            tone=state.world.tone,
+            scene_description=scene.situation,
+            character_actions=format_actions(actions),
+            resolution=resolution.outcome,
+            is_chapter_start=is_chapter_start,
+            is_chapter_end=is_chapter_end,
+        )
+
+        record = RoundRecord(
+            round_number=state.current_round,
+            chapter_number=state.current_chapter,
+            scene=scene,
+            actions=actions,
+            resolution=resolution,
+            narrator_prose=narrate_result.prose,
+        )
+        state.rounds.append(record)
+
+        for change in resolution.world_changes:
+            state.world.timeline.append(change)
+
+        if is_chapter_end:
+            finalize_chapter(state, resolution.chapter_title)
+
+        return record
+
+    def run(
+        self,
+        state: SimulationState,
+        on_round: "None | callable" = None,
+    ) -> str:
+        """Run the full simulation until the GM ends the story."""
+        rounds_in_chapter = 0
+
+        for _ in range(MAX_ROUNDS):
+            record = self.run_round(state)
+            rounds_in_chapter += 1
+
+            if on_round is not None:
+                on_round(record)
+
+            logger.info(
+                "Round %d (Ch.%d): %s -> %s",
+                record.round_number,
+                record.chapter_number,
+                record.scene.situation[:80],
+                record.resolution.pacing.value,
+            )
+
+            if record.resolution.pacing == PacingDecision.END_STORY:
+                break
+            if record.resolution.pacing in (
+                PacingDecision.NEW_CHAPTER,
+                PacingDecision.CLIMAX,
+            ):
+                rounds_in_chapter = 0
+
+            if rounds_in_chapter >= MAX_ROUNDS_PER_CHAPTER:
+                logger.warning(
+                    "Forcing chapter break after %d rounds",
+                    rounds_in_chapter,
+                )
+                finalize_chapter(state, "")
+                rounds_in_chapter = 0
+
+        self._finalize_remaining(state)
+        return compile_story(state)
+
+    def _finalize_remaining(self, state: SimulationState) -> None:
+        """Finalize any chapter that wasn't closed by the GM."""
+        unfinalized = [
+            r for r in state.rounds if r.chapter_number == state.current_chapter
+        ]
+        finalized_nums = set(range(1, len(state.chapters) + 1))
+        if unfinalized and state.current_chapter not in finalized_nums:
+            finalize_chapter(state, "")

--- a/story_sim/models.py
+++ b/story_sim/models.py
@@ -1,0 +1,168 @@
+"""Data models for multi-agent story simulation."""
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class PacingDecision(str, Enum):
+    """GM's decision about what happens next in the story structure."""
+
+    CONTINUE_SCENE = "continue_scene"
+    NEW_SCENE = "new_scene"
+    NEW_CHAPTER = "new_chapter"
+    CLIMAX = "climax"
+    END_STORY = "end_story"
+
+
+class CharacterSheet(BaseModel):
+    """A character's identity and traits, known to the character agent."""
+
+    name: str = Field(description="Character's full name.")
+    role: str = Field(
+        description="Role in the story (protagonist, antagonist, ally, etc.).",
+    )
+    backstory: str = Field(description="Character's background and history.")
+    personality: str = Field(
+        description="Core personality traits and temperament.",
+    )
+    goals: list[str] = Field(
+        description="What the character wants to achieve.",
+    )
+    secrets: list[str] = Field(
+        default_factory=list,
+        description="Things only this character (and GM) knows.",
+    )
+    relationships: dict[str, str] = Field(
+        default_factory=dict,
+        description="Relationships to other characters (name -> description).",
+    )
+
+
+class WorldState(BaseModel):
+    """Compact world representation maintained by the GM."""
+
+    setting: str = Field(description="The world's setting description.")
+    genre: str = Field(description="Story genre.")
+    tone: str = Field(
+        description="Narrative tone (dark, lighthearted, gritty, etc.).",
+    )
+    locations: list[str] = Field(
+        default_factory=list,
+        description="Known locations in the world.",
+    )
+    factions: list[str] = Field(
+        default_factory=list,
+        description="Major groups, organizations, or factions.",
+    )
+    key_facts: list[str] = Field(
+        default_factory=list,
+        description="Important world facts and rules.",
+    )
+    timeline: list[str] = Field(
+        default_factory=list,
+        description="Major events that have occurred, in order.",
+    )
+
+
+class SceneContext(BaseModel):
+    """Current scene information provided by the GM each round."""
+
+    location: str = Field(description="Where the scene takes place.")
+    characters_present: list[str] = Field(
+        description="Which characters are in the scene.",
+    )
+    time_context: str = Field(
+        description="Time of day, how much time has passed, etc.",
+    )
+    situation: str = Field(
+        description="What's happening — tensions, events, atmosphere.",
+    )
+    gm_notes: str = Field(
+        default="",
+        description="Private GM notes about this scene's purpose in the plot.",
+    )
+
+
+class CharacterAction(BaseModel):
+    """A character's response during a round."""
+
+    character_name: str = Field(description="Who is acting.")
+    action: str = Field(
+        description="What the character does (physical actions, movement).",
+    )
+    dialogue: str = Field(
+        default="",
+        description="What the character says, if anything.",
+    )
+    internal_thought: str = Field(
+        default="",
+        description="What the character is thinking (for narrator's use).",
+    )
+
+
+class RoundResolution(BaseModel):
+    """GM's resolution of a round after all characters act."""
+
+    outcome: str = Field(
+        description="What actually happens as a result of character actions.",
+    )
+    world_changes: list[str] = Field(
+        default_factory=list,
+        description="Updates to world state.",
+    )
+    character_updates: dict[str, str] = Field(
+        default_factory=dict,
+        description="Per-character consequences or state changes.",
+    )
+    pacing: PacingDecision = Field(
+        description="What happens next in terms of story structure.",
+    )
+    chapter_title: str = Field(
+        default="",
+        description="If pacing is NEW_CHAPTER or END_STORY, the chapter title.",
+    )
+
+
+class RoundRecord(BaseModel):
+    """Complete record of one simulation round."""
+
+    round_number: int
+    chapter_number: int
+    scene: SceneContext
+    actions: list[CharacterAction]
+    resolution: RoundResolution
+    narrator_prose: str = Field(
+        default="",
+        description="The narrator's rendered prose for this round.",
+    )
+
+
+class ClarifyingQuestion(BaseModel):
+    """A GM clarifying question paired with a suggested answer."""
+
+    question: str = Field(description="A question to clarify the story idea.")
+    proposed_answer: str = Field(description="A suggested default answer.")
+
+
+@dataclass
+class SimulationConfig:
+    """User-provided configuration for the simulation."""
+
+    idea: str
+    num_characters: int = 3
+    qa_context: str = ""
+
+
+@dataclass
+class SimulationState:
+    """Mutable state tracking the full simulation."""
+
+    world: WorldState
+    characters: list[CharacterSheet]
+    plot_outline: str
+    rounds: list[RoundRecord] = field(default_factory=list)
+    current_chapter: int = 1
+    current_round: int = 0
+    chapters: list[tuple[str, str]] = field(default_factory=list)

--- a/test_sim.py
+++ b/test_sim.py
@@ -1,0 +1,502 @@
+"""Tests for the multi-agent story simulation."""
+
+import dspy
+
+from story_sim.models import (
+    CharacterAction,
+    CharacterSheet,
+    ClarifyingQuestion,
+    PacingDecision,
+    RoundRecord,
+    RoundResolution,
+    SceneContext,
+    SimulationState,
+    WorldState,
+)
+from story_sim.engine import (
+    SimulationEngine,
+    compile_story,
+    finalize_chapter,
+    format_actions,
+    format_character_sheet,
+    format_characters_summary,
+    get_pacing_hint,
+    get_personal_memory,
+    get_recent_events_summary,
+    get_story_progress,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_character(
+    name: str = "Kael",
+    role: str = "protagonist",
+) -> CharacterSheet:
+    return CharacterSheet(
+        name=name,
+        role=role,
+        backstory=f"{name} grew up in the wilds.",
+        personality="Brave and stubborn.",
+        goals=["Survive", "Find the truth"],
+        secrets=["Knows the king's weakness"],
+        relationships={"Mira": "trusted ally"},
+    )
+
+
+def _make_world() -> WorldState:
+    return WorldState(
+        setting="A crumbling kingdom on the edge of a cursed forest.",
+        genre="fantasy",
+        tone="dark",
+        locations=["Castle Vorn", "The Ashwood"],
+        factions=["The Crown", "The Exiles"],
+        key_facts=["Magic costs blood"],
+        timeline=[],
+    )
+
+
+def _make_scene(characters: list[str] | None = None) -> SceneContext:
+    return SceneContext(
+        location="Castle Vorn courtyard",
+        characters_present=characters or ["Kael", "Mira"],
+        time_context="Dusk",
+        situation="The guards are changing shift. Tension is high.",
+    )
+
+
+def _make_action(name: str = "Kael") -> CharacterAction:
+    return CharacterAction(
+        character_name=name,
+        action="Slips past the guards toward the gate.",
+        dialogue="Stay close.",
+        internal_thought="This is our only chance.",
+    )
+
+
+def _make_resolution(
+    pacing: PacingDecision = PacingDecision.CONTINUE_SCENE,
+) -> RoundResolution:
+    return RoundResolution(
+        outcome="Kael slips through unnoticed. Mira follows.",
+        world_changes=["Gate left unguarded for 2 minutes"],
+        character_updates={"Kael": "Now outside the castle walls"},
+        pacing=pacing,
+        chapter_title="",
+    )
+
+
+def _make_round_record(
+    round_number: int = 1,
+    chapter_number: int = 1,
+    pacing: PacingDecision = PacingDecision.CONTINUE_SCENE,
+    characters: list[str] | None = None,
+) -> RoundRecord:
+    return RoundRecord(
+        round_number=round_number,
+        chapter_number=chapter_number,
+        scene=_make_scene(characters),
+        actions=[_make_action("Kael"), _make_action("Mira")],
+        resolution=_make_resolution(pacing),
+        narrator_prose=f"Round {round_number} prose.",
+    )
+
+
+def _make_state() -> SimulationState:
+    return SimulationState(
+        world=_make_world(),
+        characters=[_make_character("Kael"), _make_character("Mira", "ally")],
+        plot_outline="Inciting incident: castle escape. Climax: confrontation.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Model Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCharacterSheet:
+    def test_minimal_creation(self) -> None:
+        char = CharacterSheet(
+            name="Test",
+            role="protagonist",
+            backstory="None",
+            personality="Bold",
+            goals=["Win"],
+        )
+        assert char.name == "Test"
+        assert char.secrets == []
+        assert char.relationships == {}
+
+    def test_full_creation(self) -> None:
+        char = _make_character()
+        assert char.name == "Kael"
+        assert len(char.secrets) == 1
+        assert "Mira" in char.relationships
+
+
+class TestWorldState:
+    def test_creation(self) -> None:
+        world = _make_world()
+        assert world.genre == "fantasy"
+        assert len(world.locations) == 2
+
+    def test_defaults(self) -> None:
+        world = WorldState(setting="test", genre="mystery", tone="noir")
+        assert world.locations == []
+        assert world.timeline == []
+
+
+class TestPacingDecision:
+    def test_all_values(self) -> None:
+        assert len(PacingDecision) == 5
+        assert PacingDecision.END_STORY.value == "end_story"
+
+
+class TestClarifyingQuestion:
+    def test_creation(self) -> None:
+        q = ClarifyingQuestion(
+            question="What genre?",
+            proposed_answer="Fantasy",
+        )
+        assert q.question == "What genre?"
+
+
+# ---------------------------------------------------------------------------
+# Engine Helper Tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatCharacterSheet:
+    def test_includes_all_fields(self) -> None:
+        char = _make_character()
+        text = format_character_sheet(char)
+        assert "Kael" in text
+        assert "protagonist" in text
+        assert "Brave and stubborn" in text
+        assert "Survive" in text
+        assert "king's weakness" in text
+        assert "Mira" in text
+
+    def test_omits_empty_secrets(self) -> None:
+        char = CharacterSheet(
+            name="X",
+            role="npc",
+            backstory="",
+            personality="",
+            goals=[],
+        )
+        text = format_character_sheet(char)
+        assert "Secrets" not in text
+
+
+class TestFormatCharactersSummary:
+    def test_multiple_characters(self) -> None:
+        chars = [_make_character("A"), _make_character("B")]
+        text = format_characters_summary(chars)
+        assert "A" in text
+        assert "B" in text
+        assert text.count("Name:") == 2
+
+
+class TestGetRecentEventsSummary:
+    def test_empty_rounds(self) -> None:
+        result = get_recent_events_summary([])
+        assert "just begun" in result
+
+    def test_limits_to_n(self) -> None:
+        rounds = [_make_round_record(i) for i in range(1, 10)]
+        result = get_recent_events_summary(rounds, limit=3)
+        assert "Round 7" in result
+        assert "Round 9" in result
+        assert "Round 1" not in result
+
+
+class TestGetPersonalMemory:
+    def test_no_rounds(self) -> None:
+        result = get_personal_memory("Kael", [])
+        assert "No prior events" in result
+
+    def test_filters_by_presence(self) -> None:
+        r1 = _make_round_record(1, characters=["Kael", "Mira"])
+        r2 = _make_round_record(2, characters=["Mira"])
+        result = get_personal_memory("Kael", [r1, r2])
+        assert "Round 1" in result
+        assert "Round 2" not in result
+
+    def test_shows_own_action(self) -> None:
+        r = _make_round_record(1, characters=["Kael", "Mira"])
+        result = get_personal_memory("Kael", [r])
+        assert "You " in result
+
+
+class TestFormatActions:
+    def test_with_dialogue(self) -> None:
+        actions = [_make_action("Kael")]
+        result = format_actions(actions)
+        assert "Kael:" in result
+        assert 'Says: "Stay close."' in result
+
+    def test_without_dialogue(self) -> None:
+        action = CharacterAction(
+            character_name="Mira",
+            action="Watches silently.",
+        )
+        result = format_actions([action])
+        assert "Says:" not in result
+
+
+class TestGetStoryProgress:
+    def test_format(self) -> None:
+        state = _make_state()
+        state.current_round = 5
+        state.current_chapter = 2
+        state.chapters = [("Ch1", "text")]
+        result = get_story_progress(state)
+        assert "Chapter 2" in result
+        assert "Round 5" in result
+        assert "Chapters completed: 1" in result
+
+
+class TestGetPacingHint:
+    def test_early_is_setup(self) -> None:
+        state = _make_state()
+        assert "setup" in get_pacing_hint(state)
+
+    def test_mid_is_rising(self) -> None:
+        state = _make_state()
+        state.rounds = [_make_round_record(i) for i in range(5)]
+        assert "rising" in get_pacing_hint(state)
+
+    def test_late_is_resolution(self) -> None:
+        state = _make_state()
+        state.rounds = [_make_round_record(i) for i in range(35)]
+        assert "resolution" in get_pacing_hint(state)
+
+
+class TestFinalizeChapter:
+    def test_collects_prose(self) -> None:
+        state = _make_state()
+        state.rounds = [
+            _make_round_record(1, chapter_number=1),
+            _make_round_record(2, chapter_number=1),
+        ]
+        finalize_chapter(state, "The Escape")
+        assert len(state.chapters) == 1
+        assert state.chapters[0][0] == "The Escape"
+        assert "Round 1 prose" in state.chapters[0][1]
+        assert "Round 2 prose" in state.chapters[0][1]
+        assert state.current_chapter == 2
+
+    def test_default_title(self) -> None:
+        state = _make_state()
+        state.rounds = [_make_round_record(1, chapter_number=1)]
+        finalize_chapter(state, "")
+        assert state.chapters[0][0] == "Chapter 1"
+
+
+class TestCompileStory:
+    def test_formats_chapters(self) -> None:
+        state = _make_state()
+        state.chapters = [
+            ("The Escape", "They fled."),
+            ("The Forest", "Darkness swallowed them."),
+        ]
+        story = compile_story(state)
+        assert "### The Escape" in story
+        assert "### The Forest" in story
+        assert "They fled." in story
+
+    def test_empty_chapters(self) -> None:
+        state = _make_state()
+        assert compile_story(state) == ""
+
+
+# ---------------------------------------------------------------------------
+# MockLM for simulation tests
+# ---------------------------------------------------------------------------
+
+
+class SimMockLM(dspy.LM):
+    """Mock LM that returns valid JSON for simulation agent signatures."""
+
+    def __init__(self) -> None:
+        super().__init__(model="mock")
+
+    def __call__(
+        self,
+        prompt: str | None = None,
+        messages: list | None = None,
+        **kwargs: object,
+    ) -> list[str]:
+        content = self._extract_content(messages) if messages else (prompt or "")
+        return [self._route_response(content)]
+
+    def _extract_content(self, messages: list) -> str:
+        """Combine all message content for pattern matching."""
+        return "\n".join(m.get("content", "") for m in messages)
+
+    def _route_response(self, content: str) -> str:
+        if "is_chapter_start" in content or "is_chapter_end" in content:
+            return self._narrate_response()
+        if "story_progress" in content and "character_actions" in content:
+            return self._resolution_response()
+        if "personal_memory" in content and "character_sheet" in content:
+            return self._action_response()
+        if "pacing_hint" in content:
+            return self._scene_response()
+        if "plot_outline" in content and "inciting" in content.lower():
+            return self._plot_response()
+        if "CharacterSheet" in content and "num_characters" in content:
+            return self._characters_response()
+        if "WorldState" in content:
+            return self._world_response()
+        if "ClarifyingQuestion" in content:
+            return self._questions_response()
+        return '{"reasoning": "mock", "result": "fallback"}'
+
+    def _questions_response(self) -> str:
+        return (
+            '{"questions": ['
+            '{"question": "What genre?", "proposed_answer": "Fantasy"}, '
+            '{"question": "Dark or light?", "proposed_answer": "Dark"}'
+            "]}"
+        )
+
+    def _world_response(self) -> str:
+        return (
+            '{"reasoning": "mock", "world": {'
+            '"setting": "A cursed kingdom", "genre": "fantasy", '
+            '"tone": "dark", "locations": ["Castle"], '
+            '"factions": ["Crown"], "key_facts": ["Magic costs blood"], '
+            '"timeline": []}}'
+        )
+
+    def _characters_response(self) -> str:
+        return (
+            '{"reasoning": "mock", "characters": [{'
+            '"name": "Kael", "role": "protagonist", '
+            '"backstory": "Raised by wolves", '
+            '"personality": "Brave", "goals": ["Survive"], '
+            '"secrets": ["Knows the truth"], '
+            '"relationships": {"Mira": "ally"}}, '
+            '{"name": "Mira", "role": "ally", '
+            '"backstory": "Former soldier", '
+            '"personality": "Cautious", "goals": ["Protect Kael"], '
+            '"secrets": [], "relationships": {"Kael": "ward"}}'
+            "]}"
+        )
+
+    def _plot_response(self) -> str:
+        return (
+            '{"reasoning": "mock", '
+            '"plot_outline": "Inciting: Castle escape. '
+            'Rising: Forest journey. Climax: Confrontation."}'
+        )
+
+    def _scene_response(self) -> str:
+        return (
+            '{"reasoning": "mock", "scene": {'
+            '"location": "Castle courtyard", '
+            '"characters_present": ["Kael", "Mira"], '
+            '"time_context": "Dusk", '
+            '"situation": "Guards changing shift.", '
+            '"gm_notes": "Setup escape."}}'
+        )
+
+    def _action_response(self) -> str:
+        return (
+            '{"reasoning": "mock", "action": {'
+            '"character_name": "Kael", '
+            '"action": "Moves toward the gate.", '
+            '"dialogue": "Now.", '
+            '"internal_thought": "No turning back."}}'
+        )
+
+    def _resolution_response(self) -> str:
+        return (
+            '{"reasoning": "mock", "resolution": {'
+            '"outcome": "They escape through the gate.", '
+            '"world_changes": ["Gate breached"], '
+            '"character_updates": {}, '
+            '"pacing": "end_story", '
+            '"chapter_title": "The Escape"}}'
+        )
+
+    def _narrate_response(self) -> str:
+        return (
+            '{"reasoning": "mock", '
+            '"prose": "The last light of dusk painted the courtyard '
+            'in amber and shadow."}'
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integration Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSimulationEngineSetup:
+    def test_setup_creates_valid_state(self) -> None:
+        dspy.configure(lm=SimMockLM())
+        engine = SimulationEngine()
+        state = engine.setup(
+            idea="A cursed kingdom",
+            qa_context="Q: Genre?\nA: Fantasy",
+            num_characters=2,
+        )
+        assert isinstance(state.world, WorldState)
+        assert len(state.characters) >= 1
+        assert state.plot_outline != ""
+        assert state.current_round == 0
+        assert state.current_chapter == 1
+
+
+class TestSimulationEngineRound:
+    def test_single_round(self) -> None:
+        dspy.configure(lm=SimMockLM())
+        engine = SimulationEngine()
+        state = engine.setup(
+            idea="A cursed kingdom",
+            qa_context="Q: Genre?\nA: Fantasy",
+            num_characters=2,
+        )
+        record = engine.run_round(state)
+        assert record.round_number == 1
+        assert record.chapter_number == 1
+        assert len(record.actions) > 0
+        assert record.narrator_prose != ""
+        assert len(state.rounds) == 1
+
+
+class TestSimulationEngineRun:
+    def test_run_produces_story(self) -> None:
+        dspy.configure(lm=SimMockLM())
+        engine = SimulationEngine()
+        state = engine.setup(
+            idea="A cursed kingdom",
+            qa_context="Q: Genre?\nA: Fantasy",
+            num_characters=2,
+        )
+        story = engine.run(state)
+        assert "###" in story
+        assert len(state.chapters) >= 1
+
+    def test_on_round_callback(self) -> None:
+        dspy.configure(lm=SimMockLM())
+        engine = SimulationEngine()
+        state = engine.setup(
+            idea="test",
+            qa_context="",
+            num_characters=2,
+        )
+        rounds_seen: list[int] = []
+        story = engine.run(
+            state,
+            on_round=lambda r: rounds_seen.append(r.round_number),
+        )
+        assert len(rounds_seen) >= 1
+        assert story != ""


### PR DESCRIPTION
Introduce a new story generation mode where an ensemble of agents
(Game Master, Character agents, Narrator) collaboratively build a
story through turn-based simulation rounds. The GM drives pacing and
world state, characters act from their own perspective and knowledge,
and the Narrator renders each round into polished prose.

New files:
- story_sim/ package: models, agents (DSPy modules), engine
- sim_main.py: CLI entry point for simulation mode
- test_sim.py: 28 tests covering models, helpers, and integration

https://claude.ai/code/session_01HttDybUp1sSB6uyy7eAPFC