### PR TITLE
Add audiobook TTS script and Suno prompt emitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ python main.py
 - `alternate_story_modules.py` — alternate Architect→Director→Scripter→Writer pipeline modules.
 - `scripts/fetch_langfuse_traces.py` — utility to fetch/summarize Langfuse traces.
 - `test_story.py`, `test_alternate.py` — pytest coverage for main and alternate pipelines.
+- `audiobook.py` — standalone TTS script that turns `story_output.md` into per-chapter audio (local or remote providers).
 
 ## Requirements
 
@@ -183,6 +184,39 @@ Summarize traces:
 ```bash
 python scripts/fetch_langfuse_traces.py --mode summarize --input .tmp/langfuse_traces.json --output .tmp/langfuse_summary.json --summary-hours 24
 ```
+
+## Audiobook (TTS)
+
+`audiobook.py` is a standalone script that reads a generated story markdown
+and renders one audio file per chapter. It supports both local and remote TTS
+providers; install only the SDK for the provider you use.
+
+```bash
+# Local
+pip install kokoro soundfile      # Kokoro (default)
+pip install piper-tts             # Piper
+
+# Remote
+pip install requests              # NVIDIA Magpie TTS NIM (self-hosted or hosted)
+pip install openai                # OpenAI
+pip install elevenlabs            # ElevenLabs
+```
+
+Examples:
+
+```bash
+python audiobook.py --provider kokoro
+python audiobook.py --provider piper --voice-model en_US-lessac-medium.onnx
+python audiobook.py --provider nvidia \
+  --nvidia-url http://localhost:9000 \
+  --voice Magpie-Multilingual.EN-US.Aria
+python audiobook.py --provider openai --voice nova
+python audiobook.py --provider elevenlabs --voice Rachel
+```
+
+Keys come from `--api-key` or the env vars `NVIDIA_API_KEY`, `OPENAI_API_KEY`,
+`ELEVENLABS_API_KEY`. Input defaults to `.tmp/story_output.md`; output goes to
+`.tmp/audiobook/chXX_<slug>.<ext>`. Use `--only N` to re-render a single chapter.
 
 ## Running Tests
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ python main.py
 - `scripts/fetch_langfuse_traces.py` — utility to fetch/summarize Langfuse traces.
 - `test_story.py`, `test_alternate.py` — pytest coverage for main and alternate pipelines.
 - `audiobook.py` — standalone TTS script that turns `story_output.md` into per-chapter audio (local or remote providers).
+- `suno_prompt.py` — emits copy-pasteable Suno prompts (Style + Lyrics) chunked on paragraph boundaries.
 
 ## Requirements
 
@@ -217,6 +218,32 @@ python audiobook.py --provider elevenlabs --voice Rachel
 Keys come from `--api-key` or the env vars `NVIDIA_API_KEY`, `OPENAI_API_KEY`,
 `ELEVENLABS_API_KEY`. Input defaults to `.tmp/story_output.md`; output goes to
 `.tmp/audiobook/chXX_<slug>.<ext>`. Use `--only N` to re-render a single chapter.
