### PR TITLE
docs: establish model roles, refresh README, add pipeline known-issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,209 +1,81 @@
 # Story Writer
 
-Interactive DSPy-based story generation pipeline with optional image generation and Langfuse observability.
+A local-first DSPy pipeline that turns a one-line idea into a multi-chapter story.
+Runs against Ollama (or any DSPy-supported LLM), with optional Langfuse tracing.
+
+> The detailed contributor guide is **[AGENTS.md](AGENTS.md)**. A pre-rewrite
+> implementation lives under `archive/` and is not used.
 
 ## Quickstart
 
 ```bash
 pip install -r requirements.txt
 cp .env.example .env
-python main.py
+
+# non-interactive run (accepts the idea up front, still confirms each step)
+python mymain.py --idea "your story idea here" --title "Working Title" --number-of-chapters 7
+
+# fully interactive flow (clarifying questions, per-run folder under runs/)
+python story.py
 ```
 
-## What It Does
+Outputs are written incrementally, so an interrupted run keeps everything produced so far.
 
-- Guides you through an interactive ideation flow with feedback loops at every stage (questions, premise, spine, world bible, chapter plan).
-- Generates structured story artifacts (chapter plan, enhancers guide, full story).
-- Saves progress incrementally — if the process crashes, you keep everything generated so far.
-- Optionally generates character portraits and per-chapter scene illustrations via Replicate.
-- Writes all outputs to a markdown file in your chosen output directory.
+## Chapter-drafting variants
 
-## Project Layout
+The foundation (clarify → premise → spine → world bible → chapter plan) is the same;
+the three entry points differ only in how chapters are drafted afterward:
 
-- `main.py` — thin CLI entry point: parse args, setup runtime, run pipeline, save output.
-- `cli.py` — argument parsing (`build_arg_parser`, model/runtime/output flag groups).
-- `models.py` — pipeline dataclasses (`GenerationParams`, `ImageArtifacts`, `StoryFoundation`, `StoryRunArtifacts`).
-- `pipeline.py` — orchestration logic with `@observe()` tracing and user feedback loops.
-- `ui.py` — Rich-based interactive UI layer (all `console.print` / `Prompt.ask` / `Confirm.ask`).
-- `output.py` — file I/O helpers: incremental `update_artifact()` and final `save_story_output()`.
-- `qa.py` — post-generation quality checks (similar-sentence detection).
-- `story_modules.py` — core DSPy story generation modules/signatures.
-- `world_bible_modules.py` — world bible question + generation modules.
-- `world_bible.py` — structured `WorldBible` Pydantic model.
-- `image_gen.py` — Replicate-based image generation helpers.
-- `logging_config.py` — centralized logging configuration with token-usage callback.
-- `dspy_runtime.py` — shared DSPy LM configuration helpers.
-- `dspy_optimization.py` — optimized module loading.
-- `_compat.py` — compatibility shims (Langfuse `@observe()` fallback).
-- `scripts/` — utilities (Langfuse traces, text-pipeline optimization, word count).
-- `test_story.py` — pytest coverage for the primary pipeline.
+| Variant | Entry point | Drafting strategy |
+|---|---|---|
+| **A · baseline** *(default)* | `python mymain.py` | per-chapter `enhance_chapter` + a rolling plain-text "story so far" summary |
+| **B · world-state** | `python mymain_ws.py` | structured `WorldState` (story clock / characters / locations / plot threads / objects / recent events), updated after each chapter |
+| **C · dspy.Module** | `python mymain_module.py` | each chapter drafted independently from its own outline beats + world bible + act-sliced spine |
 
-## Requirements
+See **[docs/model-implementation-comparison-2026-05-10.md](docs/model-implementation-comparison-2026-05-10.md)**
+for a head-to-head of the three variants across models, and
+**[docs/pipeline-known-issues.md](docs/pipeline-known-issues.md)** for current limitations.
 
-- Python 3.10+
-- Access to an LLM provider supported by DSPy (default model is `openai/gpt-4o-mini`)
-- Optional for images: Replicate account/token
-- Optional for observability: Langfuse credentials
+## Recommended local models
 
-Install dependencies:
+| Role | Model | When to use |
+|---|---|---|
+| **Quality** | `qwen3.6:27b` (~27.8B, 17 GB, 256K ctx) | Best output by a wide margin — names its protagonist, dramatizes the premise, lands real endings. ~6–7k words for a 7-chapter run. Cost: ~1.5 h wall-clock per story on one GPU, ~24 GB VRAM at `--num-ctx 24576`. Use **variant A**. |
+| **Fast / smoke / dev** | `qwen3:latest` (~8.2B, 5.2 GB, 41K ctx) | End-to-end pipeline runs in ~5 min; fine for "does it run" and iteration where prose quality doesn't matter. Writes short (~250-word) chapters. |
+
+`gemma4:26b` is not recommended — it completes but drops/garbles words and never names the
+protagonist; `qwen3:latest` is the better fast model and `qwen3.6:27b` the better quality model.
+
+> Pin `--max-tokens 8192` (the 4096 default truncates verbose models, which currently
+> crashes the run — see the known-issues doc). At `--num-ctx 24576`, `qwen3.6:27b`'s
+> chapter-draft inputs run ~13–18k tokens, so leave headroom; bump `--num-ctx` if the log
+> shows context truncation (max 262144).
+
+## Key CLI flags (`mymain.py`, shared by `mymain_ws.py` / `mymain_module.py`)
+
+- `--model` (default `qwen3`), `--provider` (default `ollama`), `--api-key`
+- `--idea`, `--title`, `--number-of-chapters` (default 7)
+- `--max-tokens` (default 4096 — **set 8192+**), `--num-ctx` (default 16384)
+- `--cache` / `--no-cache`, `--memory-cache` / `--no-memory-cache`, `--cache-dir`
+- `--output-file` (default `.tmp/story.md`), `--log-file` (default `.tmp/mymain.log`)
+- `-v` / `-vv` / `-vvv` (INFO / LLM debug / full HTTP+LLM firehose)
+
+## Environment
+
+Copy `.env.example` → `.env`. Relevant keys: `API_KEY`, `DEEPSEEK_API_KEY` (paid fallback),
+`DSPY_CACHE_DIR`, and Langfuse (`LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` /
+`LANGFUSE_BASE_URL`). Ollama is expected at `http://localhost:11434`.
+
+## Utilities
 
 ```bash
-pip install -r requirements.txt
+python scripts/run_qa.py path/to/story.md [...]      # QA detection suite (name drift, character presence, phrase reuse)
+python scripts/word_count.py path/to/story.md        # top repeated content words in the Final Story section
+python scripts/render_story.py story.md [out.html]   # render the markdown artifact to a self-contained HTML page
 ```
 
