### PR TITLE
feat(story): add parallel world-state pipeline variant

### DIFF
--- a/COMPARISON_PLAN.md
+++ b/COMPARISON_PLAN.md
@@ -1,0 +1,112 @@
+# Comparison plan: the 3 story-drafting variants
+
+Handoff brief for an agent running locally against Ollama. Goal: run all three
+chapter-drafting strategies on identical inputs, score them, and recommend
+which to keep / merge / drop.
+
+Branch: `claude/world-state-implementation-UN9s6` — `git pull origin claude/world-state-implementation-UN9s6` before starting.
+
+## The variants
+
+All three are identical up to **and including** world-bible generation
+(`build_world_bible`); they differ only in how chapters are drafted afterward.
+
+| | Entry point | Drafting code | Continuity between chapters |
+|---|---|---|---|
+| **A · baseline** | `python mymain.py` | `pipeline.py` | per-chapter `run_enhance_chapter` + rolling text summary (`run_generate_story_so_far`) |
+| **B · world-state** | `python mymain_ws.py` | `pipeline_ws.py` + `world_state.py` | structured `WorldState` (story clock / characters / locations / plot threads / key objects / recent events), updated after each chapter |
+| **C · dspy.Module** | `python mymain_module.py` | `pipeline_module.py` → `story_module.WriteStory` | *none* — each chapter drafted from its own outline beats + world bible + act-sliced spine (DSPy `DraftArticle` style) |
+
+## Step 0 — make runs unattended
+
+All three prompt via `ui.review_answer` (Rich `Confirm.ask(..., default=True)`)
+for every foundation step (idea, premise, spine, each rule/location/character…),
+and A & B also for the chapter plan and every chapter — ~30-40 prompts per run.
+No code change needed: pipe an endless stream of blank lines, so every confirm
+takes its default (accept the proposed answer). Accepted answers never trigger
+the follow-up `Prompt.ask`, so blank input is sufficient.
+
+- Use `yes '' | …` (blank lines), **not** `< /dev/null` — EOF on stdin can make
+  Rich misbehave; an endless stream of blank lines is safe.
+- This means every proposed answer is accepted and every confirm takes its
+  default — exactly what you want for a clean A/B (no human-introduced
+  divergence). Don't pipe if you ever want to hand-edit something mid-run.
+- `yes` getting SIGPIPE when Python exits is normal/harmless; the pipeline's
+  exit code is Python's. Piping stdin also makes Rich non-interactive (no
+  color) — fine.
+
+## Step 1 — fixed inputs
+
+Same `--idea` / `--title` / `--number-of-chapters` for all three. Suggested:
+
+```
+--idea "A lighthouse keeper on a dying coast discovers the light is the only thing holding back something in the fog; the mainland wants the lighthouse decommissioned." --title "The Last Keeper" --number-of-chapters 7
+```
+
+## Step 2 — warm the shared cache (recommended)
+
+Keep the DSPy disk cache **on** (default). Run **A first**: the foundation calls
+(clarify / premise / spine / world bible) and the chapters-plan call use
+identical signatures + inputs in A and B, so B reuses them from cache →
+byte-identical foundation, isolating the drafting difference. C diverges at the
+outline (new `StoryOutline` signature) but still shares idea / premise / spine /
+world-bible from cache.
+
+## Step 3 — run all three
+
+The `--output-file` default is shared across the three entry points, so you
+**must** override it each time.
+
+```bash
+mkdir -p .tmp/cmp
+yes '' | python mymain.py        --idea "<IDEA>" --title "<TITLE>" --number-of-chapters 7 --num-ctx 24576 --output-file .tmp/cmp/A_baseline.md   -v
+yes '' | python mymain_ws.py     --idea "<IDEA>" --title "<TITLE>" --number-of-chapters 7 --num-ctx 24576 --output-file .tmp/cmp/B_worldstate.md -v
+yes '' | python mymain_module.py --idea "<IDEA>" --title "<TITLE>" --number-of-chapters 7 --num-ctx 24576 --output-file .tmp/cmp/C_module.md     -v
+```
+
+Use whatever Ollama model you're running (`--model qwen3 --provider ollama`,
+etc.). Logs land in `.tmp/mymain.log`. If the log shows context truncation,
+bump `--num-ctx`; if a run OOMs, lower `--num-ctx` / `--max-tokens` or use
+`--number-of-chapters 5` — and **re-run all three** with the same settings so
+they stay comparable.
+
+## Step 4 — automated metrics
+
+```bash
+python scripts/run_qa.py .tmp/cmp/A_baseline.md .tmp/cmp/B_worldstate.md .tmp/cmp/C_module.md
+python scripts/word_count.py .tmp/cmp/A_baseline.md      # repeat for B and C
+```
+
+Per variant, record:
+- `# FAIL` / `# WARN` findings from `run_qa.py` — especially `check_name_drift`,
+  `check_character_presence`, `check_cross_chapter_phrase_reuse`.
+- Top repeated content words (`word_count.py`).
+- Total word count + per-chapter word counts (consistency).
+- Wall-clock time, and total tokens if a token callback / Langfuse is active.
+
+## Step 5 — read-through rubric (the real test)
+
+Read all three "Final Story" sections. Score each 1-5 on:
+
+1. **Continuity** — characters / places / objects stay consistent
+   chapter-to-chapter; setups pay off.
+2. **Coherence** — one story vs. 7 disconnected episodes.
+3. **Structure** — follows the spine / 3-act arc; the ending lands.
+4. **Prose quality** — varied rhythm, concrete scenes, no purple boilerplate or
+   reused phrasing.
+5. **Plot-thread tracking** — early open questions get resolved.
+
+Note 2-3 concrete good/bad examples per variant.
+
+## Step 6 — write up
+
+`.tmp/cmp/REPORT.md`: metrics table + rubric scores + standout examples + a
+recommendation (which strategy to keep / merge / drop, plus quick wins — e.g.
+"C drifts on names → also feed it the full outline into `DraftChapter`").
+
+## Notes
+
+- `.tmp/` is gitignored — outputs won't be committed (fine). If you want the
+  report in the repo, put it elsewhere and say so.
+- The variants are isolated files; nothing in `story.py` / `pipeline.py` needs
+  touching.

