### PR TITLE
feat(story): act-aware spine slicing for chapter drafting

### DIFF
--- a/mymain.py
+++ b/mymain.py
@@ -77,6 +77,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--idea", type=str, required=False, help="The initial story idea/prompt")
     parser.add_argument("--title", type=str, required=False, help="The title of the story")
+    parser.add_argument("--number-of-chapters", type=int, default=7, help="The number of chapters to generate")
     parser.add_argument("--output-file", default=".tmp/story.md")
     return parser.parse_args()
 
@@ -113,5 +114,5 @@ if __name__ == "__main__":
     initialize_artifact(args.output_file)
     update_artifact(args.output_file, "Generation Parameters", format_generation_parameters(args))
     
-    logger.info("Starting story writer")
-    write(args.idea, args.title, args.output_file)
+    logger.info("Starting story writer with %d chapters", args.number_of_chapters)
+    write(args.idea, args.title, args.output_file, args.number_of_chapters)

--- a/pipeline.py
+++ b/pipeline.py
@@ -94,7 +94,7 @@ def build_world_bible(updated_idea: str, story_title: str, spine: str, output_fi
 
 
 @observe()
-def write(idea: str, title: str, output_file: str):
+def write(idea: str, title: str, output_file: str, number_of_chapters: int = 7):
     logger.info("STEP clarify_idea | inputs idea=%s | title=%s",
                 _snip(idea), _snip(title, 80))
     updated_idea, story_title = run_clarify_idea(idea, title)
@@ -131,10 +131,10 @@ def write(idea: str, title: str, output_file: str):
         return
 
     # Chapters plan
-    logger.info("STEP chapters_plan | inputs idea=%s | title=%s | spine=%s | world_bible(chars=%d, locs=%d)",
+    logger.info("STEP chapters_plan | inputs idea=%s | title=%s | spine=%s | world_bible(chars=%d, locs=%d) | number_of_chapters=%d",
                 _snip(updated_idea), _snip(story_title, 80), _snip(spine),
-                len(world_bible.characters), len(world_bible.locations))
-    chapters_plan = run_generate_chapters_plan(updated_idea, story_title, spine, world_bible)
+                len(world_bible.characters), len(world_bible.locations), number_of_chapters)
+    chapters_plan = run_generate_chapters_plan(updated_idea, story_title, spine, world_bible, number_of_chapters)
     logger.info("STEP chapters_plan | output count=%d", len(chapters_plan))
     update_artifact(output_file, "Chapters Plan", "", level=3)
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -151,7 +151,10 @@ def write(idea: str, title: str, output_file: str, number_of_chapters: int = 7):
         chapter_plan_str = f"{chapter.chapter_title}\n{chapter.chapter_beats}"
         logger.info("STEP enhance_chapter[%d/%d] | chapter_outline=%s | story_so_far_len=%d",
                     i, len(chapters_plan), _snip(chapter_plan_str, 200), len(story_so_far))
-        enhanced = run_enhance_chapter(chapter_plan_str, updated_idea, story_title, spine, world_bible, story_so_far)
+        enhanced = run_enhance_chapter(
+            chapter_plan_str, updated_idea, story_title, spine, world_bible, story_so_far,
+            chapter_index=i, total_chapters=len(chapters_plan),
+        )
         logger.info("STEP enhance_chapter[%d/%d] | output_chars=%d preview=%s",
                     i, len(chapters_plan), len(enhanced), _snip(enhanced, 240))
         update_artifact(output_file, f"Chapter {i}: {chapter.chapter_title}", enhanced, level=3)

--- a/qa.py
+++ b/qa.py
@@ -1,0 +1,279 @@
+"""Post-generation quality checks for story markdown output.
+
+Each check is a pure function: takes the path of a story `.md` artifact and
+returns a list of `Finding` records. The CLI in `scripts/run_qa.py` runs all
+checks and prints a comparative report.
+
+The story markdown is expected to follow the layout produced by `mymain.py`:
+
+    # Story
+    ## ...                # generation params, idea, premise, spine
+    ## World bible
+    ### Rules of the World
+    ### Locations
+        - <bullet>, <description>
+        ...
+    #### Location 1
+    #### Location 2
+    ...
+    ### Characters
+        1. <name>, <description>
+        ...
+    #### Character 1
+    ...
+    ### Timeline
+    ## Final Story
+    ### Chapter 1: <title>
+    ...
+"""
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+NGRAM = 5
+WORD_RE = re.compile(r"[A-Za-z']+")
+PROPER_NOUN_RE = re.compile(r"\b([A-Z][a-z]+(?:\s+(?:the\s+)?[A-Z][a-z]+){0,2})\b")
+
+
+@dataclass
+class Finding:
+    check: str
+    severity: str  # "info" | "warn" | "fail"
+    message: str
+
+
+# --- section parsing ---------------------------------------------------------
+
+def _read(path: Path) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
+def _section(text: str, heading_level: int, heading: str) -> str:
+    """Return the body under `<level> heading`, up to the next heading at the
+    same level (`## ...` for level 2, `### ...` for level 3)."""
+    prefix = "#" * heading_level + " "
+    same_level_re = re.compile(rf"^#{{{heading_level}}} (?!#)")
+    lines = text.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip() == f"{prefix}{heading}":
+            start = i + 1
+            break
+    if start is None:
+        return ""
+    end = len(lines)
+    for j in range(start, len(lines)):
+        if same_level_re.match(lines[j]):
+            end = j
+            break
+    return "\n".join(lines[start:end])
+
+
+def split_chapters(text: str) -> dict[str, str]:
+    final = _section(text, 2, "Final Story")
+    chapters: dict[str, str] = {}
+    current = None
+    buf: list[str] = []
+    for line in final.splitlines():
+        if line.startswith("### "):
+            if current is not None:
+                chapters[current] = "\n".join(buf).strip()
+            current = line[4:].strip()
+            buf = []
+        else:
+            buf.append(line)
+    if current is not None:
+        chapters[current] = "\n".join(buf).strip()
+    return chapters
+
+
+def character_bullets(text: str) -> list[str]:
+    """Return the list of `<name>, <desc>` bullets from `### Characters`.
+    Only the first numbered list is read; enhanced `#### Character N` blocks
+    are skipped."""
+    section = _section(text, 3, "Characters")
+    bullets: list[str] = []
+    for line in section.splitlines():
+        m = re.match(r"^\s*\d+\.\s+(.+)", line)
+        if m:
+            bullets.append(m.group(1).strip())
+    return bullets
+
+
+_NAME_DELIM_RE = re.compile(r"[,:;—–\-]")
+_GENERIC_FIRST_TOKENS = {"The", "A", "An"}
+
+
+def canonical_name(bullet: str) -> str:
+    """Return the head of a `Name <delim> description` bullet.
+
+    Tries the first comma, colon, semicolon, em-dash, en-dash, or hyphen — whichever
+    comes first."""
+    m = _NAME_DELIM_RE.search(bullet)
+    head = bullet[: m.start()] if m else bullet
+    return head.strip()
+
+
+# --- check 1: cross-chapter phrase reuse -------------------------------------
+
+def _words(text: str) -> list[str]:
+    return [m.group(0).lower() for m in WORD_RE.finditer(text)]
+
+
+def _ngrams(toks: list[str], n: int) -> set[tuple[str, ...]]:
+    return {tuple(toks[i : i + n]) for i in range(len(toks) - n + 1)}
+
+
+def check_cross_chapter_phrase_reuse(text: str, n: int = NGRAM, min_chapters: int = 2) -> list[Finding]:
+    """Detect n-gram phrases reused verbatim across multiple chapters.
+
+    Excludes phrases that appear in the World bible (those are caught by the
+    bible-leakage check)."""
+    chapters = split_chapters(text)
+    bible_grams = _ngrams(_words(_section(text, 2, "World bible")), n)
+
+    by_chapter: dict[str, set[tuple[str, ...]]] = {
+        title: _ngrams(_words(body), n) for title, body in chapters.items()
+    }
+
+    counter: Counter[tuple[str, ...]] = Counter()
+    for grams in by_chapter.values():
+        for g in grams:
+            counter[g] += 1
+
+    findings: list[Finding] = []
+    repeated = [
+        (g, c) for g, c in counter.items()
+        if c >= min_chapters and g not in bible_grams
+    ]
+    repeated.sort(key=lambda x: -x[1])
+    for gram, count in repeated[:10]:
+        findings.append(Finding(
+            check="cross_chapter_phrase_reuse",
+            severity="warn",
+            message=f"x{count} chapters: '{' '.join(gram)}'",
+        ))
+    findings.append(Finding(
+        check="cross_chapter_phrase_reuse",
+        severity="info",
+        message=f"total repeated {n}-grams across {len(chapters)} chapters: {len(repeated)}",
+    ))
+    return findings
+
+
+# --- check 2: name drift -----------------------------------------------------
+
+def _proper_nouns(body: str) -> Counter[str]:
+    """Return counts of capitalized 1-3 word sequences in `body`."""
+    counts: Counter[str] = Counter()
+    for m in PROPER_NOUN_RE.finditer(body):
+        counts[m.group(1)] += 1
+    return counts
+
+
+def check_name_drift(text: str) -> list[Finding]:
+    """Flag chapter-prose names that look like drifted variants of canonical
+    character names (same first token, different full name)."""
+    bullets = character_bullets(text)
+    canonical = [canonical_name(b) for b in bullets]
+    canonical_set = set(canonical)
+    # Skip generic first tokens like "The"/"A"/"An" so that a canonical
+    # like "The Young Mage" doesn't mark every "The X" proper noun in
+    # chapters as drift.
+    canonical_first_tokens = {
+        n.split()[0] for n in canonical
+        if n and n.split()[0] not in _GENERIC_FIRST_TOKENS
+    }
+
+    chapters = split_chapters(text)
+    chapter_prose = "\n\n".join(chapters.values())
+    seen = _proper_nouns(chapter_prose)
+
+    findings: list[Finding] = []
+    drifts: dict[str, set[str]] = {}
+    for proper, count in seen.items():
+        first = proper.split()[0]
+        if first not in canonical_first_tokens:
+            continue
+        if proper in canonical_set:
+            continue  # exact canonical match — fine
+        # Same first token, different full form — possible drift
+        # Skip cases where the chapter form is a strict prefix of the canonical
+        # (e.g. "Kaelen" alone when canonical is "Kaelen Vey") — that's a
+        # legitimate first-name reference, not drift.
+        canonical_with_same_first = [n for n in canonical if n.split()[0] == first]
+        is_strict_prefix = any(
+            c == proper or c.startswith(proper + " ") for c in canonical_with_same_first
+        )
+        if is_strict_prefix:
+            continue
+        drifts.setdefault(first, set()).add(proper)
+
+    for first, variants in drifts.items():
+        canonical_form = next(n for n in canonical if n.split()[0] == first)
+        findings.append(Finding(
+            check="name_drift",
+            severity="fail",
+            message=f"canonical='{canonical_form}' but chapters also use: {sorted(variants)}",
+        ))
+
+    if not drifts:
+        findings.append(Finding(
+            check="name_drift",
+            severity="info",
+            message=f"no drift detected ({len(canonical)} canonical names)",
+        ))
+    return findings
+
+
+# --- check 3: character presence --------------------------------------------
+
+def check_character_presence(text: str) -> list[Finding]:
+    """Each canonical character must appear in chapter prose at least once."""
+    bullets = character_bullets(text)
+    canonical = [canonical_name(b) for b in bullets]
+    chapter_prose = "\n\n".join(split_chapters(text).values())
+
+    findings: list[Finding] = []
+    missing: list[str] = []
+    for name in canonical:
+        # Match full name OR first token (e.g. "Kaelen" alone is OK for
+        # "Kaelen Vey").
+        first = name.split()[0]
+        if name in chapter_prose or re.search(rf"\b{re.escape(first)}\b", chapter_prose):
+            continue
+        missing.append(name)
+
+    for name in missing:
+        findings.append(Finding(
+            check="character_presence",
+            severity="fail",
+            message=f"character never appears in chapters: '{name}'",
+        ))
+    if not missing:
+        findings.append(Finding(
+            check="character_presence",
+            severity="info",
+            message=f"all {len(canonical)} characters appear in chapters",
+        ))
+    return findings
+
+
+# --- runner ------------------------------------------------------------------
+
+CHECKS = [
+    check_cross_chapter_phrase_reuse,
+    check_name_drift,
+    check_character_presence,
+]
+
+
+def run_all(path: Path) -> list[Finding]:
+    text = _read(path)
+    out: list[Finding] = []
+    for check in CHECKS:
+        out.extend(check(text))
+    return out

--- a/scripts/run_qa.py
+++ b/scripts/run_qa.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Run the QA detection suite on one or more story markdown files."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Add repo root so `import qa` works when run from anywhere.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from qa import run_all  # noqa: E402
+
+
+SEVERITY_RANK = {"fail": 0, "warn": 1, "info": 2}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="+", type=Path, help="story markdown file(s)")
+    args = parser.parse_args(argv)
+
+    exit_code = 0
+    for path in args.paths:
+        if not path.is_file():
+            print(f"!! not a file: {path}")
+            exit_code = 1
+            continue
+        print(f"\n=== {path} ===")
+        findings = run_all(path)
+        findings.sort(key=lambda f: (SEVERITY_RANK.get(f.severity, 9), f.check))
+        for f in findings:
+            tag = {"fail": "FAIL", "warn": "WARN", "info": "info"}[f.severity]
+            print(f"[{tag}] {f.check}: {f.message}")
+            if f.severity == "fail":
+                exit_code = 2
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/story.py
+++ b/story.py
@@ -1,3 +1,4 @@
+import math
 import random
 from dataclasses import dataclass
 