-For development/test tooling:
-
-```bash
-pip install -r requirements-dev.txt
-```
-
-If you plan to use image generation, also install:
-
-```bash
-pip install replicate
-```
-
-## Environment Variables
-
-Copy `.env.example` to `.env` and fill what you need.
-
-Core model/runtime settings:
-
-- `MODEL` (default: `openai/gpt-4o-mini`)
-- `LLM_URL` (for local/custom providers, e.g. Ollama)
-- `API_KEY`
-- `DSPY_CACHE_DIR`
-- `DSPY_USE_OPTIMIZED` (set `true`/`1` to load optimized text-module artifacts)
-- `DSPY_OPTIMIZED_MANIFEST` (path to text-pipeline optimization manifest)
-
-Optional image generation:
-
-- `REPLICATE_API_TOKEN`
-
-Optional logging:
-
-- `LOG_LEVEL` (e.g. `DEBUG`, `INFO`)
-- `LOG_FORMAT` (`text` or `json`)
-- `LOG_FILE` (set to enable JSON file logging)
-
-Optional Langfuse:
-
-- `LANGFUSE_PUBLIC_KEY`
-- `LANGFUSE_SECRET_KEY`
-- `LANGFUSE_HOST` (default in example: `https://cloud.langfuse.com`)
-
-## Running the App
-
-Basic run:
-
-```bash
-python main.py
-```
-
-Example with explicit model endpoint:
-
-```bash
-python main.py --model ollama_chat/llama3 --llm-url http://localhost:11434
-```
-
-Enable images:
-
-```bash
-python main.py --enable-images --replicate-api-token "$REPLICATE_API_TOKEN"
-```
-
-## Main CLI Flags (`main.py`)
-
-- `--model`
-- `--llm-url`
-- `--api-key`
-- `--max-tokens`
-- `--output-dir` (default: `.tmp`)
-- `--cache` / `--no-cache`
-- `--memory-cache` / `--no-memory-cache`
-- `--cache-dir` (default: `.cache/dspy`)
-- `--use-optimized` / `--no-use-optimized`
-- `--optimized-manifest` (default: `.tmp/dspy_optimized/text_pipeline_manifest.json`)
-- `--enable-images`
-- `--replicate-api-token`
-- `--log-file`
-- `-v`, `-vv`, `-vvv` (increasing verbosity)
-
-## Text Pipeline Optimization
-
-Compile/save text-module artifacts and a manifest:
-
-```bash
-python scripts/optimize_text_pipeline.py \
-  --model openai/gpt-4o-mini \
-  --manifest .tmp/dspy_optimized/text_pipeline_manifest.json
-```
-
-Run with optimized text modules enabled:
-
-```bash
-python main.py \
-  --use-optimized \
-  --optimized-manifest .tmp/dspy_optimized/text_pipeline_manifest.json
-```
-
-Optimize only a subset of text modules:
-
-```bash
-python scripts/optimize_text_pipeline.py \
-  --modules QuestionGenerator,CorePremiseGenerator,StoryGenerator
-```
-
-## Output
-
-By default, output is written to:
-
-- `.tmp/story_output.md`
-
-The markdown includes:
-
-- Generation Parameters (model, max_tokens, cache settings)
-- Core Premise
-- Spine Template
-- World Bible
-- Chapter Plan
-- Enhancers Guide
-- Final Story
-- Optional character portraits / scene image embeds when images are enabled
-
-Sections are written incrementally as they are generated, so partial progress is preserved on interruption.
-
-## Logging Behavior
-
-- Console logging is always enabled.
-- `--log-file` (or `LOG_FILE`) enables JSON file logging.
-- Verbosity flags:
-  - `-v`: INFO for app logs
-  - `-vv`: includes LLM-related debug logs
-  - `-vvv`: full HTTP + LLM debug firehose
-
-## Langfuse Trace Utility
-
-Fetch traces:
-
-```bash
-python scripts/fetch_langfuse_traces.py --mode fetch --limit 50 --hours 24 --output .tmp/langfuse_traces.json
-```
-
-Summarize traces:
-
-```bash
-python scripts/fetch_langfuse_traces.py --mode summarize --input .tmp/langfuse_traces.json --output .tmp/langfuse_summary.json --summary-hours 24
-```
-
-## Running Tests
+## Tests
 
 ```bash
 pytest -q
 ```
-
-## TODO
-
-- Defer DSPy optimization for image-oriented modules until text-pipeline metrics are stable:
-  - `CharacterVisualDescriber`
-  - `SceneImagePromptGenerator`