--- a/mymain_module.py
+++ b/mymain_module.py
@@ -1,0 +1,37 @@
+"""CLI entry point for the dspy.Module-based story pipeline variant.
+
+Reuses argument parsing and runtime setup from :mod:`mymain`; only the
+pipeline implementation differs (see :mod:`pipeline_module`).
+"""
+
+import logging
+
+from dotenv import load_dotenv
+
+from artifact import initialize_artifact, update_artifact
+from mymain import (
+    configure_logging,
+    configure_runtime,
+    format_generation_parameters,
+    parse_args,
+)
+from pipeline_module import write
+
+logger = logging.getLogger(__name__)
+
+
+if __name__ == "__main__":
+    load_dotenv()
+    args = parse_args()
+    configure_logging(args)
+    configure_runtime(args)
+
+    initialize_artifact(args.output_file)
+    update_artifact(
+        args.output_file, "Generation Parameters", format_generation_parameters(args)
+    )
+
+    logger.info(
+        "Starting module-based story writer with %d chapters", args.number_of_chapters
+    )
+    write(args.idea, args.title, args.output_file, args.number_of_chapters)

--- a/mymain_ws.py
+++ b/mymain_ws.py
@@ -1,0 +1,37 @@
+"""CLI entry point for the world-state story pipeline variant.
+
+Reuses argument parsing and runtime setup from :mod:`mymain`; only the
+pipeline implementation differs (see :mod:`pipeline_ws`).
+"""
+
+import logging
+
+from dotenv import load_dotenv
+
+from artifact import initialize_artifact, update_artifact
+from mymain import (
+    configure_logging,
+    configure_runtime,
+    format_generation_parameters,
+    parse_args,
+)
+from pipeline_ws import write
+
+logger = logging.getLogger(__name__)
+
+
+if __name__ == "__main__":
+    load_dotenv()
+    args = parse_args()
+    configure_logging(args)
+    configure_runtime(args)
+
+    initialize_artifact(args.output_file)
+    update_artifact(
+        args.output_file, "Generation Parameters", format_generation_parameters(args)
+    )
+
+    logger.info(
+        "Starting world-state story writer with %d chapters", args.number_of_chapters
+    )
+    write(args.idea, args.title, args.output_file, args.number_of_chapters)

