### PR TITLE
feat(story): recursive chapter drafting variant

### DIFF
--- a/mymain.py
+++ b/mymain.py
@@ -78,6 +78,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--idea", type=str, required=False, help="The initial story idea/prompt")
     parser.add_argument("--title", type=str, required=False, help="The title of the story")
     parser.add_argument("--number-of-chapters", type=int, default=7, help="The number of chapters to generate")
+    parser.add_argument(
+        "--max-depth",
+        type=int,
+        default=2,
+        help="Recursion depth for the recursive variant (1=chapters only, 2=story→chapter→scene). Ignored by other variants.",
+    )
     parser.add_argument("--output-file", default=".tmp/story.md")
     return parser.parse_args()
 

--- a/mymain_recursive.py
+++ b/mymain_recursive.py
@@ -1,0 +1,46 @@
+"""CLI entry point for the recursive story pipeline variant.
+
+Reuses argument parsing and runtime setup from :mod:`mymain`; only the
+pipeline implementation differs (see :mod:`pipeline_recursive`). Use
+``--max-depth`` to control how deep the recursion goes.
+"""
+
+import logging
+
+from dotenv import load_dotenv
+
+from artifact import initialize_artifact, update_artifact
+from mymain import (
+    configure_logging,
+    configure_runtime,
+    format_generation_parameters,
+    parse_args,
+)
+from pipeline_recursive import write
+
+logger = logging.getLogger(__name__)
+
+
+if __name__ == "__main__":
+    load_dotenv()
+    args = parse_args()
+    configure_logging(args)
+    configure_runtime(args)
+
+    initialize_artifact(args.output_file)
+    update_artifact(
+        args.output_file, "Generation Parameters", format_generation_parameters(args)
+    )
+
+    logger.info(
+        "Starting recursive story writer with %d chapters, max_depth=%d",
+        args.number_of_chapters,
+        args.max_depth,
+    )
+    write(
+        args.idea,
+        args.title,
+        args.output_file,
+        args.number_of_chapters,
+        args.max_depth,
+    )

--- a/pipeline_recursive.py
+++ b/pipeline_recursive.py
@@ -1,0 +1,88 @@
+"""Story pipeline variant that drafts chapters recursively.
+
+Everything up to and including the world bible is the existing interactive
+pipeline (reused verbatim via :func:`pipeline_ws._build_foundation`). From there
+a non-interactive recursive ``dspy.Module`` — outline → recurse into sub-beats
+→ draft prose at the leaves → concatenate — takes over. See
+:class:`story_recursive.RecursiveWriteStory`.
+"""
+
+import logging
+
+from _compat import observe
+from artifact import update_artifact
+from pipeline_ws import _build_foundation  # shared idea→premise→spine→world-bible steps
+from story import sanity_check
+from story_recursive import RecursiveWriteStory, StoryNode
+
+logger = logging.getLogger(__name__)
+
+
+def _scene_plan_lines(nodes: list[StoryNode], indent: int = 0) -> list[str]:
+    lines: list[str] = []
+    for node in nodes:
+        lines.append(f"{'  ' * indent}- {node.title}")
+        if node.children:
+            lines.extend(_scene_plan_lines(node.children, indent + 1))
+    return lines
+
+
+def _record_outline(output_file: str, outline) -> None:
+    """Write the top-level chapter outline to the artifact."""
+    update_artifact(output_file, "Chapters Plan", "", level=3)
+    for i, spec in enumerate(outline, 1):
+        update_artifact(
+            output_file,
+            f"Chapter {i}: {spec.chapter_title}",
+            spec.chapter_beats,
+            level=4,
+        )
+
+
+def _record_chapters(output_file: str, roots: list[StoryNode]) -> None:
+    """Write each chapter (its scene plan, then its assembled prose)."""
+    update_artifact(output_file, "Final Story", "", level=2)
+    for i, node in enumerate(roots, 1):
+        if node.children:
+            update_artifact(
+                output_file,
+                f"Chapter {i}: {node.title} — scene plan",
+                "\n".join(_scene_plan_lines(node.children)),
+                level=4,
+            )
+        prose = node.assembled_prose()
+        update_artifact(output_file, f"Chapter {i}: {node.title}", prose, level=3)
+        logger.info(
+            "Chapter %d written (%d chars, %d leaves)",
+            i, len(prose), node.leaf_count(),
+        )
+
+
+@observe()
+def write(
+    idea: str,
+    title: str,
+    output_file: str,
+    number_of_chapters: int = 7,
+    max_depth: int = 2,
+) -> None:
+    """Run the recursive story pipeline end to end."""
+    updated_idea, story_title, spine, world_bible = _build_foundation(
+        idea, title, output_file
+    )
+
+    if not sanity_check(updated_idea, story_title, spine, world_bible):
+        logger.error("Idea, spine, and world bible are not consistent")
+        return
+
+    result = RecursiveWriteStory()(
+        story_idea=updated_idea,
+        story_title=story_title,
+        story_spine=spine,
+        world_bible=world_bible,
+        number_of_chapters=number_of_chapters,
+        max_depth=max_depth,
+    )
+
+    _record_outline(output_file, result.outline)
+    _record_chapters(output_file, result.roots)