--- a/archive/README.md
+++ b/archive/README.md
@@ -1,0 +1,215 @@
+> **Archived.** This documents the pre-rewrite pipeline (`archive/main.py`, `archive/cli.py`,
+> `archive/models.py`, `archive/story_modules.py`, …) and is kept for reference alongside that
+> code. The current pipeline is documented in the repo-root [`README.md`](../README.md).
+
+---
+
+# Story Writer
+
+Interactive DSPy-based story generation pipeline with optional image generation and Langfuse observability.
+
+## Quickstart
+
+```bash
+pip install -r requirements.txt
+cp .env.example .env
+python main.py
+```
+
+## What It Does
+
+- Guides you through an interactive ideation flow with feedback loops at every stage (questions, premise, spine, world bible, chapter plan).
+- Generates structured story artifacts (chapter plan, enhancers guide, full story).
+- Saves progress incrementally — if the process crashes, you keep everything generated so far.
+- Optionally generates character portraits and per-chapter scene illustrations via Replicate.
+- Writes all outputs to a markdown file in your chosen output directory.
+
+## Project Layout
+
+- `main.py` — thin CLI entry point: parse args, setup runtime, run pipeline, save output.
+- `cli.py` — argument parsing (`build_arg_parser`, model/runtime/output flag groups).
+- `models.py` — pipeline dataclasses (`GenerationParams`, `ImageArtifacts`, `StoryFoundation`, `StoryRunArtifacts`).
+- `pipeline.py` — orchestration logic with `@observe()` tracing and user feedback loops.
+- `ui.py` — Rich-based interactive UI layer (all `console.print` / `Prompt.ask` / `Confirm.ask`).
+- `output.py` — file I/O helpers: incremental `update_artifact()` and final `save_story_output()`.
+- `qa.py` — post-generation quality checks (similar-sentence detection).
+- `story_modules.py` — core DSPy story generation modules/signatures.
+- `world_bible_modules.py` — world bible question + generation modules.
+- `world_bible.py` — structured `WorldBible` Pydantic model.
+- `image_gen.py` — Replicate-based image generation helpers.
+- `logging_config.py` — centralized logging configuration with token-usage callback.
+- `dspy_runtime.py` — shared DSPy LM configuration helpers.
+- `dspy_optimization.py` — optimized module loading.
+- `_compat.py` — compatibility shims (Langfuse `@observe()` fallback).
+- `scripts/` — utilities (Langfuse traces, text-pipeline optimization, word count).
+- `test_story.py` — pytest coverage for the primary pipeline.
+
+## Requirements
+
+- Python 3.10+
+- Access to an LLM provider supported by DSPy (default model is `openai/gpt-4o-mini`)
+- Optional for images: Replicate account/token
+- Optional for observability: Langfuse credentials
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+For development/test tooling:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+If you plan to use image generation, also install:
+
+```bash
+pip install replicate
+```
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill what you need.
+
+Core model/runtime settings:
+
+- `MODEL` (default: `openai/gpt-4o-mini`)
+- `LLM_URL` (for local/custom providers, e.g. Ollama)
+- `API_KEY`
+- `DSPY_CACHE_DIR`
+- `DSPY_USE_OPTIMIZED` (set `true`/`1` to load optimized text-module artifacts)
+- `DSPY_OPTIMIZED_MANIFEST` (path to text-pipeline optimization manifest)
+
+Optional image generation:
+
+- `REPLICATE_API_TOKEN`
+
+Optional logging:
+
+- `LOG_LEVEL` (e.g. `DEBUG`, `INFO`)
+- `LOG_FORMAT` (`text` or `json`)
+- `LOG_FILE` (set to enable JSON file logging)
+
+Optional Langfuse:
+
+- `LANGFUSE_PUBLIC_KEY`
+- `LANGFUSE_SECRET_KEY`
+- `LANGFUSE_HOST` (default in example: `https://cloud.langfuse.com`)
+
+## Running the App
+
+Basic run:
+
+```bash
+python main.py
+```
+
+Example with explicit model endpoint:
+
+```bash
+python main.py --model ollama_chat/llama3 --llm-url http://localhost:11434
+```
+
+Enable images:
+
+```bash
+python main.py --enable-images --replicate-api-token "$REPLICATE_API_TOKEN"
+```
+
+## Main CLI Flags (`main.py`)
+
+- `--model`
+- `--llm-url`
+- `--api-key`
+- `--max-tokens`
+- `--output-dir` (default: `.tmp`)
+- `--cache` / `--no-cache`
+- `--memory-cache` / `--no-memory-cache`
+- `--cache-dir` (default: `.cache/dspy`)
+- `--use-optimized` / `--no-use-optimized`
+- `--optimized-manifest` (default: `.tmp/dspy_optimized/text_pipeline_manifest.json`)
+- `--enable-images`
+- `--replicate-api-token`
+- `--log-file`
+- `-v`, `-vv`, `-vvv` (increasing verbosity)
+
+## Text Pipeline Optimization
+
+Compile/save text-module artifacts and a manifest:
+
+```bash
+python scripts/optimize_text_pipeline.py \
+  --model openai/gpt-4o-mini \
+  --manifest .tmp/dspy_optimized/text_pipeline_manifest.json
+```
+
+Run with optimized text modules enabled:
+
+```bash
+python main.py \
+  --use-optimized \
+  --optimized-manifest .tmp/dspy_optimized/text_pipeline_manifest.json
+```
+
+Optimize only a subset of text modules:
+
+```bash
+python scripts/optimize_text_pipeline.py \
+  --modules QuestionGenerator,CorePremiseGenerator,StoryGenerator
+```
+
+## Output
+
+By default, output is written to:
+
+- `.tmp/story_output.md`
+
+The markdown includes:
+
+- Generation Parameters (model, max_tokens, cache settings)
+- Core Premise
+- Spine Template
+- World Bible
+- Chapter Plan
+- Enhancers Guide
+- Final Story
+- Optional character portraits / scene image embeds when images are enabled
+
+Sections are written incrementally as they are generated, so partial progress is preserved on interruption.
+
+## Logging Behavior
+
+- Console logging is always enabled.
+- `--log-file` (or `LOG_FILE`) enables JSON file logging.
+- Verbosity flags:
+  - `-v`: INFO for app logs
+  - `-vv`: includes LLM-related debug logs
+  - `-vvv`: full HTTP + LLM debug firehose
+
+## Langfuse Trace Utility
+
+Fetch traces:
+
+```bash
+python scripts/fetch_langfuse_traces.py --mode fetch --limit 50 --hours 24 --output .tmp/langfuse_traces.json
+```
+
+Summarize traces:
+
+```bash
+python scripts/fetch_langfuse_traces.py --mode summarize --input .tmp/langfuse_traces.json --output .tmp/langfuse_summary.json --summary-hours 24
+```
+
+## Running Tests
+
+```bash
+pytest -q
+```
+
+## TODO
+
+- Defer DSPy optimization for image-oriented modules until text-pipeline metrics are stable:
+  - `CharacterVisualDescriber`
+  - `SceneImagePromptGenerator`