--- a/pipeline_module.py
+++ b/pipeline_module.py
@@ -1,0 +1,62 @@
+"""Story pipeline variant that drafts chapters via the :mod:`story_module` dspy.Module.
+
+Everything up to and including the world bible is the existing interactive
+pipeline (reused verbatim via :func:`pipeline_ws._build_foundation`). From
+there a non-interactive two-stage ``dspy.Module`` — outline → draft each
+chapter, with no rolling summary — takes over. See :class:`story_module.WriteStory`.
+"""
+
+import logging
+
+from _compat import observe
+from artifact import update_artifact
+from pipeline_ws import _build_foundation  # shared idea→premise→spine→world-bible steps
+from story import sanity_check
+from story_module import WriteStory
+
+logger = logging.getLogger(__name__)
+
+
+def _record_outline(output_file: str, outline) -> None:
+    """Write the chapter outline to the artifact."""
+    update_artifact(output_file, "Chapters Plan", "", level=3)
+    for i, spec in enumerate(outline, 1):
+        update_artifact(
+            output_file,
+            f"Chapter {i}: {spec.chapter_title}",
+            spec.chapter_beats,
+            level=4,
+        )
+
+
+def _record_chapters(output_file: str, chapters) -> None:
+    """Write the drafted chapters to the artifact."""
+    update_artifact(output_file, "Final Story", "", level=2)
+    for i, chapter in enumerate(chapters, 1):
+        update_artifact(
+            output_file, f"Chapter {i}: {chapter.chapter_title}", chapter.prose, level=3
+        )
+        logger.info("Chapter %d written (%d chars)", i, len(chapter.prose))
+
+
+@observe()
+def write(idea: str, title: str, output_file: str, number_of_chapters: int = 7) -> None:
+    """Run the module-based story pipeline end to end."""
+    updated_idea, story_title, spine, world_bible = _build_foundation(
+        idea, title, output_file
+    )
+
+    if not sanity_check(updated_idea, story_title, spine, world_bible):
+        logger.error("Idea, spine, and world bible are not consistent")
+        return
+
+    result = WriteStory()(
+        story_idea=updated_idea,
+        story_title=story_title,
+        story_spine=spine,
+        world_bible=world_bible,
+        number_of_chapters=number_of_chapters,
+    )
+
+    _record_outline(output_file, result.outline)
+    _record_chapters(output_file, result.chapters)