+
+## Suno Prompts
+
+`suno_prompt.py` is a separate script that emits copy-pasteable prompts for
+Suno (Custom mode). It does not call any API — Suno doesn't behave like a
+narrator out of the box, so this gives you the upside (emotive performance)
+while keeping a deterministic TTS path for true narration.
+
+For each chapter it writes one or more `.txt` files under
+`.tmp/suno_prompts/`. Each file contains:
+
+- `STYLE` block — paste into Suno's "Style of Music" field.
+- `LYRICS` block — paste into "Lyrics". Wrapped with `[Spoken Word]` /
+  `[no singing]` / `[no melody]` and a fresh `[Narrator]` tag per paragraph
+  so Suno re-evaluates tone when emotion shifts.
+- `TIPS` block — usage notes for the Suno UI.
+
+Prose is chunked greedily on paragraph boundaries up to ~2500 chars (under
+Suno's 5000-char lyrics cap, leaving headroom for tags). Paragraphs longer
+than 2500 chars are sentence-split.
+
+```bash
+python suno_prompt.py
+python suno_prompt.py --style "noir audiobook narration, jazz ambient bed"
+python suno_prompt.py --only 3
+```
 
 ## Running Tests
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,22 @@ python suno_prompt.py --style "noir audiobook narration, jazz ambient bed"
 python suno_prompt.py --only 3
 ```
 
+### LLM-segmented mode
+
+`--llm-segment` asks a DSPy-configured model to split each chapter into
+emotionally coherent segments (≥500 prose chars per multi-paragraph segment,
+≤2500 chars per segment, contiguous coverage of the chapter) and to author a
+fresh Suno "Style of Music" string for each segment. The script validates the
+LLM's segments and falls back to greedy chunking on invalid output.
+
+```bash
+python suno_prompt.py --llm-segment --model openai/gpt-4o-mini
+python suno_prompt.py --llm-segment --min-chars 750 --only 2
+```
+
+Reuses the same env vars as the main pipeline: `MODEL`, `LLM_URL`, `API_KEY`
+(with `OPENAI_API_KEY` as a fallback for OpenAI-flavored model ids).
+
 ## Running Tests
 
 ```bash

--- a/audiobook.py
+++ b/audiobook.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Standalone audiobook synthesizer for story_writer markdown output.
+
+Reads a story markdown file (default `.tmp/story_output.md`), extracts chapters
+from the `## Final Story` section, and renders one audio file per chapter via a
+selectable TTS provider. Local and remote providers share a thin adapter
+interface; pick via `--provider`.
+
+Supported providers:
+  Local   : kokoro, piper
+  Remote  : nvidia (Magpie TTS NIM; self-hosted or build.nvidia.com),
+            openai, elevenlabs
+
+Each provider imports its SDK lazily so you only need the dependency you use.
+
+Examples:
+  python audiobook.py --provider kokoro
+  python audiobook.py --provider piper --voice-model en_US-lessac-medium.onnx
+  python audiobook.py --provider nvidia --nvidia-url http://localhost:9000 \\
+      --voice Magpie-Multilingual.EN-US.Aria
+  python audiobook.py --provider openai --voice nova
+  python audiobook.py --provider elevenlabs --voice Rachel
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+
+
+# ---------- Markdown parsing ----------
+
+FINAL_STORY_HEADER = re.compile(r"^##\s+Final Story\s*$", re.MULTILINE)
+NEXT_H2 = re.compile(r"^##\s+\S", re.MULTILINE)
+CHAPTER_SPLIT = re.compile(r"^###\s+Chapter\s+", re.MULTILINE)
+
+IMG_RE = re.compile(r"!\[[^\]]*\]\([^)]*\)")
+LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]*\)")
+INLINE_FMT_RE = re.compile(r"(\*\*|\*|__|_|`)")
+HEADING_HASHES_RE = re.compile(r"^#+\s*", re.MULTILINE)
+
+
+@dataclass
+class Chapter:
+    index: int
+    title: str
+    text: str
+
+
+def extract_final_story(md: str) -> str:
+    m = FINAL_STORY_HEADER.search(md)
+    if not m:
+        raise SystemExit("No '## Final Story' section found in input markdown.")
+    start = m.end()
+    nxt = NEXT_H2.search(md, pos=start)
+    return md[start : nxt.start() if nxt else len(md)]
+
+
+def parse_chapters(md: str) -> list[Chapter]:
+    body = extract_final_story(md)
+    pieces = CHAPTER_SPLIT.split(body)
+    pieces = [p for p in pieces if p.strip()]
+    chapters: list[Chapter] = []
+    for i, piece in enumerate(pieces, start=1):
+        first_line, _, rest = piece.partition("\n")
+        title = first_line.strip().rstrip(":") or f"Chapter {i}"
+        chapters.append(Chapter(index=i, title=f"Chapter {title}", text=rest.strip()))
+    if not chapters:
+        raise SystemExit("Found '## Final Story' but no '### Chapter ...' entries.")
+    return chapters
+
+
+def clean_for_tts(text: str) -> str:
+    text = IMG_RE.sub("", text)
+    text = LINK_RE.sub(r"\1", text)
+    text = HEADING_HASHES_RE.sub("", text)
+    text = INLINE_FMT_RE.sub("", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+# ---------- Provider interface ----------
+
+class TTSProvider(ABC):
+    """One audio file per synth() call. Output format is provider-dependent
+    (wav/mp3); callers use the returned path as-is."""
+
+    name: str = "base"
+    default_ext: str = "wav"
+
+    @abstractmethod
+    def synth(self, text: str, out_path: Path, voice: str | None) -> Path: ...
+
+
+# ---------- Local: Kokoro ----------
+
+class KokoroProvider(TTSProvider):
+    name = "kokoro"
+    default_ext = "wav"
+
+    def __init__(self, voice_default: str = "af_heart", lang: str = "a"):
+        try:
+            from kokoro import KPipeline  # type: ignore
+        except ImportError as e:
+            raise SystemExit(
+                "kokoro not installed. Try: pip install kokoro soundfile"
+            ) from e
+        self._KPipeline = KPipeline
+        self._pipe = KPipeline(lang_code=lang)
+        self._voice_default = voice_default
+
+    def synth(self, text: str, out_path: Path, voice: str | None) -> Path:
+        import numpy as np
+        import soundfile as sf
+        v = voice or self._voice_default
+        chunks = []
+        for _, _, audio in self._pipe(text, voice=v):
+            chunks.append(audio)
+        if not chunks:
+            raise RuntimeError("Kokoro produced no audio.")
+        audio = np.concatenate(chunks)
+        sf.write(str(out_path), audio, 24000)
+        return out_path
+
+
+# ---------- Local: Piper ----------
+
+class PiperProvider(TTSProvider):
+    name = "piper"
+    default_ext = "wav"
+
+    def __init__(self, voice_model: str):
+        if not voice_model:
+            raise SystemExit(
+                "--voice-model is required for piper (path to a .onnx voice)."
+            )
+        try:
+            from piper.voice import PiperVoice  # type: ignore
+        except ImportError as e:
+            raise SystemExit("piper-tts not installed. Try: pip install piper-tts") from e
+        self._voice = PiperVoice.load(voice_model)
+
+    def synth(self, text: str, out_path: Path, voice: str | None) -> Path:
+        import wave
+        with wave.open(str(out_path), "wb") as wf:
+            self._voice.synthesize(text, wf)
+        return out_path
+
+
+# ---------- Remote: NVIDIA Magpie TTS NIM ----------
+
+class NvidiaMagpieProvider(TTSProvider):
+    """Works against a self-hosted Magpie NIM container or a build.nvidia.com
+    hosted endpoint. Uses the NIM REST surface at /v1/audio/synthesize."""
+
+    name = "nvidia"
+    default_ext = "wav"
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str | None,
+        language: str = "en-US",
+        voice_default: str = "Magpie-Multilingual.EN-US.Aria",
+    ):
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self._language = language
+        self._voice_default = voice_default
+
+    def synth(self, text: str, out_path: Path, voice: str | None) -> Path:
+        try:
+            import requests
+        except ImportError as e:
+            raise SystemExit("requests not installed. Try: pip install requests") from e
+        headers = {}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        url = f"{self._base_url}/v1/audio/synthesize"
+        r = requests.post(
+            url,
+            headers=headers,
+            data={
+                "language": self._language,
+                "text": text,
+                "voice": voice or self._voice_default,
+            },
+            timeout=600,
+        )
+        if r.status_code >= 400:
+            raise RuntimeError(f"NVIDIA TTS error {r.status_code}: {r.text[:300]}")
+        out_path.write_bytes(r.content)
+        return out_path
+
+
+# ---------- Remote: OpenAI ----------
+
+class OpenAIProvider(TTSProvider):
+    name = "openai"
+    default_ext = "mp3"
+
+    def __init__(self, api_key: str | None, model: str = "gpt-4o-mini-tts"):
+        try:
+            from openai import OpenAI  # type: ignore
+        except ImportError as e:
+            raise SystemExit("openai not installed. Try: pip install openai") from e
+        self._client = OpenAI(api_key=api_key) if api_key else OpenAI()
+        self._model = model
+
+    def synth(self, text: str, out_path: Path, voice: str | None) -> Path:
+        with self._client.audio.speech.with_streaming_response.create(
+            model=self._model,
+            voice=voice or "nova",
+            input=text,
+            response_format="mp3",
+        ) as resp:
+            resp.stream_to_file(str(out_path))
+        return out_path
+
+
+# ---------- Remote: ElevenLabs ----------
+
+class ElevenLabsProvider(TTSProvider):
+    name = "elevenlabs"
+    default_ext = "mp3"
+
+    def __init__(self, api_key: str | None, model: str = "eleven_multilingual_v2"):
+        try:
+            from elevenlabs.client import ElevenLabs  # type: ignore
+        except ImportError as e:
+            raise SystemExit("elevenlabs not installed. Try: pip install elevenlabs") from e
+        self._client = ElevenLabs(api_key=api_key) if api_key else ElevenLabs()
+        self._model = model
+
+    def synth(self, text: str, out_path: Path, voice: str | None) -> Path:
+        audio = self._client.text_to_speech.convert(
+            voice_id=voice or "JBFqnCBsd6RMkjVDRZzb",
+            model_id=self._model,
+            text=text,
+            output_format="mp3_44100_128",
+        )
+        with open(out_path, "wb") as f:
+            for chunk in audio:
+                if chunk:
+                    f.write(chunk)
+        return out_path
+
+
+# ---------- Orchestration ----------
+
+def build_provider(args: argparse.Namespace) -> TTSProvider:
+    p = args.provider
+    if p == "kokoro":
+        return KokoroProvider(voice_default=args.voice or "af_heart", lang=args.kokoro_lang)
+    if p == "piper":
+        return PiperProvider(voice_model=args.voice_model)
+    if p == "nvidia":
+        key = args.api_key or os.getenv("NVIDIA_API_KEY")
+        return NvidiaMagpieProvider(
+            base_url=args.nvidia_url,
+            api_key=key,
+            language=args.nvidia_language,
+            voice_default=args.voice or "Magpie-Multilingual.EN-US.Aria",
+        )
+    if p == "openai":
+        key = args.api_key or os.getenv("OPENAI_API_KEY")
+        return OpenAIProvider(api_key=key, model=args.openai_model)
+    if p == "elevenlabs":
+        key = args.api_key or os.getenv("ELEVENLABS_API_KEY")
+        return ElevenLabsProvider(api_key=key, model=args.elevenlabs_model)
+    raise SystemExit(f"Unknown provider: {p}")
+
+
+def safe_slug(s: str, limit: int = 40) -> str:
+    s = re.sub(r"[^A-Za-z0-9]+", "_", s).strip("_").lower()
+    return s[:limit] or "chapter"
+
+
+def render_chapters(
+    chapters: list[Chapter],
+    provider: TTSProvider,
+    voice: str | None,
+    out_dir: Path,
+) -> list[Path]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    paths: list[Path] = []
+    for ch in chapters:
+        text = clean_for_tts(ch.text)
+        if not text:
+            print(f"[skip] Chapter {ch.index}: empty after cleaning", file=sys.stderr)
+            continue
+        fname = f"ch{ch.index:02d}_{safe_slug(ch.title)}.{provider.default_ext}"
+        out_path = out_dir / fname
+        print(f"[{provider.name}] Chapter {ch.index}: {out_path}")
+        provider.synth(text, out_path, voice)
+        paths.append(out_path)
+    return paths
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description="Render a story markdown into per-chapter audio.")
+    ap.add_argument("--input", default=".tmp/story_output.md",
+                    help="Path to story markdown (default: .tmp/story_output.md)")
+    ap.add_argument("--output-dir", default=".tmp/audiobook",
+                    help="Where to write per-chapter audio files.")
+    ap.add_argument("--provider", required=True,
+                    choices=["kokoro", "piper", "nvidia", "openai", "elevenlabs"])
+    ap.add_argument("--voice", default=None,
+                    help="Provider-specific voice identifier (falls back to a sensible default).")
+    ap.add_argument("--api-key", default=None, help="Remote-provider API key (overrides env).")
+    ap.add_argument("--only", type=int, default=None,
+                    help="Render only this chapter index (1-based).")
+
+    # Kokoro
+    ap.add_argument("--kokoro-lang", default="a",
+                    help="Kokoro lang_code: a=American, b=British, etc.")
+    # Piper
+    ap.add_argument("--voice-model", default=None,
+                    help="Piper: path to .onnx voice model.")
+    # NVIDIA
+    ap.add_argument("--nvidia-url", default="http://localhost:9000",
+                    help="Base URL for Magpie TTS NIM (local container or hosted endpoint).")
+    ap.add_argument("--nvidia-language", default="en-US")
+    # OpenAI
+    ap.add_argument("--openai-model", default="gpt-4o-mini-tts")
+    # ElevenLabs
+    ap.add_argument("--elevenlabs-model", default="eleven_multilingual_v2")
+
+    return ap.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    md_path = Path(args.input)
+    if not md_path.exists():
+        raise SystemExit(f"Input not found: {md_path}")
+    chapters = parse_chapters(md_path.read_text(encoding="utf-8"))
+    if args.only is not None:
+        chapters = [c for c in chapters if c.index == args.only]
+        if not chapters:
+            raise SystemExit(f"--only {args.only} did not match any chapter.")
+    provider = build_provider(args)
+    paths = render_chapters(chapters, provider, args.voice, Path(args.output_dir))
+    print(f"\nWrote {len(paths)} file(s) to {args.output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/suno_prompt.py
+++ b/suno_prompt.py
@@ -21,14 +21,25 @@ Usage:
   python suno_prompt.py --input .tmp/story_output.md --output-dir .tmp/suno
   python suno_prompt.py --style "noir audiobook narration, jazz ambient bed"
   python suno_prompt.py --only 3
+
+LLM-segmented mode (`--llm-segment`) asks a DSPy-configured model to split
+each chapter into emotionally coherent segments and author a fresh Suno
+"Style of Music" string for each one. Falls back to greedy chunking if the
+LLM output fails validation.
 """
 from __future__ import annotations
 
 import argparse
+import logging
+import os
 import re
 from pathlib import Path
+from typing import Optional
 
 from audiobook import Chapter, parse_chapters, clean_for_tts, safe_slug
+
+
+logger = logging.getLogger("suno_prompt")
 
 
 DEFAULT_STYLE = (
@@ -41,6 +52,7 @@ LYRICS_HEADER = "[Spoken Word]\n[no singing]\n[no melody]\n"
 PARA_TAG = "[Narrator]"
 
 PROSE_CAP = 2500            # per-chunk prose budget
+PROSE_FLOOR = 500           # min chars per LLM segment (single-paragraph segments may be smaller)
 SENTENCE_RE = re.compile(r"(?<=[.!?])\s+(?=[A-Z\"'(])")
 
 
@@ -127,21 +139,193 @@ def render_chunk_file(
     )
 
 
-def emit_for_chapter(chapter: Chapter, out_dir: Path, style: str) -> list[Path]:
+# ---------- LLM-based segmentation (DSPy) ----------
+
+def _build_segment_signature():
+    """Lazy-build the DSPy signature/module so we don't import dspy unless used."""
+    import dspy  # type: ignore
+    from pydantic import BaseModel, Field
+
+    class ChapterSegment(BaseModel):
+        paragraph_start: int = Field(description="0-indexed first paragraph (inclusive).")
+        paragraph_end: int = Field(description="0-indexed last paragraph (inclusive).")
+        style: str = Field(description=(
+            "Suno 'Style of Music' string for this segment. Describe genre, "
+            "mood, instrumentation, tempo. Discourage melodic singing — this "
+            "is spoken-word audiobook narration with a music underscore."
+        ))
+        rationale: str = Field(description="One sentence explaining why these paragraphs form one beat.")
+
+    class SegmentChapterSig(dspy.Signature):
+        """Split a chapter into contiguous segments for music-backed
+        spoken-word narration via Suno. Each segment becomes a single Suno
+        generation and gets its own Style string matched to the segment's
+        emotional/narrative tone.
+
+        Hard rules:
+        - Segments are contiguous and ordered: segment[0].paragraph_start = 0,
+          segment[i].paragraph_start = segment[i-1].paragraph_end + 1, and
+          the last segment ends at len(paragraphs) - 1.
+        - Total prose chars in each segment must be <= max_chars.
+        - Multi-paragraph segments must have prose chars >= min_chars.
+          A single-paragraph segment may be shorter than min_chars only if
+          that paragraph's tone clearly differs from its neighbors.
+        - Prefer fewer, longer segments over many tiny ones; only split when
+          there's a real shift in tone, pace, location, or stakes.
+        - Style strings must be specific (instruments, mood, tempo) and
+          must include negative cues against melodic vocals (e.g.
+          "no singing, no melody on vocals, narration only").
+        """
+        chapter_title: str = dspy.InputField()
+        paragraphs: list[str] = dspy.InputField(desc="Chapter paragraphs in order, 0-indexed.")
+        min_chars: int = dspy.InputField()
+        max_chars: int = dspy.InputField()
+        segments: list[ChapterSegment] = dspy.OutputField()
+
+    class ChapterSegmenter(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.predict = dspy.ChainOfThought(SegmentChapterSig)
+
+        def forward(self, chapter_title, paragraphs, min_chars, max_chars):
+            return self.predict(
+                chapter_title=chapter_title,
+                paragraphs=paragraphs,
+                min_chars=min_chars,
+                max_chars=max_chars,
+            )
+
+    return ChapterSegmenter, ChapterSegment
+
+
+def configure_dspy(model: str, llm_url: Optional[str], api_key: Optional[str]) -> None:
+    import dspy  # type: ignore
+    kwargs = {}
+    if llm_url:
+        kwargs["api_base"] = llm_url
+    if api_key:
+        kwargs["api_key"] = api_key
+    elif "openai" in model.lower() and os.environ.get("OPENAI_API_KEY"):
+        kwargs["api_key"] = os.environ["OPENAI_API_KEY"]
+    lm = dspy.LM(model, max_tokens=4000, **kwargs)
+    dspy.configure(lm=lm)
+
+
+def _segments_valid(
+    segments,
+    paragraphs: list[str],
+    min_chars: int,
+    max_chars: int,
+) -> bool:
+    if not segments:
+        return False
+    n = len(paragraphs)
+    if segments[0].paragraph_start != 0 or segments[-1].paragraph_end != n - 1:
+        return False
+    for i, seg in enumerate(segments):
+        if seg.paragraph_start > seg.paragraph_end or seg.paragraph_end >= n:
+            return False
+        if i > 0 and seg.paragraph_start != segments[i - 1].paragraph_end + 1:
+            return False
+        if not seg.style or not seg.style.strip():
+            return False
+        span = paragraphs[seg.paragraph_start : seg.paragraph_end + 1]
+        prose_chars = sum(len(p) for p in span) + 2 * max(0, len(span) - 1)
+        if prose_chars > max_chars:
+            return False
+        if len(span) > 1 and prose_chars < min_chars:
+            return False
+    return True
+
+
+def llm_segment_chapter(
+    chapter: Chapter,
+    paragraphs: list[str],
+    min_chars: int,
+    max_chars: int,
+):
+    try:
+        ChapterSegmenter, _ = _build_segment_signature()
+        segmenter = ChapterSegmenter()
+        result = segmenter(
+            chapter_title=chapter.title,
+            paragraphs=paragraphs,
+            min_chars=min_chars,
+            max_chars=max_chars,
+        )
+        segments = list(result.segments or [])
+    except Exception as e:
+        logger.warning("LLM segmentation failed for %s: %s", chapter.title, e)
+        return None
+    if not _segments_valid(segments, paragraphs, min_chars, max_chars):
+        logger.warning(
+            "LLM segments for %s failed validation; falling back to greedy chunker.",
+            chapter.title,
+        )
+        return None
+    return segments
+
+
+# ---------- Emission ----------
+
+def _emit_chunk(
+    chapter: Chapter,
+    chunk_idx: int,
+    chunk_total: int,
+    paragraphs: list[str],
+    style: str,
+    out_dir: Path,
+) -> Path:
+    fname = f"ch{chapter.index:02d}_part{chunk_idx:02d}_{safe_slug(chapter.title)}.txt"
+    path = out_dir / fname
+    path.write_text(
+        render_chunk_file(chapter, chunk_idx, chunk_total, paragraphs, style),
+        encoding="utf-8",
+    )
+    return path
+
+
+def emit_for_chapter(
+    chapter: Chapter,
+    out_dir: Path,
+    style: str,
+    *,
+    use_llm: bool = False,
+    min_chars: int = PROSE_FLOOR,
+) -> list[Path]:
     text = clean_for_tts(chapter.text)
     if not text:
         return []
     paragraphs = split_paragraphs(text)
-    chunks = chunk_paragraphs(paragraphs, cap=PROSE_CAP)
+
+    segments = (
+        llm_segment_chapter(chapter, paragraphs, min_chars, PROSE_CAP)
+        if use_llm
+        else None
+    )
+
     paths: list[Path] = []
+    if segments is not None:
+        # One file per LLM segment, using the LLM-authored style. Sentence-split
+        # any single-paragraph segment that exceeds the cap.
+        emitted_chunks: list[tuple[list[str], str]] = []
+        for seg in segments:
+            span = paragraphs[seg.paragraph_start : seg.paragraph_end + 1]
+            prose_chars = sum(len(p) for p in span) + 2 * max(0, len(span) - 1)
+            if prose_chars <= PROSE_CAP:
+                emitted_chunks.append((span, seg.style))
+                continue
+            # Single-paragraph oversize: sentence-split, reuse same style.
+            for piece in split_long_paragraph(span[0], PROSE_CAP):
+                emitted_chunks.append(([piece], seg.style))
+        for i, (chunk, chunk_style) in enumerate(emitted_chunks, start=1):
+            paths.append(_emit_chunk(chapter, i, len(emitted_chunks), chunk, chunk_style, out_dir))
+        return paths
+
+    # Greedy fallback (also the default when --llm-segment is off).
+    chunks = chunk_paragraphs(paragraphs, cap=PROSE_CAP)
     for i, chunk in enumerate(chunks, start=1):
-        fname = f"ch{chapter.index:02d}_part{i:02d}_{safe_slug(chapter.title)}.txt"
-        path = out_dir / fname
-        path.write_text(
-            render_chunk_file(chapter, i, len(chunks), chunk, style),
-            encoding="utf-8",
-        )
-        paths.append(path)
+        paths.append(_emit_chunk(chapter, i, len(chunks), chunk, style, out_dir))
     return paths
 
 
@@ -150,14 +334,25 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     ap.add_argument("--input", default=".tmp/story_output.md")
     ap.add_argument("--output-dir", default=".tmp/suno_prompts")
     ap.add_argument("--style", default=DEFAULT_STYLE,
-                    help="Override the Suno 'Style of Music' string.")
+                    help="Default Suno 'Style of Music' string (used unless --llm-segment overrides per segment).")
     ap.add_argument("--only", type=int, default=None,
                     help="Emit prompts only for this chapter index (1-based).")
+    ap.add_argument("--llm-segment", action="store_true",
+                    help="Use a DSPy LM to split chapters into emotionally coherent segments and author a Suno style per segment.")
+    ap.add_argument("--min-chars", type=int, default=PROSE_FLOOR,
+                    help=f"Minimum prose chars per multi-paragraph LLM segment (default {PROSE_FLOOR}).")
+    ap.add_argument("--model", default=os.environ.get("MODEL", "openai/gpt-4o-mini"),
+                    help="DSPy model id (used only with --llm-segment). Defaults to MODEL env var.")
+    ap.add_argument("--llm-url", default=os.environ.get("LLM_URL"),
+                    help="Custom API base URL (e.g. Ollama).")
+    ap.add_argument("--api-key", default=os.environ.get("API_KEY"),
+                    help="API key for the LLM (overrides env).")
     return ap.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
     md_path = Path(args.input)
     if not md_path.exists():
         raise SystemExit(f"Input not found: {md_path}")
@@ -166,11 +361,17 @@ def main(argv: list[str] | None = None) -> int:
         chapters = [c for c in chapters if c.index == args.only]
         if not chapters:
             raise SystemExit(f"--only {args.only} did not match any chapter.")
+    if args.llm_segment:
+        configure_dspy(args.model, args.llm_url, args.api_key)
     out_dir = Path(args.output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     total = 0
     for ch in chapters:
-        paths = emit_for_chapter(ch, out_dir, args.style)
+        paths = emit_for_chapter(
+            ch, out_dir, args.style,
+            use_llm=args.llm_segment,
+            min_chars=args.min_chars,
+        )
         total += len(paths)
         print(f"{ch.title}: {len(paths)} chunk(s)")
     print(f"\nWrote {total} prompt file(s) to {out_dir}")

--- a/suno_prompt.py
+++ b/suno_prompt.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Emit copy-pasteable Suno prompts (Style + Lyrics) from a story_writer
+markdown.
+
+Suno is a music engine first, narrator second. This script doesn't call any
+API: it produces per-chunk `.txt` files you paste into Suno's Custom mode
+(Style of Music + Lyrics fields). Each chunk:
+
+  * Stays under 2500 characters of prose so total lyrics (prose + tags) fit
+    comfortably under Suno's 5000-character lyrics cap with a safe buffer.
+  * Packs greedily on paragraph boundaries — never splits a paragraph unless
+    that paragraph alone exceeds the cap, in which case it splits on sentence
+    boundaries.
+  * Wraps each paragraph in a fresh `[Narrator]` tag so Suno re-evaluates
+    tone per paragraph (helps when emotion shifts between paragraphs).
+  * Prepends `[Spoken Word]` / `[no singing]` / `[no melody]` to bias the
+    model away from melodic vocals.
+
+Usage:
+  python suno_prompt.py
+  python suno_prompt.py --input .tmp/story_output.md --output-dir .tmp/suno
+  python suno_prompt.py --style "noir audiobook narration, jazz ambient bed"
+  python suno_prompt.py --only 3
+"""
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+from audiobook import Chapter, parse_chapters, clean_for_tts, safe_slug
+
+
+DEFAULT_STYLE = (
+    "spoken word audiobook narration, warm baritone narrator, "
+    "gentle cinematic ambient underscore, slow calm pacing, "
+    "no singing, no melodic vocals, no chorus, no rap"
+)
+
+LYRICS_HEADER = "[Spoken Word]\n[no singing]\n[no melody]\n"
+PARA_TAG = "[Narrator]"
+
+PROSE_CAP = 2500            # per-chunk prose budget
+SENTENCE_RE = re.compile(r"(?<=[.!?])\s+(?=[A-Z\"'(])")
+
+
+def split_paragraphs(text: str) -> list[str]:
+    paras = [p.strip() for p in re.split(r"\n\s*\n", text) if p.strip()]
+    return paras
+
+
+def split_long_paragraph(p: str, cap: int) -> list[str]:
+    """Sentence-pack a too-long paragraph into <=cap pieces."""
+    sentences = SENTENCE_RE.split(p)
+    out: list[str] = []
+    buf = ""
+    for s in sentences:
+        candidate = (buf + " " + s).strip() if buf else s
+        if len(candidate) <= cap:
+            buf = candidate
+            continue
+        if buf:
+            out.append(buf)
+        if len(s) <= cap:
+            buf = s
+        else:
+            # Sentence itself exceeds cap; hard-wrap on whitespace.
+            for i in range(0, len(s), cap):
+                out.append(s[i : i + cap])
+            buf = ""
+    if buf:
+        out.append(buf)
+    return out
+
+
+def chunk_paragraphs(paragraphs: list[str], cap: int = PROSE_CAP) -> list[list[str]]:
+    """Greedy pack paragraphs into chunks up to `cap` chars of prose."""
+    chunks: list[list[str]] = []
+    current: list[str] = []
+    used = 0
+    for p in paragraphs:
+        pieces = [p] if len(p) <= cap else split_long_paragraph(p, cap)
+        for piece in pieces:
+            cost = len(piece) + (2 if current else 0)  # +2 for paragraph break
+            if used + cost > cap and current:
+                chunks.append(current)
+                current = [piece]
+                used = len(piece)
+            else:
+                current.append(piece)
+                used += cost
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def render_lyrics_block(paragraphs: list[str]) -> str:
+    body = "\n\n".join(f"{PARA_TAG}\n{p}" for p in paragraphs)
+    return f"{LYRICS_HEADER}\n{body}\n"
+
+
+def render_chunk_file(
+    chapter: Chapter,
+    chunk_idx: int,
+    chunk_total: int,
+    paragraphs: list[str],
+    style: str,
+) -> str:
+    lyrics = render_lyrics_block(paragraphs)
+    prose_chars = sum(len(p) for p in paragraphs)
+    tips = (
+        "- Use Suno Custom mode; paste Style above into 'Style of Music' and Lyrics into 'Lyrics'.\n"
+        "- Leave 'Instrumental' UNCHECKED — you want vocals, just not melodic ones.\n"
+        "- If it starts singing, regenerate or strengthen the negative cues "
+        "(e.g. add 'monotone, deadpan' to style).\n"
+        "- For consistent voice across chunks, reuse the same Persona/Style for every paste."
+    )
+    return (
+        f"=== STYLE (paste into 'Style of Music') ===\n{style}\n\n"
+        f"=== LYRICS (paste into 'Lyrics') ===\n{lyrics}\n"
+        f"=== TIPS ===\n{tips}\n\n"
+        f"--- meta ---\n"
+        f"chapter: {chapter.title}\n"
+        f"chunk: {chunk_idx}/{chunk_total}\n"
+        f"prose_chars: {prose_chars}\n"
+        f"lyrics_chars: {len(lyrics)}\n"
+    )
+
+
+def emit_for_chapter(chapter: Chapter, out_dir: Path, style: str) -> list[Path]:
+    text = clean_for_tts(chapter.text)
+    if not text:
+        return []
+    paragraphs = split_paragraphs(text)
+    chunks = chunk_paragraphs(paragraphs, cap=PROSE_CAP)
+    paths: list[Path] = []
+    for i, chunk in enumerate(chunks, start=1):
+        fname = f"ch{chapter.index:02d}_part{i:02d}_{safe_slug(chapter.title)}.txt"
+        path = out_dir / fname
+        path.write_text(
+            render_chunk_file(chapter, i, len(chunks), chunk, style),
+            encoding="utf-8",
+        )
+        paths.append(path)
+    return paths
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--input", default=".tmp/story_output.md")
+    ap.add_argument("--output-dir", default=".tmp/suno_prompts")
+    ap.add_argument("--style", default=DEFAULT_STYLE,
+                    help="Override the Suno 'Style of Music' string.")
+    ap.add_argument("--only", type=int, default=None,
+                    help="Emit prompts only for this chapter index (1-based).")
+    return ap.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    md_path = Path(args.input)
+    if not md_path.exists():
+        raise SystemExit(f"Input not found: {md_path}")
+    chapters = parse_chapters(md_path.read_text(encoding="utf-8"))
+    if args.only is not None:
+        chapters = [c for c in chapters if c.index == args.only]
+        if not chapters:
+            raise SystemExit(f"--only {args.only} did not match any chapter.")
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    total = 0
+    for ch in chapters:
+        paths = emit_for_chapter(ch, out_dir, args.style)
+        total += len(paths)
+        print(f"{ch.title}: {len(paths)} chunk(s)")
+    print(f"\nWrote {total} prompt file(s) to {out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- `audiobook.py`: standalone script that parses `## Final Story` → `### Chapter N` from `story_output.md` and renders one audio file per chapter via a pluggable provider. Local (Kokoro, Piper) and remote (NVIDIA Magpie TTS NIM, OpenAI, ElevenLabs) providers share a thin adapter with lazy SDK imports, so you only install what you use.
- `suno_prompt.py`: separate script that emits copy-pasteable Suno prompts (Style + Lyrics) chunked greedily on paragraph boundaries up to ~2500 prose chars (under Suno's 5000-char lyrics cap). Each paragraph is wrapped in a fresh `[Narrator]` tag so Suno re-evaluates tone across paragraph-level emotion shifts; lyrics are prefixed with `[Spoken Word]` / `[no singing]` / `[no melody]` to bias against melodic vocals. Oversized paragraphs are sentence-split.
- README updated with usage for both scripts.

## Test plan
- [x] `python audiobook.py --help` renders.
- [x] Chapter parser smoke test: extracts `### Chapter ...` from `## Final Story`, strips images/links/inline markdown.
- [x] `suno_prompt.py` smoke test with a synthetic 5400-char paragraph: produces 4 chunks, max lyrics size 2535 chars (well under 5000 cap), all chunks contain `[Spoken Word]` and `[Narrator]`.
- [ ] End-to-end TTS run with at least one local and one remote provider against a real `story_output.md`.

https://claude.ai/code/session_01WFeGGg84ZebTLAF9iKLsMo

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFeGGg84ZebTLAF9iKLsMo)_