--- a/docs/handoff-pipeline-fixes.md
+++ b/docs/handoff-pipeline-fixes.md
@@ -1,0 +1,50 @@
+# Handoff — pipeline fixes after the model bake-off
+
+For the next session. Context lives in:
+- `docs/model-implementation-comparison-2026-05-10.md` — the 3-models × 3-variants bake-off + recommendation.
+- `docs/pipeline-known-issues.md` — the full prioritized issue list (this handoff is the action plan for it).
+- `.tmp/cmp/` — raw bake-off outputs (gitignored): `<model>/{A_baseline,B_worldstate,C_module}.{md,log,console}`,
+  `NOTES.md`, `REPORT.md`, the per-model `*.driver.log`, and `run_model.sh` (the driver — re-usable for re-running the matrix).
+- PR **#101** (`docs/model-roles-and-known-issues` branch) — README rewrite + the two docs above + a `mymain.py` help fix. Docs-only; can merge independently.
+
+Recommended config for any test run: **`--model qwen3 --num-ctx 24576 --max-tokens 8192`** (the small 8B; full A run ≈ 5 min).
+For a real quality check, `--model qwen3.6:27b` (≈90 min for variant A). Drive runs unattended with `yes '' | python mymain.py ...`.
+After a run: `python scripts/run_qa.py <story.md>` and eyeball the prose.
+
+## Work items, in suggested order
+
+### 1. `--max-tokens` truncation → `None` → hard crash  *(highest impact)*
+- Bump the `--max-tokens` default in `mymain.py` from `4096` to `8192` (and check `story.py` / any other entry point for the same default).
+- Wrap the LM-producing steps so a single bad/truncated/`None` response doesn't kill the run:
+  - guard sites that currently assume non-`None`: `pipeline.py` (`len(enhanced)` around line ~159), `world_state.py` (`render_world_state(state.story_clock)` etc.), `story_module.py`, `pipeline_ws.py`, `pipeline_module.py`.
+  - add a small bounded retry (2–3 tries) around each `dspy` call that returns a structured field; on persistent failure, fail *that chapter/step* with a clear logged error rather than crashing the whole pipeline (and write a placeholder so the artifact still renders).
+- Stretch: a checkpoint/resume so a run that dies at chapter N can restart from N (today only the DSPy disk cache softens a same-process re-run).
+- Verify: ran `qwen3.6:27b` at `--max-tokens 4096` and all three variants crashed exactly here; at `8192` all three completed. Repro the crash by forcing `--max-tokens 4096` with `qwen3.6:27b` (or any verbose model).
+
+### 2. Chapter-1 cold-open has no protagonist name  *(user thinks this is the easiest)*
+The drafter writes literal "the protagonist" / "the child" in ch1 because the name isn't established yet (variant B avoids it — its `WorldState` carries the name into ch1; variant C is worst).
+Two ways, pick one:
+- **Cheap, no LLM:** once the protagonist's name is known (it reliably appears by ch2 — "Cinder" in the bake-off, and/or is derivable from the world-bible Characters block), post-process chapter 1: literal string-replace the placeholder ("the protagonist", "the child", maybe "the Hunter") with the name. This is basically search-and-replace. Watch for: the placeholder appears mid-sentence, sometimes capitalized ("The protagonist"); only do it in ch1 prose, not the world-bible/plan sections.
+- **Cleaner:** add a `protagonist_name` field to the foundation (have the premise/world-bible step name them) and feed it into chapter-1 drafting (the way `pipeline_ws.py` already does via `WorldState`). Then merge that behaviour into variant A.
+- Verify: `grep -n "the protagonist\|the child" <ch1 of the rendered story>` should come back empty after the fix; re-read ch1.
+
+### 3. QA: fail empty / very-short prose  *(small, contained)*
+`qa.py` — add a hard rule: chapter prose below ~N words (start with N≈80) fails. Pre-existing gap: `runs/demo-hollow` ch3 was empty and passed R1–R6.
+
+### 4. QA: fix `character_presence` parser  *(small, contained)*
+`qa.py` — it currently extracts "character names" by grabbing bolded spans, so it treats world-bible list items ("**Reclaim Identity**", "**Protect the Nursery**", …) as characters → spurious FAIL on every `qwen3.6:27b` run. Key off the actual `#### Character N` blocks and their declared names instead. Also relax `name_drift` so paraphrases ("High Cardinal Vane" ↔ "High Clergy") and WorldState-block parse artifacts ("Renn\n\nThe Sanctum", "Soren the Ash" ↔ "Soren Vael") don't FAIL.
+
+### 5. QA: add a POV / protagonist-naming consistency check across chapters  *(new, moderate)*
+Variant C's real flaw at 27B is narration drift (third-person "Cinder" → full first-person in ch5 → "the protagonist" in ch6) and `name_drift` can't see it. Add a check that flags: (a) chapters whose dominant narrator-person differs from the rest, (b) chapters that use a placeholder ("the protagonist"/"the child") instead of the established name.
+
+### 6. Per-chapter anti-repetition  *(moderate–large)*
+Model tics leak across chapters in every variant ("silver suppression runes etched into…" — `qwen3.6:27b`; "kaleidoscopic nightmare of overlapping…" — `gemma4:26b`). Feed prior chapters' sentences (or the top repeated n-grams from `scripts/word_count.py` / the QA reuse list) into the drafter as avoid/negative context.
+
+### 7. Variant B: stop leaking `#### World State after Chapter N` blocks into the artifact  *(small–moderate; only if B is kept/merged)*
+`pipeline_ws.py` renders the state into the story markdown after every chapter. Render it to a sidecar file, or strip it before the "Final Story" section. (It also doubles B's file size and floods the QA repetition metric.)
+
+### 8. Fast-model chapter length  *(small)*
+`qwen3:latest` writes ~250-word chapters regardless of `--max-tokens`. If it's ever used for real output, give the drafter an explicit per-chapter word target.
+
+## Cross-cutting note for whoever picks this up
+The `qwen3.6:27b` + variant A path is the recommended quality config (README). Items 1, 2, 3, 4 are the ones that most directly improve *that* path; 5–8 are quality polish. Items 3 and 4 are nearly free. Item 2 is the one the user flagged as probably a simple search-and-replace.

--- a/docs/model-implementation-comparison-2026-05-10.md
+++ b/docs/model-implementation-comparison-2026-05-10.md
@@ -1,0 +1,162 @@
+# Story-pipeline comparison — 3 models × 3 drafting variants
+
+Run date: 2026-05-10. Idea: *"A nameless child, raised and trained by the Church to hunt
+demons, discovers the Church secretly breeds the very demons it sells protection from — and
+must decide whether to destroy the one institution standing between the world and the dark."*
+Title: **"The Tithe of Ash"**. 7 chapters. Settings: `--num-ctx 24576 --max-tokens 8192`,
+Ollama, DSPy disk cache **on** (wiped per model; within a model, variant A warms the
+foundation and B/C reuse it). Raw outputs: `.tmp/cmp/<model>/{A_baseline,B_worldstate,C_module}.{md,log,console}`.
+First pass used `--max-tokens 4096` — see "Cross-cutting issues" #1; archived in
+`.tmp/cmp/*_mt4096*`.
+
+## The variants
+
+| | Entry point | Inter-chapter continuity |
+|---|---|---|
+| **A · baseline** | `mymain.py` / `pipeline.py` | per-chapter `run_enhance_chapter` + rolling text summary |
+| **B · world-state** | `mymain_ws.py` / `pipeline_ws.py` + `world_state.py` | structured `WorldState` (story clock / characters / locations / threads / objects / recent events), updated each chapter, **also rendered into the artifact** |
+| **C · dspy.Module** | `mymain_module.py` / `pipeline_module.py` + `story_module.py` | none — each chapter drafted independently from its own outline beats + world bible + act-sliced spine. Builds its own outline (different chapter titles). |
+
+## The models
+
+| Tag | Size | Notes |
+|---|---|---|
+| `qwen3:latest` | ~8B (5.2 GB) | small local baseline; the model used in earlier `runs/` |
+| `qwen3.6:27b` | ~27B (17 GB) | the newly-pulled candidate |
+| `gemma4:26b` | (17 GB) | the model that "failed miserably" before |
+
+## Completion / robustness
+
+All 9 runs completed and produced 7 non-empty chapters **at `--max-tokens 8192`**. At the
+old default `--max-tokens 4096`: `qwen3:latest` A & B completed but **C crashed
+deterministically** (`build_outline` JSON truncated → `ValidationError` on `list[PlanEntry]`),
+and **all three `qwen3.6:27b` variants crashed** (verbose model hits the 4096 ceiling →
+truncated response → DSPy returns `None` → unguarded `len(None)` / `None.story_clock`). So
+robustness is a *pipeline* problem, not a model one — see issue #1.
+
+## Metrics (prose only; variant B's rendered WorldState blocks excluded)
+
+| Model | Variant | Wall-clock | Prose words | Per-chapter words | Repeated 5-grams (≥2 ch) | QA fails (real) |
+|---|---|---|---|---|---|---|
+| qwen3:latest | A | 297 s | 1,815 | 206–307 | 27 | char_presence (3 cast absent) |
+| qwen3:latest | B | 196 s | 1,932 | 186–386 | 27 | (name_drift fail is a parse artifact) |
+| qwen3:latest | C | 91 s | 2,042 | 224–430 | 21 | char_presence (2 cast absent) |
+| **qwen3.6:27b** | **A** | **86 min** | **6,362** | 596–1,634 | 26 | — (char_presence fail is a parser artifact) |
+| **qwen3.6:27b** | **B** | 39 min | 5,821 | 558–1,196 | **12** | — (Soren the Ash↔Soren Vael, minor) |
+| **qwen3.6:27b** | **C** | 21 min | **7,154** | 816–1,536 | 21 | — |
+| gemma4:26b | A | 552 s | 3,642 | 393–690 | 22 | name_drift (Vane↔High Clergy, paraphrase); protagonist unnamed |
+| gemma4:26b | B | 402 s | 3,711 | 440–583 | 16 | char_presence ('Elara' unused) |
+| gemma4:26b | C | 196 s | 3,618 | 256–619 | 24 | name_drift (Vane↔High Inquisitor) |
+
+(B's *raw* file word counts are ~2× higher because the per-chapter "World State after Chapter
+N" blocks are rendered into the artifact. Wall-clock for B/C is short because they reuse the
+cached foundation; the 27B's foundation alone is ~45–50 min.)
+
+## Read-through (1–5: continuity / coherence / structure / prose / plot-thread tracking)
+
+### qwen3.6:27b — clearly the best model
+- **A (baseline)** — 4.5 / 4.5 / 4.5 / 4 / 4. Crisp declarative prose, concrete sensory
+  detail; named protagonist **Cinder**; coherent cast (Veyra, Soren, Archivist Malora,
+  Cardinal Valerius, Matron Oros, Kaelen — who sacrifices himself in ch6). The
+  protection-racket premise is actually *dramatized* (the Ash-Furnace Atrium rendering
+  hunters into ash bricks, demons kept as "stock", an "Asset Alpha — Terminal Yield: Maximum"
+  ledger). Real resolution in ch7 (the "third path" — weaving human/demon resonance instead
+  of consuming either; the furnaces fall silent), with a controlled cold-tea/mug image set up
+  in ch7 and paid off in the final beat. **Flaw:** chapter 1 (the cold open) calls the
+  character "the protagonist" ×8 — the name isn't established yet. Minor repetition crutches
+  ("silver suppression runes etched into…", "the heat in their veins", italic *Ash-Burn*).
+- **B (world-state)** — 4.5 / 4 / 4.5 / 4 / 4. Same world; **the most consistent narration**
+  — "Cinder", third person, in *every* chapter including ch1 (the WorldState handoff feeds
+  the name into ch1 drafting). Lowest prose repetition of any run (12). Slightly thinner
+  prose (5.8k). Downside: the artifact is cluttered with seven "#### World State after Chapter
+  N" scaffolding dumps a human reader has to skip; one minor name wobble (Soren the
+  Ash ↔ Soren Vael).
+- **C (dspy.Module)** — 4 / 3 / 4.5 / 4 / 3.5. *Most* prose (7.2k) and the same coherent arc
+  (the one-shot outline carries the through-line even with no inter-chapter state). **But the
+  narrative voice isn't stitched:** ch1 = "the child" ×16, ch2–4 = "Cinder", **ch5 lurches to
+  full first person** ("I stepped through the fracture… my collarbone…", "Cinder" ×0), ch6
+  reverts to third person but says "the protagonist" ×12, ch7 = "Cinder". Each chapter drafted
+  independently → POV/name drift the `name_drift` QA can't detect.
+
+### gemma4:26b — *not* a miserable failure anymore; ~8B-tier
+- **A** — 3.5 / 3.5 / 3.5 / 2.5 / 3. Coherent: "the Hunter" (never named — "Elara" sits unused
+  in the bible), "The Sight" power, the Aegis as a parasitic shield that consumes the
+  "Unworthy", Father Malachi (ex-mentor), High Cardinal Vane, Sister Valerica the relic-flail
+  Inquisitor, the Great Conduit. Recurring bell motif (ch2 dead-thud → ch7 found in the ash).
+  Ending lands but is **bleak and abrupt** — the Hunter shatters the Aegis, the world drowns
+  in grey/Ash-Wastes, story ends mid-stalk; picks "destroy", no third path. **Real prose
+  defects:** dropped/garbled words — "shredly the reinforced leather", "wreatened in a dim
+  light", "curdended into oily", "curdified" (×2), "Lower Wands" (= Wards). qwen3.6:27b never
+  did this. Heavy tics: "kaleidoscopic nightmare of overlapping {realities, truths}", "the
+  Hunter gasped, teeth grinding against…".
+- **B** — ~3.5 overall. Same story; the WorldState updates barely evolve between chapters
+  ("industrial gothic processing area for the 'unworthy'" appears in 5 of 7 state blocks,
+  "demon incursion at the iron border outpost" in 4) — the world-state mechanism adds little
+  signal with this model.
+- **C** — ~3.5; ch7 collapses to 262 prose words. Coherent, own outline; uses "the hunter"
+  throughout so it doesn't show the name/POV drift the 27B's C did.
+
+### qwen3:latest (8B) — coherent but thin and stiff
+- **A** — 4 / 3.5 / 3 / 2.5 / 2.5. ~1.8k words total (≈260 wpc). Coherent (Kael, Veyra, the
+  High Inquisitor, demons-as-trapped-souls, the relic-is-a-forge reveal, reformist Brother
+  Elias), but **the ending whiffs** — chapters 5, 6 and 7 all close on Kael's hand "hovering
+  over the choice"; no decision, no climax. Crutch-phrased ("their scar burned in time with…"
+  nearly every chapter; "[place] seemed to hold its breath" ×3). The protection-racket
+  economics are stated, never shown.
+- **B** — similar quality; QA caught two world-bible characters (Eira, Kael) never appearing
+  in the chapters — the world-state summarization dropped them.
+- **C** — runs clean at 8192 (the 4096 crash was a truncation artifact); ~2k words; same tier.
+
+## Recommendation
+
+1. **Adopt `qwen3.6:27b` as the default local model.** It is a clear, large step up from both
+   `qwen3:latest` and `gemma4:26b` — 3–4× the prose volume, dramatizes the premise instead of
+   gesturing at it, lands real endings, and is the only model that reliably names its
+   protagonist. Cost: ~2.5 h for a 7-chapter story (vs ~10–20 min for the smaller models), and
+   ~24 GB VRAM at `num-ctx 24576`. Worth it for quality runs; keep `qwen3:latest` as a fast
+   smoke-test model.
+2. **`gemma4:26b`: keep around as a same-speed sanity model, not a quality model.** It no
+   longer "fails miserably" (that was the 4096-token crash), but it drops/garbles words and
+   never names the protagonist. If you want a fast model, `qwen3:latest` writes cleaner prose;
+   `gemma4:26b` is a touch more coherent on plot. Roughly a wash.
+3. **Variant: keep A as the default, but adopt B's two good ideas; drop C as a standalone.**
+   - **A (baseline)** is the best all-rounder at 27B. Its one real wart is the unnamed cold
+     open — fix by establishing the protagonist's name in the foundation (or feeding it into
+     ch1 drafting, the way B does).
+   - **B (world-state)** gives the best narration consistency and the lowest prose repetition,
+     but rendering the WorldState blocks into the artifact is a UX bug — render them to a
+     sidecar or strip them before "Final Story". With that fixed, B ≈ A; the structured state
+     is a genuine asset. Worth merging the WorldState-into-chapter-1 behaviour into A even if
+     B itself isn't kept.
+   - **C (dspy.Module)** produces the most prose and a coherent arc (the one-shot outline does
+     the heavy lifting), but drafting chapters in isolation lets the *voice* drift
+     chapter-to-chapter (first person in ch5, "the protagonist" in ch6). Not worth keeping as
+     a user-facing mode unless it also threads POV/style state between chapters — at which
+     point it converges on B.
+
+## Cross-cutting issues (independent of model & variant — worth fixing before the next bake-off)
+
+1. **`--max-tokens` default (4096) is too low and the failure mode is a hard crash.** A
+   verbose model truncates at the ceiling → DSPy returns `None` for the field → `pipeline.py`
+   does `len(enhanced)` / `world_state.py` does `state.story_clock` on `None` and the whole
+   run dies. Raise the default (8192 worked here) **and** wrap LM-producing steps with a
+   retry + a `None`/empty guard so one bad response doesn't kill a 2-hour run.
+2. **QA `character_presence` mis-parses the world bible.** It treats bold list items
+   ("**Reclaim Identity**", "**Protect the Nursery**", …) as character names → spurious FAILs
+   on every `qwen3.6:27b` run. Tighten the extractor to the actual `#### Character N` blocks.
+3. **QA can't see POV / pronoun drift** — variant C's real weakness (first-person ch5,
+   "the protagonist" ch6) goes unflagged while `name_drift` fires on harmless paraphrases
+   ("High Cardinal Vane" ↔ "High Clergy") and on WorldState-block parsing artifacts
+   ("Renn\n\nThe Sanctum"). Add a check for narrator-person consistency and protagonist-naming
+   consistency across chapters.
+4. **QA still doesn't flag empty / very-short prose** (pre-existing — `runs/demo-hollow` ch3
+   was empty and passed R1–R6). Add a hard rule: chapter prose below N words fails.
+5. **Variant B leaks pipeline scaffolding into the artifact** — the "#### World State after
+   Chapter N" blocks. Render to a sidecar file or strip before the "Final Story" section.
+6. **Chapter-1 cold-open has no protagonist name** in A and (worse) C → literal "the
+   protagonist" / "the child" placeholder text. B avoids it. Fix in the foundation or in ch1
+   drafting.
+7. **Per-chapter anti-repetition would help every model.** "silver suppression runes etched
+   into…" (qwen3.6:27b) and "kaleidoscopic nightmare of overlapping…" (gemma4:26b) recur
+   across all three variants. Feeding prior chapters' sentences into the drafter as
+   negative/avoid context would suppress the worst tics.