@@ -449,6 +450,56 @@ def run_generate_chapters_plan(
             return chapters.chapters
 
 
+_ACT_LABELS = {
+    1: "Act 1: Setup",
+    2: "Act 2: Confrontation",
+    3: "Act 3: Resolution",
+}
+
+
+def act_hint_for_chapter(i: int, n: int, story_spine: str) -> dict:
+    """Map 1-indexed chapter `i` (of `n`) onto a 3-act structure.
+
+    Splits chapters using a ~25/50/25 ratio, with at least one chapter per
+    act when n >= 3. Returns the act number, a human-readable label, and
+    the spine sliced up to and including the current act (so chapter prose
+    only sees beats it should know about, not later-act foreshadowing).
+    """
+    if n >= 3:
+        a1 = max(1, math.ceil(n / 4))
+        a3 = max(1, math.ceil(n / 4))
+        a2 = n - a1 - a3
+        if a2 < 1:
+            a2 = 1
+            a3 = max(1, n - a1 - a2)
+            a1 = max(1, n - a2 - a3)
+    elif n == 2:
+        a1, a2, a3 = 1, 0, 1
+    else:
+        a1, a2, a3 = 1, 0, 0
+
+    if i <= a1:
+        act = 1
+    elif i <= a1 + a2:
+        act = 2
+    else:
+        act = 3
+
+    # Spine is 7 newline-separated beats from Pixar's formula:
+    # 0:once_upon_a_time 1:every_day 2:until_one_day  -> Act 1
+    # 3:because_of_that 4:and_because_of_that         -> Act 2
+    # 5:until_finally 6:ever_since_that_day           -> Act 3
+    beats = story_spine.split("\n")
+    cutoff = {1: 3, 2: 5, 3: 7}[act]
+    spine_through_act = "\n".join(beats[:cutoff])
+
+    return {
+        "act": act,
+        "label": _ACT_LABELS[act],
+        "spine_through_act": spine_through_act,
+    }
+
+
 @observe()
 def run_enhance_chapter(
     chapter: str,
@@ -457,6 +508,8 @@ def run_enhance_chapter(
     story_spine: str,
     world_bible: WorldBible,
     story_so_far: str,
+    chapter_index: int = 1,
+    total_chapters: int = 1,
 ):
     class DraftChapter(dspy.Signature):
         """Write the chapter prose.
@@ -469,10 +522,17 @@ a cost paid on the page). End on an action or image, not a thematic aphorism.
 Vary sentence rhythm; avoid stacking triadic 'X and Y' constructions or
 'not X but Y' parallelism. Show the world's cost on a body or an object rather
 than restating it.
+
+Write this chapter in a tone appropriate to {act_hint}; do not foreshadow
+events from later acts. The story_spine you receive only covers beats up to
+and including the current act — treat anything beyond it as not yet decided.
 """
         story_idea: str = dspy.InputField()
         story_title: str = dspy.InputField()
         story_spine: str = dspy.InputField()
+        act_hint: str = dspy.InputField(
+            desc="Which act of the three-act structure this chapter belongs to",
+        )
         rules_of_the_world: list[str] = dspy.InputField()
         characters: list[str] = dspy.InputField()
         locations: list[str] = dspy.InputField()
@@ -500,13 +560,16 @@ than restating it.
             desc="Random detail that doesn't influence the chapter but makes it more interesting. Scenry description or quirky item or a meal or something else fitting the setting",
         )
 
+    hint = act_hint_for_chapter(chapter_index, total_chapters, story_spine)
+    spine_for_draft = hint["spine_through_act"]
+
     random_detail = ""
     random_gen = dspy.ChainOfThought(GenerateRandomDetail)
     if random.random() < 0.33:
         random_detail = random_gen(
             story_idea=story_idea,
             story_title=story_title,
-            story_spine=story_spine,
+            story_spine=spine_for_draft,
             rules_of_the_world=world_bible.rules_of_the_world,
             characters=world_bible.characters,
             locations=world_bible.locations,
@@ -520,7 +583,8 @@ than restating it.
         result = draft_chapter_func(
             story_idea=story_idea,
             story_title=story_title,
-            story_spine=story_spine,
+            story_spine=spine_for_draft,
+            act_hint=hint["label"],
             rules_of_the_world=world_bible.rules_of_the_world,
             characters=world_bible.characters,
             locations=world_bible.locations,

--- a/story.py
+++ b/story.py
@@ -459,7 +459,17 @@ def run_enhance_chapter(
     story_so_far: str,
 ):
     class DraftChapter(dspy.Signature):
-        """Draft or enhance the chapter prose"""
+        """Write the chapter prose.
+
+The world bible (locations, characters, timeline, rules) is reference material,
+not source material — describe scenes in fresh language and never reuse
+evocative phrases from the bible verbatim. Drive the chapter on a concrete
+scene with at least one moment of friction (a request denied, a plan reversed,
+a cost paid on the page). End on an action or image, not a thematic aphorism.
+Vary sentence rhythm; avoid stacking triadic 'X and Y' constructions or
+'not X but Y' parallelism. Show the world's cost on a body or an object rather
+than restating it.
+"""
         story_idea: str = dspy.InputField()
         story_title: str = dspy.InputField()
         story_spine: str = dspy.InputField()


### PR DESCRIPTION
## Summary
- Adds `act_hint_for_chapter(i, n, story_spine)` in `story.py` — maps a 1-indexed chapter onto a 3-act structure (~25/50/25, min 1 chapter per act for n≥3) and returns `{act, label, spine_through_act}`.
- Threads `chapter_index` / `total_chapters` from `pipeline.py` into `run_enhance_chapter`, which now feeds `DraftChapter` (and `GenerateRandomDetail`) the through-act spine slice instead of the full 7-beat spine.
- Adds an `act_hint` InputField to `DraftChapter` and tightens the docstring: tone matches the current act, and beats from later acts are explicitly off-limits.

Motivation: the editorial review of `.tmp/story.md` (see `.tmp/story_review.md`) flagged that early chapters were leaking climax-shaped foreshadowing because every chapter saw the entire Pixar-7 spine. This is the smallest meaningful change to test that hypothesis end-to-end before broader fixes.

## Test plan
- [ ] Run e2e generation; spot-check Ch1 for climax foreshadowing.
- [ ] Run `qa.py` on the new story output and compare against the prior baseline.
- [ ] Sanity-check act split for typical N=7 (expected 2/3/2) and edge N=3 (1/1/1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)