--- a/pipeline_ws.py
+++ b/pipeline_ws.py
@@ -1,0 +1,162 @@
+"""Story pipeline variant that tracks a structured world state.
+
+Identical to :mod:`pipeline` up to and including :func:`pipeline.build_world_bible`.
+From there it maintains a :class:`world_state.WorldState` instead of a freeform
+``story_so_far`` summary: the world bible is the static canon, and the world
+state is what mutates chapter by chapter.
+"""
+
+import logging
+
+from _compat import observe
+from artifact import update_artifact
+from pipeline import _snip, build_world_bible
+from story import (
+    run_clarify_idea,
+    run_generate_chapters_plan,
+    run_generate_core_premise,
+    run_generate_spine,
+    sanity_check,
+)
+from world_state import (
+    render_world_state,
+    run_advance_world_state,
+    run_draft_chapter_with_state,
+    run_init_world_state,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@observe()
+def _build_foundation(idea: str, title: str, output_file: str):
+    """Run the shared idea → premise → spine → world bible steps."""
+    updated_idea, story_title = run_clarify_idea(idea, title)
+    update_artifact(output_file, "Story Title", story_title)
+
+    core_premise = run_generate_core_premise(updated_idea)
+    update_artifact(output_file, "Core Premise", core_premise)
+    logger.info("STEP core_premise | output=%s", _snip(core_premise, 600))
+
+    spine = run_generate_spine(updated_idea, core_premise)
+    update_artifact(output_file, "Spine", spine)
+    logger.info("STEP spine | output=%s", _snip(spine, 800))
+
+    world_bible = build_world_bible(updated_idea, story_title, spine, output_file)
+    return updated_idea, story_title, spine, world_bible
+
+
+@observe()
+def _plan_chapters(
+    updated_idea, story_title, spine, world_bible, output_file, number_of_chapters
+):
+    """Generate and record the chapter plan."""
+    chapters_plan = run_generate_chapters_plan(
+        updated_idea,
+        story_title,
+        spine,
+        world_bible,
+        number_of_chapters,
+    )
+    update_artifact(output_file, "Chapters Plan", "", level=3)
+    for i, chapter in enumerate(chapters_plan, 1):
+        update_artifact(
+            output_file,
+            f"Chapter {i}: {chapter.chapter_title}",
+            chapter.chapter_beats,
+            level=4,
+        )
+    logger.info("STEP chapters_plan | output count=%d", len(chapters_plan))
+    return chapters_plan
+
+
+@observe()
+def _draft_chapters(
+    updated_idea,
+    story_title,
+    spine,
+    world_bible,
+    world_state,
+    chapters_plan,
+    output_file,
+):
+    """Draft each chapter, advancing the world state after every one."""
+    total = len(chapters_plan)
+    update_artifact(output_file, "Final Story", "", level=2)
+    for i, chapter in enumerate(chapters_plan, 1):
+        chapter_plan_str = f"{chapter.chapter_title}\n{chapter.chapter_beats}"
+        logger.info(
+            "STEP draft_chapter[%d/%d] | clock=%s",
+            i,
+            total,
+            _snip(world_state.story_clock, 120),
+        )
+        prose = run_draft_chapter_with_state(
+            chapter_plan_str,
+            updated_idea,
+            story_title,
+            spine,
+            world_bible,
+            world_state,
+            chapter_index=i,
+            total_chapters=total,
+        )
+        update_artifact(
+            output_file, f"Chapter {i}: {chapter.chapter_title}", prose, level=3
+        )
+        world_state = run_advance_world_state(
+            world_state,
+            chapter_plan_str,
+            prose,
+            updated_idea,
+            story_title,
+            world_bible,
+        )
+        update_artifact(
+            output_file,
+            f"World State after Chapter {i}",
+            render_world_state(world_state),
+            level=4,
+        )
+        logger.info(
+            "STEP advance_world_state[%d/%d] | clock=%s",
+            i,
+            total,
+            _snip(world_state.story_clock, 120),
+        )
+
+
+@observe()
+def write(idea: str, title: str, output_file: str, number_of_chapters: int = 7) -> None:
+    """Run the world-state story pipeline end to end."""
+    updated_idea, story_title, spine, world_bible = _build_foundation(
+        idea, title, output_file
+    )
+
+    if not sanity_check(updated_idea, story_title, spine, world_bible):
+        logger.error("Idea, spine, and world bible are not consistent")
+        return
+
+    chapters_plan = _plan_chapters(
+        updated_idea,
+        story_title,
+        spine,
+        world_bible,
+        output_file,
+        number_of_chapters,
+    )
+
+    world_state = run_init_world_state(updated_idea, story_title, spine, world_bible)
+    update_artifact(
+        output_file, "World State (initial)", render_world_state(world_state), level=3
+    )
+
+    _draft_chapters(
+        updated_idea,
+        story_title,
+        spine,
+        world_bible,
+        world_state,
+        chapters_plan,
+        output_file,
+    )

--- a/story_module.py
+++ b/story_module.py
@@ -1,0 +1,123 @@
+"""Multi-stage story drafting expressed as a composable ``dspy.Module``.
+
+Modeled on DSPy's ``DraftArticle`` example (outline → draft each section):
+:class:`WriteStory` takes the foundation produced by the interactive pipeline
+(idea, title, spine, world bible) and, with no human in the loop, builds a
+chapter outline and then drafts each chapter from that outline. Like the
+article example there is *no* rolling summary between chapters — each chapter
+is drafted from its own outline entry plus the shared world bible and the
+act-sliced spine. (If continuity drift shows up in practice, the obvious next
+step is to feed the whole outline, or a running recap, into ``DraftChapter``.)
+
+``forward`` is kept pure — no prompts, no I/O — so the program can be
+evaluated, replayed and compiled by DSPy optimizers. All interactive review
+lives in the calling pipeline.
+"""
+
+import logging
+from dataclasses import dataclass
+
+import dspy
+
+from _compat import observe
+from story import PlanEntry, WorldBible, act_hint_for_chapter
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DraftedChapter:
+    """One chapter of the finished draft: its outline entry plus the prose."""
+
+    chapter_title: str
+    chapter_beats: str
+    prose: str
+
+
+class StoryOutline(dspy.Signature):
+    """Outline a thorough chapter-by-chapter plan for the story."""
+
+    story_idea: str = dspy.InputField()
+    story_title: str = dspy.InputField()
+    story_spine: str = dspy.InputField()
+    world_bible: WorldBible = dspy.InputField()
+    number_of_chapters: int = dspy.InputField()
+    chapters: list[PlanEntry] = dspy.OutputField(
+        desc="Ordered chapters, each with a title and a few concrete beats",
+    )
+
+
+class DraftChapter(dspy.Signature):
+    """Draft one chapter of the story from its outline entry.
+
+    The world_bible (rules, characters, locations, timeline) is reference
+    material, not source material — describe scenes in fresh language and never
+    reuse evocative phrases from it verbatim. Drive the chapter on a concrete
+    scene with at least one moment of friction (a request denied, a plan
+    reversed, a cost paid on the page). End on an action or image, not a
+    thematic aphorism. Vary sentence rhythm; avoid stacking triadic 'X and Y'
+    constructions or 'not X but Y' parallelism.
+
+    Write in a tone appropriate to act_hint and do not foreshadow events from
+    later acts — the story_spine you receive only covers beats up to and
+    including the current act, so treat anything beyond it as not yet decided.
+    """
+
+    story_idea: str = dspy.InputField()
+    story_title: str = dspy.InputField()
+    story_spine: str = dspy.InputField(
+        desc="Spine beats up to and including this chapter's act",
+    )
+    act_hint: str = dspy.InputField(
+        desc="Which act of the three-act structure this chapter belongs to",
+    )
+    world_bible: WorldBible = dspy.InputField(desc="Reference canon, not to be quoted")
+    chapter: str = dspy.InputField(desc="This chapter's title and beats")
+    prose: str = dspy.OutputField(desc="Chapter prose")
+
+
+class WriteStory(dspy.Module):
+    """Two stages: build a chapter outline, then draft each chapter from it."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.build_outline = dspy.ChainOfThought(StoryOutline)
+        self.draft_chapter = dspy.ChainOfThought(DraftChapter)
+
+    @observe()
+    def forward(
+        self,
+        story_idea: str,
+        story_title: str,
+        story_spine: str,
+        world_bible: WorldBible,
+        number_of_chapters: int = 7,
+    ) -> dspy.Prediction:
+        outline = self.build_outline(
+            story_idea=story_idea,
+            story_title=story_title,
+            story_spine=story_spine,
+            world_bible=world_bible,
+            number_of_chapters=number_of_chapters,
+        )
+        total = len(outline.chapters)
+        drafted: list[DraftedChapter] = []
+        for i, spec in enumerate(outline.chapters, 1):
+            hint = act_hint_for_chapter(i, total, story_spine)
+            logger.info("draft_chapter[%d/%d] | %s", i, total, spec.chapter_title)
+            section = self.draft_chapter(
+                story_idea=story_idea,
+                story_title=story_title,
+                story_spine=hint["spine_through_act"],
+                act_hint=hint["label"],
+                world_bible=world_bible,
+                chapter=f"{spec.chapter_title}\n{spec.chapter_beats}",
+            )
+            drafted.append(
+                DraftedChapter(
+                    chapter_title=spec.chapter_title,
+                    chapter_beats=spec.chapter_beats,
+                    prose=section.prose,
+                )
+            )
+        return dspy.Prediction(outline=outline.chapters, chapters=drafted)

--- a/test_story_module.py
+++ b/test_story_module.py
@@ -1,0 +1,17 @@
+from story_module import DraftedChapter, WriteStory
+
+
+def test_drafted_chapter_holds_outline_entry_and_prose():
+    chapter = DraftedChapter(
+        chapter_title="The Letter",
+        chapter_beats="Mara finds the letter; she decides to leave.",
+        prose="Mara turned the envelope over twice before she broke the seal.",
+    )
+    assert chapter.chapter_title == "The Letter"
+    assert "broke the seal" in chapter.prose
+
+
+def test_write_story_module_builds_its_two_stages():
+    module = WriteStory()
+    assert hasattr(module, "build_outline")
+    assert hasattr(module, "draft_chapter")

--- a/test_world_state.py
+++ b/test_world_state.py
@@ -1,0 +1,29 @@
+from world_state import WorldState, render_world_state
+
+
+def test_world_state_recent_events_defaults_empty():
+    state = WorldState(
+        story_clock="Opening",
+        characters=["Mara: at home, knows nothing"],
+        locations=["The cottage: intact"],
+        plot_threads=["Who sent the letter?"],
+        key_objects=["The sealed letter: in Mara's pocket"],
+    )
+    assert state.recent_events == []
+
+
+def test_render_world_state_includes_all_sections_and_handles_empty():
+    state = WorldState(
+        story_clock="Day 3, dusk",
+        characters=["Mara: in the city, suspicious of To"],
+        locations=[],
+        plot_threads=["Who sent the letter?"],
+        key_objects=["The sealed letter: lost"],
+        recent_events=["Ch.1: Mara left home"],
+    )
+    rendered = render_world_state(state)
+    assert "Day 3, dusk" in rendered
+    assert "Mara: in the city" in rendered
+    assert "Ch.1: Mara left home" in rendered
+    # Empty list renders a placeholder rather than nothing.
+    assert "- (none)" in rendered

--- a/world_state.py
+++ b/world_state.py
@@ -1,0 +1,228 @@
+"""Mutable world state that evolves chapter-by-chapter.
+
+The *world bible* (rules, character/location profiles, backstory timeline) is
+the static canon produced before drafting begins. ``WorldState`` is the part
+that *changes* as the story unfolds: where characters are and what they know,
+how locations have changed, which plot threads are open, where we are on the
+story clock, and what happened in recent chapters.
+
+This module is a parallel alternative to the freeform ``story_so_far`` summary
+used by :mod:`pipeline`; it reuses :func:`story.act_hint_for_chapter` and the
+:class:`story.WorldBible` produced by :func:`pipeline.build_world_bible`.
+"""
+
+import logging
+from dataclasses import dataclass, field
+
+import dspy
+
+import ui
+from _compat import observe
+from story import WorldBible, act_hint_for_chapter
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class WorldState:
+    """A snapshot of everything that changes while the story is being told."""
+
+    story_clock: str
+    characters: list[str]
+    locations: list[str]
+    plot_threads: list[str]
+    key_objects: list[str]
+    recent_events: list[str] = field(default_factory=list)
+
+
+def render_world_state(state: WorldState) -> str:
+    """Render a ``WorldState`` as a human-readable markdown block."""
+
+    def _bullets(items: list[str]) -> str:
+        return "\n".join(f"- {item}" for item in items) if items else "- (none)"
+
+    return "\n".join(
+        [
+            f"**Story clock:** {state.story_clock}",
+            "",
+            "**Characters (current state):**",
+            _bullets(state.characters),
+            "",
+            "**Locations (current state):**",
+            _bullets(state.locations),
+            "",
+            "**Open plot threads:**",
+            _bullets(state.plot_threads),
+            "",
+            "**Key objects:**",
+            _bullets(state.key_objects),
+            "",
+            "**Recent events:**",
+            _bullets(state.recent_events),
+        ]
+    )
+
+
+@observe()
+def run_init_world_state(
+    story_idea: str,
+    story_title: str,
+    story_spine: str,
+    world_bible: WorldBible,
+) -> WorldState:
+    """Derive the opening world state from the world bible, before Chapter 1."""
+
+    class InitWorldState(dspy.Signature):
+        """Derive the world state at the very start of the story.
+
+        Translate the static world bible into a *snapshot at story opening*:
+        where each character is and what they know/believe right now, the
+        starting condition of each location, the plot threads the premise sets
+        up, key objects and where they begin. recent_events starts empty.
+        """
+
+        story_idea: str = dspy.InputField()
+        story_title: str = dspy.InputField()
+        story_spine: str = dspy.InputField()
+        world_bible: WorldBible = dspy.InputField()
+        previous_result: str = dspy.InputField(
+            desc="Previous attempt at the world state, if regenerating",
+        )
+        feedback: str = dspy.InputField(
+            desc="Feedback from the user for the world state",
+        )
+        world_state: WorldState = dspy.OutputField(
+            desc="The state of the story world at the opening, before Chapter 1",
+        )
+
+    feedback = ""
+    previous_result = ""
+    init_func = dspy.ChainOfThought(InitWorldState)
+    while True:
+        result = init_func(
+            story_idea=story_idea,
+            story_title=story_title,
+            story_spine=story_spine,
+            world_bible=world_bible,
+            previous_result=previous_result,
+            feedback=feedback,
+        )
+        previous_result = render_world_state(result.world_state)
+        feedback, is_correct = ui.review_answer("Initial world state:", previous_result)
+        if is_correct:
+            return result.world_state
+
+
+@observe()
+def run_advance_world_state(
+    current_state: WorldState,
+    chapter_plan: str,
+    chapter_prose: str,
+    story_idea: str,
+    story_title: str,
+    world_bible: WorldBible,
+) -> WorldState:
+    """Fold a freshly written chapter into a new world state."""
+
+    class AdvanceWorldState(dspy.Signature):
+        """Update the world state after a chapter has been written.
+
+        Reflect everything the chapter changed: character positions, knowledge,
+        relationships and physical condition; physical or political changes to
+        locations; plot threads opened or resolved; the advanced story clock;
+        movement of key objects. Append the new chapter to recent_events, and
+        condense the oldest entries if that log is getting long.
+        """
+
+        story_idea: str = dspy.InputField()
+        story_title: str = dspy.InputField()
+        world_bible: WorldBible = dspy.InputField(desc="Static canon, for reference")
+        chapter_plan: str = dspy.InputField(
+            desc="Plan/beats for the chapter just written"
+        )
+        chapter_prose: str = dspy.InputField(
+            desc="Full prose of the chapter just written"
+        )
+        current_state: WorldState = dspy.InputField(
+            desc="World state at the chapter's start"
+        )
+        updated_state: WorldState = dspy.OutputField(
+            desc="World state reflecting everything that changed in the chapter",
+        )
+
+    advance_func = dspy.ChainOfThought(AdvanceWorldState)
+    result = advance_func(
+        story_idea=story_idea,
+        story_title=story_title,
+        world_bible=world_bible,
+        chapter_plan=chapter_plan,
+        chapter_prose=chapter_prose,
+        current_state=current_state,
+    )
+    return result.updated_state
+
+
+@observe()
+def run_draft_chapter_with_state(
+    chapter: str,
+    story_idea: str,
+    story_title: str,
+    story_spine: str,
+    world_bible: WorldBible,
+    world_state: WorldState,
+    chapter_index: int = 1,
+    total_chapters: int = 1,
+) -> str:
+    """Draft chapter prose from the static world bible plus the current state."""
+
+    class DraftChapterWithState(dspy.Signature):
+        """Write the chapter prose.
+
+        The world_bible (locations, characters, timeline, rules) is reference material,
+        not source material — describe scenes in fresh language and never reuse
+        evocative phrases from the bible verbatim. The world_state tells you where the
+        story actually stands right now: honour it (character positions, knowledge,
+        injuries, open threads, where key objects are) and do not contradict it.
+        Drive the chapter on a concrete scene with at least one moment of friction (a
+        request denied, a plan reversed, a cost paid on the page). End on an action or
+        image, not a thematic aphorism. Vary sentence rhythm; avoid stacking triadic
+        'X and Y' constructions or 'not X but Y' parallelism. Show the world's cost on
+        a body or an object rather than restating it.
+
+        Write this chapter in a tone appropriate to {act_hint}; do not foreshadow
+        events from later acts. The story_spine you receive only covers beats up to
+        and including the current act — treat anything beyond it as not yet decided.
+        """
+
+        story_idea: str = dspy.InputField()
+        story_title: str = dspy.InputField()
+        story_spine: str = dspy.InputField()
+        act_hint: str = dspy.InputField(
+            desc="Which act of the three-act structure this chapter belongs to",
+        )
+        world_bible: WorldBible = dspy.InputField(desc="Static canon, reference only")
+        world_state: WorldState = dspy.InputField(
+            desc="State of the world as this chapter opens"
+        )
+        chapter: str = dspy.InputField()
+        feedback: str = dspy.InputField(desc="Feedback from the user for the chapter")
+        prose: str = dspy.OutputField(desc="Chapter prose")
+
+    hint = act_hint_for_chapter(chapter_index, total_chapters, story_spine)
+
+    feedback = ""
+    draft_func = dspy.ChainOfThought(DraftChapterWithState)
+    while True:
+        result = draft_func(
+            story_idea=story_idea,
+            story_title=story_title,
+            story_spine=hint["spine_through_act"],
+            act_hint=hint["label"],
+            world_bible=world_bible,
+            world_state=world_state,
+            chapter=chapter,
+            feedback=feedback,
+        )
+        feedback, is_correct = ui.review_answer("Drafted Chapter:", result.prose)
+        if is_correct:
+            return result.prose


### PR DESCRIPTION
Adds an alternate path that keeps everything through world-bible generation
identical to the existing pipeline, then tracks a structured WorldState
(story clock, characters, locations, open plot threads, key objects, recent
events) that mutates per chapter instead of the freeform story_so_far summary.

- world_state.py: WorldState dataclass + init/advance/draft DSPy steps,
  reusing story.WorldBible and story.act_hint_for_chapter
- pipeline_ws.py: orchestration reusing build_world_bible and the shared
  idea/premise/spine/chapters-plan steps
- mymain_ws.py: thin entry point reusing mymain's arg parsing/runtime setup
- test_world_state.py: pure-function tests for WorldState/render_world_state

https://claude.ai/code/session_014YDuBCsRhANw2iKKsEK8gA