--- a/docs/pipeline-known-issues.md
+++ b/docs/pipeline-known-issues.md
@@ -1,0 +1,82 @@
+# Pipeline known issues
+
+Last reviewed: 2026-05-10, against the **`qwen3.6:27b` + variant A (baseline)** path —
+the recommended quality config (see `README.md` and
+`docs/model-implementation-comparison-2026-05-10.md`).
+
+Ordered roughly by how much they hurt that path.
+
+## 1. Truncated / `None` LM output is a hard crash (no retry, no guard) — **highest priority**
+
+`qwen3.6:27b` is verbose. With the default `--max-tokens 4096`, chapter-draft and
+world-state calls hit the token ceiling exactly, the response is truncated, DSPy fails to
+parse the structured field and returns `None`, and the pipeline dies on the next use of it:
+
+- `pipeline.py` — `len(enhanced)` on `enhanced is None` → `TypeError`
+- `world_state.py` — `render_world_state(None)` → `AttributeError: 'NoneType' has no 'story_clock'`
+- `story_module.py` — same `None` → `TypeError`
+
+This took down the entire `qwen3.6:27b` run on the first pass. Workaround today: pass
+`--max-tokens 8192`. Real fix: (a) raise the default, **and** (b) wrap LM-producing steps in
+a bounded retry plus a `None`/empty guard so one bad response doesn't kill a ~90-minute run.
+Bonus: a checkpoint/resume so a run that dies at chapter 6 doesn't need the exact same
+process to restart and rely on the DSPy cache.
+
+## 2. Chapter 1 (the cold open) has no protagonist name yet
+
+Variant A drafts chapter 1 before the protagonist is named anywhere, so the prose says
+"the protagonist" / "the child" literally. (Variant B avoids this because its `WorldState`
+hand-off carries the name into chapter-1 drafting; variant C is worse — "the child" ×16 in
+ch1.) Fix: establish the protagonist's name in the foundation (premise/world bible) and feed
+it into chapter-1 drafting, the way B does.
+
+## 3. Model-tic repetition leaks across chapters
+
+`qwen3.6:27b` reuses signature phrases — e.g. "silver suppression runes etched into …",
+"the heat in their veins", an italicised *Ash-Burn* on every occurrence — in every variant.
+QA's `cross_chapter_phrase_reuse` flags it but nothing acts on it. Fix: feed prior chapters'
+sentences into the drafter as avoid/negative context.
+
+## 4. QA `character_presence` mis-parses the world bible
+
+It treats bold list items in the world-bible Characters section ("**Reclaim Identity**",
+"**Protect the Nursery**", "**Subvert the Tithe**", …) as character names, then reports them
+as "never appears in chapters" → spurious `FAIL` on every `qwen3.6:27b` run. Tighten the
+extractor to the actual `#### Character N` blocks (and their names), not every bolded span.
+
+## 5. QA can't see POV / pronoun drift
+
+Variant C's real defect at 27B is that the narrative voice drifts chapter-to-chapter
+(third-person "Cinder" → full first-person in ch5 → "the protagonist" in ch6). `name_drift`
+only tracks proper nouns, so this goes unflagged — while `name_drift` *does* fire on harmless
+paraphrases ("High Cardinal Vane" ↔ "High Clergy") and on `WorldState`-block parsing
+artifacts ("Renn\n\nThe Sanctum", "Soren the Ash" ↔ "Soren Vael"). Add a
+narrator-person / protagonist-naming consistency check; relax the proper-noun matcher so
+paraphrase variants don't FAIL.
+
+## 6. QA still doesn't flag empty / very-short prose
+
+Pre-existing: an empty chapter passes R1–R6 (`runs/demo-hollow` chapter 3 was empty and
+passed). Add a hard rule: chapter prose below N words fails.
+
+## 7. Variant B leaks pipeline scaffolding into the artifact
+
+`pipeline_ws.py` renders a `#### World State after Chapter N` block into the story markdown
+after every chapter — a human reader has to skip seven of them, and it inflates word-count /
+repetition metrics (~2× the file size, hundreds of bogus repeated n-grams from the block
+headers). Render the state to a sidecar file, or strip it before the "Final Story" section.
+(Not on the recommended path, but relevant if B is kept or merged into A.)
+
+## 8. Chapters are thin on the fast model
+
+`qwen3:latest` writes ~250-word chapters regardless of `--max-tokens`, so a 7-chapter "story"
+is ~2k words. Fine for smoke tests; if it's ever used for real output, the drafter needs an
+explicit length target.
+
+## Not an issue (clearing the record)
+
+- **`gemma4:26b` "fails miserably"** — that was issue #1 (the 4096-token crash), not the
+  model. At `--max-tokens 8192` on the current pipeline it completes all 7 chapters; it's
+  just lower quality (garbled/dropped words, unnamed protagonist) than `qwen3.6:27b`.
+- **Variant C "deterministically crashes" on `qwen3:latest`** — also issue #1: `build_outline`
+  JSON was truncated at a deterministic point. At `--max-tokens 8192` it runs clean.

