### PR TITLE
ci: add real-LLM integration workflow and provider-agnostic API key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Model configuration
 MODEL=openai/gpt-4o-mini
 LLM_URL=
+# Provider-agnostic API key. LLM_API_KEY takes precedence, then API_KEY,
+# then OPENAI_API_KEY (kept for back-compat).
+LLM_API_KEY=
 API_KEY=
 
 # DSPy cache

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,49 @@
+name: Integration (real LLM)
+
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "Model identifier (e.g. openai/llama-3.3-70b-versatile)"
+        required: false
+      llm_url:
+        description: "Base URL (e.g. https://api.groq.com/openai/v1)"
+        required: false
+  schedule:
+    - cron: "0 6 * * 1"  # Mondays 06:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  real-llm:
+    runs-on: ubuntu-latest
+    environment: llm-integration
+    env:
+      MODEL: ${{ inputs.model || vars.LLM_MODEL }}
+      LLM_URL: ${{ inputs.llm_url || vars.LLM_URL }}
+      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run end-to-end pipeline
+        run: python scripts/run_integration.py
+
+      - name: Upload story output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: story_output
+          path: .tmp/story_output.md
+          if-no-files-found: warn

--- a/dspy_runtime.py
+++ b/dspy_runtime.py
@@ -44,22 +44,37 @@ def dspy_config_from_namespace(args: Namespace) -> DSPyConfig:
     )
 
 
+_API_KEY_ENV_VARS = ("LLM_API_KEY", "API_KEY", "OPENAI_API_KEY")
+
+
+def resolve_api_key(explicit: str | None = None) -> str | None:
+    """Resolve an API key from explicit value or provider-agnostic env vars.
+
+    Checks LLM_API_KEY, API_KEY, OPENAI_API_KEY in that order.
+    """
+    if explicit:
+        return explicit
+    for name in _API_KEY_ENV_VARS:
+        value = os.environ.get(name)
+        if value:
+            return value
+    return None
+
+
 def configure_dspy(config: DSPyConfig) -> None:
     """Configure DSPy LM and optional instrumentation."""
     kwargs: dict[str, str] = {}
     if config.api_base:
         kwargs["api_base"] = config.api_base
-    if config.api_key is not None:
-        kwargs["api_key"] = config.api_key
-    elif "openai" in config.model_name.lower():
-        env_key = os.environ.get("OPENAI_API_KEY")
-        if env_key:
-            kwargs["api_key"] = env_key
-        else:
-            logger.warning(
-                "OPENAI_API_KEY not found in environment variables. "
-                "Assuming mock or alternative setup."
-            )
+
+    api_key = resolve_api_key(config.api_key)
+    if api_key:
+        kwargs["api_key"] = api_key
+    elif "ollama" not in config.model_name.lower() and config.model_name != "mock":
+        logger.warning(
+            "No API key found (checked LLM_API_KEY, API_KEY, OPENAI_API_KEY). "
+            "Assuming mock or local setup."
+        )
 
     dspy.configure_cache(
         enable_disk_cache=config.cache,

--- a/scripts/run_integration.py
+++ b/scripts/run_integration.py
@@ -1,0 +1,44 @@
+"""Run the end-to-end story pipeline against a real LLM provider.
+
+Reads MODEL, LLM_URL, and the provider-agnostic API key from environment
+(see dspy_runtime.resolve_api_key for the lookup order). Intended for CI
+integration jobs and local smoke tests.
+"""
+
+import argparse
+import os
+import sys
+
+from dotenv import load_dotenv
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from test_story import test_pipeline  # noqa: E402
+
+
+def main() -> int:
+    load_dotenv()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default=os.environ.get("MODEL"))
+    parser.add_argument("--llm-url", default=os.environ.get("LLM_URL"))
+    parser.add_argument("--max-tokens", type=int, default=2048)
+    parser.add_argument("--output-dir", default=".tmp")
+    args = parser.parse_args()
+
+    if not args.model:
+        parser.error("MODEL env var or --model is required")
+
+    test_pipeline(
+        model_name=args.model,
+        api_base=args.llm_url or None,
+        api_key=None,
+        output_dir=args.output_dir,
+        max_tokens=args.max_tokens,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test_story.py
+++ b/test_story.py
@@ -239,18 +239,15 @@ def test_pipeline(
 ):
     from image_gen import ImageGenerator
 
+    from dspy_runtime import resolve_api_key
+
     kwargs = {"max_tokens": max_tokens}
     if api_base:
         kwargs["api_base"] = api_base
 
-    if api_key is not None:
-        kwargs["api_key"] = api_key
-    elif "openai" in model_name.lower():
-        env_key = os.environ.get("OPENAI_API_KEY")
-        if env_key:
-            kwargs["api_key"] = env_key
-    elif "ollama" in model_name.lower():
-        pass
+    resolved_key = resolve_api_key(api_key)
+    if resolved_key:
+        kwargs["api_key"] = resolved_key
 
     logger.info(f"Testing pipeline with model: {model_name}...")
     logger.debug(
@@ -285,10 +282,11 @@ def test_pipeline(
         lm = MockLM()
         dspy.configure(lm=lm, callbacks=callbacks)
     else:
-        # We assume OPENAI_API_KEY is available in the run_in_bash_session, if not, we skip the actual test
-        if "openai" in model_name.lower() and not kwargs.get("api_key"):
+        needs_key = "ollama" not in model_name.lower()
+        if needs_key and not kwargs.get("api_key"):
             logger.warning(
-                "OPENAI_API_KEY not found. Skipping full integration test to avoid errors."
+                "No API key found (checked LLM_API_KEY, API_KEY, OPENAI_API_KEY). "
+                "Skipping full integration test to avoid errors."
             )
             return
 


### PR DESCRIPTION
- Introduce LLM_API_KEY as the primary provider-agnostic env var, with
  API_KEY and OPENAI_API_KEY as fallbacks. Resolution centralised in
  dspy_runtime.resolve_api_key and reused by test_story.test_pipeline.
- Drop the model-name-must-contain-"openai" gate in the test harness so
  Groq, OpenRouter, Gemini, NVIDIA NIM, etc. work without code changes.
- Add scripts/run_integration.py wrapper that drives test_pipeline from
  env vars (MODEL, LLM_URL, LLM_API_KEY).
- Add .github/workflows/integration.yml: workflow_dispatch + weekly
  cron, gated behind an "llm-integration" Environment so the secret
  cannot leak via fork PRs.

https://claude.ai/code/session_01MWM5Jj1cUpDtEkcB92XDYc