--- a/story_recursive.py
+++ b/story_recursive.py
@@ -1,0 +1,223 @@
+"""Recursive story drafting: the story-generation procedure applied to itself.
+
+Drafting a story needs an idea, a spine, a (subset of the) world bible, and a
+plan of beats. Drafting a *chapter* needs the same things at a smaller scale —
+so this module treats each chapter's beats as a child "idea" and recurses:
+project the world bible down to what the unit uses, reuse the parent's
+act-sliced spine, decompose the unit into sub-beats, and recurse again until a
+depth cap (or an atomic unit) is hit, at which point prose is drafted at the
+leaves. Leaf prose is concatenated bottom-up — no smoothing pass, no rolling
+summary (matching :mod:`story_module`).
+
+``forward`` is kept pure — no prompts, no I/O — so the program can be evaluated,
+replayed and compiled by DSPy optimizers. All interactive review lives in the
+calling pipeline.
+"""
+
+import logging
+from dataclasses import dataclass, field
+
+import dspy
+
+from _compat import observe
+from story import PlanEntry, WorldBible, act_hint_for_chapter
+from story_module import DraftChapter, StoryOutline
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class StoryNode:
+    """One node of the recursive draft.
+
+    Either an internal node (``children`` populated, ``prose`` ``None``) or a
+    leaf (``prose`` populated, ``children`` empty). ``beats`` is the plan text
+    that produced this node's children, or the brief this leaf was drafted from.
+    """
+
+    title: str
+    beats: str
+    depth: int
+    children: list["StoryNode"] = field(default_factory=list)
+    prose: str | None = None
+
+    @property
+    def is_leaf(self) -> bool:
+        return self.prose is not None
+
+    def leaf_count(self) -> int:
+        if self.is_leaf:
+            return 1
+        return sum(child.leaf_count() for child in self.children)
+
+    def assembled_prose(self) -> str:
+        if self.is_leaf:
+            return self.prose
+        return "\n\n".join(child.assembled_prose() for child in self.children)
+
+
+class ExpandUnit(dspy.Signature):
+    """Break one story unit into an ordered list of smaller sub-units.
+
+    The ``unit`` is itself a beat (or set of beats) from the parent's plan; treat
+    it as the brief for this stretch of the story and decompose it into concrete
+    sub-beats, each with a short title. Stay within the unit — do not introduce
+    events that belong to earlier or later parts of the story, and do not
+    foreshadow later acts (the ``story_spine`` only covers beats up to and
+    including this unit's act).
+    """
+
+    story_idea: str = dspy.InputField()
+    story_title: str = dspy.InputField()
+    story_spine: str = dspy.InputField(
+        desc="Spine beats up to and including this unit's act",
+    )
+    act_hint: str = dspy.InputField(
+        desc="Which act of the three-act structure this unit belongs to",
+    )
+    world_bible: WorldBible = dspy.InputField(
+        desc="Reference canon for this unit, not to be quoted",
+    )
+    unit: str = dspy.InputField(desc="This unit's title and beats")
+    sub_units: list[PlanEntry] = dspy.OutputField(
+        desc="Ordered sub-units, each with a title and a few concrete beats",
+    )
+
+
+class ProjectWorldBible(dspy.Signature):
+    """Select the slice of the world bible relevant to one story unit.
+
+    Keep only the rules, characters, locations, and timeline entries this unit
+    actually uses. Copy entries verbatim from the full bible — do not rewrite,
+    merge, summarize, or invent. When in doubt, keep the entry. ``story_title``
+    is unchanged.
+    """
+
+    story_title: str = dspy.InputField()
+    world_bible: WorldBible = dspy.InputField(desc="The full canon")
+    unit: str = dspy.InputField(desc="This unit's title and beats")
+    relevant_bible: WorldBible = dspy.OutputField(
+        desc="The subset of the canon relevant to this unit",
+    )
+
+
+class RecursiveWriteStory(dspy.Module):
+    """Outline the story, recurse into sub-beats, draft prose at the leaves.
+
+    Stages reused at every level: :class:`~story_module.StoryOutline` (top
+    level only), :class:`ExpandUnit` (decompose a unit), :class:`ProjectWorldBible`
+    (narrow the canon), and :class:`~story_module.DraftChapter` (leaf prose).
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.build_outline = dspy.ChainOfThought(StoryOutline)
+        self.expand_unit = dspy.ChainOfThought(ExpandUnit)
+        self.project_bible = dspy.ChainOfThought(ProjectWorldBible)
+        self.draft_chapter = dspy.ChainOfThought(DraftChapter)
+
+    @observe()
+    def forward(
+        self,
+        story_idea: str,
+        story_title: str,
+        story_spine: str,
+        world_bible: WorldBible,
+        number_of_chapters: int = 7,
+        max_depth: int = 2,
+    ) -> dspy.Prediction:
+        if max_depth < 1:
+            raise ValueError("max_depth must be >= 1")
+
+        outline = self.build_outline(
+            story_idea=story_idea,
+            story_title=story_title,
+            story_spine=story_spine,
+            world_bible=world_bible,
+            number_of_chapters=number_of_chapters,
+        )
+        total = len(outline.chapters)
+        roots: list[StoryNode] = []
+        for i, spec in enumerate(outline.chapters, 1):
+            hint = act_hint_for_chapter(i, total, story_spine)
+            roots.append(
+                self._write_unit(
+                    title=spec.chapter_title,
+                    beats=spec.chapter_beats,
+                    story_idea=story_idea,
+                    story_title=story_title,
+                    spine_slice=hint["spine_through_act"],
+                    act_label=hint["label"],
+                    world_bible=world_bible,
+                    depth=1,
+                    max_depth=max_depth,
+                    label=f"ch {i}/{total}",
+                )
+            )
+        return dspy.Prediction(outline=outline.chapters, roots=roots)
+
+    def _write_unit(
+        self,
+        *,
+        title: str,
+        beats: str,
+        story_idea: str,
+        story_title: str,
+        spine_slice: str,
+        act_label: str,
+        world_bible: WorldBible,
+        depth: int,
+        max_depth: int,
+        label: str,
+    ) -> StoryNode:
+        unit_text = f"{title}\n{beats}"
+        node = StoryNode(title=title, beats=beats, depth=depth)
+
+        if depth >= max_depth or not beats.strip():
+            logger.info("draft_leaf[%s] depth=%d | %s", label, depth, title)
+            node.prose = self.draft_chapter(
+                story_idea=story_idea,
+                story_title=story_title,
+                story_spine=spine_slice,
+                act_hint=act_label,
+                world_bible=world_bible,
+                chapter=unit_text,
+            ).prose
+            return node
+
+        # Narrow the canon to what this unit actually touches.
+        sub_bible = self.project_bible(
+            story_title=story_title,
+            world_bible=world_bible,
+            unit=unit_text,
+        ).relevant_bible
+
+        # The unit's beats become the child "idea": decompose into sub-units.
+        sub_units = self.expand_unit(
+            story_idea=story_idea,
+            story_title=story_title,
+            story_spine=spine_slice,
+            act_hint=act_label,
+            world_bible=sub_bible,
+            unit=unit_text,
+        ).sub_units
+        logger.info(
+            "expand[%s] depth=%d | %s -> %d sub-units",
+            label, depth, title, len(sub_units),
+        )
+        for j, child_spec in enumerate(sub_units, 1):
+            node.children.append(
+                self._write_unit(
+                    title=child_spec.chapter_title,
+                    beats=child_spec.chapter_beats,
+                    story_idea=unit_text,        # the unit's brief is the child's idea
+                    story_title=story_title,
+                    spine_slice=spine_slice,     # cheap variant: reuse the parent's act-slice
+                    act_label=act_label,
+                    world_bible=sub_bible,
+                    depth=depth + 1,
+                    max_depth=max_depth,
+                    label=f"{label}.{j}",
+                )
+            )
+        return node

--- a/test_story_recursive.py
+++ b/test_story_recursive.py
@@ -1,0 +1,46 @@
+from story_recursive import RecursiveWriteStory, StoryNode
+
+
+def _leaf(title: str, prose: str) -> StoryNode:
+    return StoryNode(title=title, beats="", depth=2, prose=prose)
+
+
+def test_leaf_node_assembles_to_its_own_prose():
+    leaf = _leaf("Scene", "Just this.")
+    assert leaf.is_leaf is True
+    assert leaf.leaf_count() == 1
+    assert leaf.assembled_prose() == "Just this."
+
+
+def test_internal_node_assembles_children_depth_first():
+    parent = StoryNode(
+        title="Chapter 1",
+        beats="Mara leaves; the door closes.",
+        depth=1,
+        children=[_leaf("Scene A", "Alpha."), _leaf("Scene B", "Beta.")],
+    )
+    assert parent.is_leaf is False
+    assert parent.leaf_count() == 2
+    assert parent.assembled_prose() == "Alpha.\n\nBeta."
+
+
+def test_nested_tree_flattens_left_to_right():
+    root = StoryNode(
+        title="Story",
+        beats="",
+        depth=0,
+        children=[
+            StoryNode("Ch1", "", 1, children=[_leaf("1a", "A"), _leaf("1b", "B")]),
+            StoryNode("Ch2", "", 1, children=[_leaf("2a", "C")]),
+        ],
+    )
+    assert root.leaf_count() == 3
+    assert root.assembled_prose() == "A\n\nB\n\nC"
+
+
+def test_recursive_write_story_builds_its_stages():
+    module = RecursiveWriteStory()
+    assert hasattr(module, "build_outline")
+    assert hasattr(module, "expand_unit")
+    assert hasattr(module, "project_bible")
+    assert hasattr(module, "draft_chapter")


### PR DESCRIPTION
Add a new pipeline variant that applies the story-generation procedure to
itself: each chapter's beats become a child "idea", the world bible is
projected down to what the unit uses, the parent's act-sliced spine is
reused, and the unit is decomposed into sub-beats — recursing until a depth
cap (default 2: story -> chapter -> scene) or an atomic unit, at which point
prose is drafted at the leaves and concatenated bottom-up.

- story_recursive.py: RecursiveWriteStory dspy.Module + StoryNode tree,
  ExpandUnit and ProjectWorldBible signatures; reuses StoryOutline and
  DraftChapter from story_module.
- pipeline_recursive.py / mymain_recursive.py: variant pipeline and CLI,
  mirroring the _module / _ws variants; --max-depth controls recursion depth.
- test_story_recursive.py: StoryNode assembly/leaf-count coverage.

https://claude.ai/code/session_01MxzPkLacHkMPYJ4UuQSSsQ