--- a/mymain.py
+++ b/mymain.py
@@ -45,7 +45,7 @@ def parse_args() -> argparse.Namespace:
         default=16384,
         help=(
             "Ollama context window size (num_ctx). Bigger = more VRAM. "
-            "qwen3 max 40960; gemma4:26b max 262144."
+            "qwen3:latest max 40960; qwen3.6:27b max 262144."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
## What

Documentation pass following the 3-models × 3-drafting-variants bake-off.

- **README rewritten** for the current pipeline (`mymain.py` + the A/B/C chapter-drafting variants). The old README documented the archived `main.py`/`cli.py` implementation that's no longer used.
- **Model roles established** (new "Recommended local models" section):
  - `qwen3.6:27b` — quality model; use with **variant A**. ~6–7k words / 7-chapter run, ~1.5 h, ~24 GB VRAM at `--num-ctx 24576`.
  - `qwen3:latest` — fast / smoke / dev model; ~5 min end-to-end, fine when prose quality is irrelevant.
  - `gemma4:26b` — marked **not recommended** (completes, but garbles words / never names the protagonist).
- **`mymain.py`** `--num-ctx` help text: dropped the stale `gemma4:26b` reference; now cites `qwen3:latest` (41K) / `qwen3.6:27b` (256K) max context.
- **New `docs/model-implementation-comparison-2026-05-10.md`** — full bake-off (metrics + read-through + recommendation: adopt `qwen3.6:27b`, keep variant A, steal variant B's "feed the protagonist name into chapter 1" idea, don't ship variant C standalone).
- **New `docs/pipeline-known-issues.md`** — current limitations, prioritized for the `qwen3.6:27b` + variant A path:
  1. Truncated/`None` LM output is a hard crash (no retry/guard) — workaround is `--max-tokens 8192`.
  2. Chapter-1 cold open has no protagonist name → literal "the protagonist" in ch1.
  3. Model-tic phrases repeat across chapters; QA flags but nothing acts.
  4. QA `character_presence` mis-parses bold world-bible list items as character names.
  5. QA can't see POV/pronoun drift (variant C's real flaw).
  6. QA still passes empty/very-short chapters.
  7. Variant B dumps `#### World State after Chapter N` scaffolding into the artifact.
  8. Fast model writes ~250-word chapters regardless of token budget.
  Plus a "not an issue" section clearing the record on "gemma4 fails miserably" and "variant C deterministically crashes" — both were just issue #1 (the 4096-token truncation crash).

## Notes

- Docs-only + a one-line help-string fix; no behavior change.
- Raw bake-off outputs live under `.tmp/cmp/` (gitignored, not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)