### PR TITLE
fix(pipeline): guard LM calls against truncated/None output (#102 item 1)

### DIFF
--- a/dspy_runtime.py
+++ b/dspy_runtime.py
@@ -25,7 +25,7 @@ class DSPyConfig:
     model_name: str
     api_base: str | None = None
     api_key: str | None = None
-    max_tokens: int = 8000
+    max_tokens: int = 8192
     num_ctx: int | None = None
     cache: bool = True
     memory_cache: bool = True
@@ -38,7 +38,7 @@ def dspy_config_from_namespace(args: Namespace) -> DSPyConfig:
         model_name=args.model,
         api_base=getattr(args, "llm_url", None),
         api_key=getattr(args, "api_key", None),
-        max_tokens=getattr(args, "max_tokens", 8000),
+        max_tokens=getattr(args, "max_tokens", 8192),
         cache=getattr(args, "cache", True),
         memory_cache=getattr(args, "memory_cache", True),
         cache_dir=getattr(args, "cache_dir", None),

--- a/lm_retry.py
+++ b/lm_retry.py
@@ -1,0 +1,90 @@
+"""Bounded retry + empty-output guard for DSPy structured-output calls.
+
+A truncated LM response makes the DSPy adapter fail to parse the structured
+output field and hand back ``None`` (or an empty value); downstream code then
+dies on ``len(None)`` / ``None.story_clock`` and the whole multi-hour run is
+lost over one bad chapter. :func:`call_with_retry` reruns such a call a few
+times and, if it still cannot get a usable result, raises :class:`LMOutputError`
+so the caller can fail just that step -- and write a placeholder so the artifact
+still renders -- instead of crashing the pipeline.
+"""
+
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ATTEMPTS = 3
+DEFAULT_BACKOFF_SECONDS = 2.0
+
+
+class LMOutputError(RuntimeError):
+    """A DSPy call kept returning an unusable (empty/``None``) structured output."""
+
+
+def _looks_empty(value: object) -> bool:
+    """True if ``value`` is the kind of thing a truncated/failed parse leaves behind."""
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return not value.strip()
+    if isinstance(value, (list, tuple, set, dict)):
+        return len(value) == 0
+    return False
+
+
+def call_with_retry(
+    program,
+    *,
+    fields=(),
+    label: str,
+    attempts: int = DEFAULT_ATTEMPTS,
+    backoff_seconds: float = DEFAULT_BACKOFF_SECONDS,
+    **kwargs,
+):
+    """Call ``program(**kwargs)`` (a DSPy module invocation), retrying on failure.
+
+    An attempt counts as failed if the call raises *or* if any attribute named in
+    ``fields`` is empty/``None`` on the returned prediction. After ``attempts``
+    failed tries, raise :class:`LMOutputError`.
+
+    Args:
+        program: The configured DSPy module (e.g. ``dspy.ChainOfThought(Sig)``).
+        fields: Name, or iterable of names, of output field(s) that must be
+            non-empty. Empty/omitted means "retry on exceptions only".
+        label: Human-readable step name, used in log messages and the error.
+        attempts: Maximum number of tries (>= 1).
+        backoff_seconds: Multiplier for the linear sleep between tries.
+        **kwargs: Forwarded to ``program``.
+    """
+    field_names = (fields,) if isinstance(fields, str) else tuple(fields)
+    last_error: BaseException | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            result = program(**kwargs)
+        except Exception as exc:  # noqa: BLE001 - any LM/transport/parse error is retryable
+            last_error = exc
+            logger.warning(
+                "LM step %r failed on attempt %d/%d: %s", label, attempt, attempts, exc
+            )
+        else:
+            empty = [f for f in field_names if _looks_empty(getattr(result, f, None))]
+            if not empty:
+                if attempt > 1:
+                    logger.info(
+                        "LM step %r recovered on attempt %d/%d", label, attempt, attempts
+                    )
+                return result
+            last_error = LMOutputError(
+                f"{label}: empty output field(s): {', '.join(empty)}"
+            )
+            logger.warning(
+                "LM step %r returned empty %s on attempt %d/%d "
+                "(response was probably truncated; try a larger --max-tokens)",
+                label, empty, attempt, attempts,
+            )
+        if attempt < attempts:
+            time.sleep(backoff_seconds * attempt)
+    raise LMOutputError(
+        f"{label}: no usable output after {attempts} attempts"
+    ) from last_error

--- a/mymain.py
+++ b/mymain.py
@@ -36,8 +36,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--max-tokens",
         type=int,
-        default=4096,
-        help="The maximum number of tokens to use for the model. Defaults to 4096.",
+        default=8192,
+        help=(
+            "Max tokens the model may emit per call. Defaults to 8192. "
+            "Verbose models (e.g. qwen3.6:27b) truncate at 4096 mid-structure, "
+            "which the parser turns into an empty/None field."
+        ),
     )
     parser.add_argument(
         "--num-ctx",

--- a/pipeline.py
+++ b/pipeline.py
@@ -2,6 +2,7 @@ import logging
 
 from _compat import observe
 from artifact import update_artifact
+from lm_retry import LMOutputError
 from story import (
     WorldBible,
     run_clarify_idea,
@@ -151,10 +152,17 @@ def write(idea: str, title: str, output_file: str, number_of_chapters: int = 7):
         chapter_plan_str = f"{chapter.chapter_title}\n{chapter.chapter_beats}"
         logger.info("STEP enhance_chapter[%d/%d] | chapter_outline=%s | story_so_far_len=%d",
                     i, len(chapters_plan), _snip(chapter_plan_str, 200), len(story_so_far))
-        enhanced = run_enhance_chapter(
-            chapter_plan_str, updated_idea, story_title, spine, world_bible, story_so_far,
-            chapter_index=i, total_chapters=len(chapters_plan),
-        )
+        try:
+            enhanced = run_enhance_chapter(
+                chapter_plan_str, updated_idea, story_title, spine, world_bible, story_so_far,
+                chapter_index=i, total_chapters=len(chapters_plan),
+            )
+        except LMOutputError as exc:
+            logger.error("Chapter %d drafting failed after retries: %s", i, exc)
+            enhanced = (
+                f"*[Chapter {i} could not be generated — the model returned no "
+                f"usable text. {exc}]*"
+            )
         logger.info("STEP enhance_chapter[%d/%d] | output_chars=%d preview=%s",
                     i, len(chapters_plan), len(enhanced), _snip(enhanced, 240))
         update_artifact(output_file, f"Chapter {i}: {chapter.chapter_title}", enhanced, level=3)
@@ -164,5 +172,9 @@ def write(idea: str, title: str, output_file: str, number_of_chapters: int = 7):
                     i, len(chapters_plan), len(plan_so_far))
 
         chapter_plan_strs = [c.chapter_title + "\n" + c.chapter_beats for c in plan_so_far]
-        story_so_far = run_generate_story_so_far(chapter_plan_strs, story_so_far, enhanced)
+        try:
+            story_so_far = run_generate_story_so_far(chapter_plan_strs, story_so_far, enhanced)
+        except LMOutputError as exc:
+            logger.error("story_so_far summary failed after retries at chapter %d: %s; "
+                         "keeping previous summary", i, exc)
         logger.info("STEP story_so_far[%d/%d] | new_len=%d", i, len(chapters_plan), len(story_so_far))

--- a/pipeline_ws.py
+++ b/pipeline_ws.py
@@ -10,6 +10,7 @@ import logging
 
 from _compat import observe
 from artifact import update_artifact
+from lm_retry import LMOutputError
 from pipeline import _snip, build_world_bible
 from story import (
     run_clarify_idea,
@@ -91,27 +92,42 @@ def _draft_chapters(
             total,
             _snip(world_state.story_clock, 120),
         )
-        prose = run_draft_chapter_with_state(
-            chapter_plan_str,
-            updated_idea,
-            story_title,
-            spine,
-            world_bible,
-            world_state,
-            chapter_index=i,
-            total_chapters=total,
-        )
+        try:
+            prose = run_draft_chapter_with_state(
+                chapter_plan_str,
+                updated_idea,
+                story_title,
+                spine,
+                world_bible,
+                world_state,
+                chapter_index=i,
+                total_chapters=total,
+            )
+        except LMOutputError as exc:
+            logger.error("Chapter %d drafting failed after retries: %s", i, exc)
+            prose = (
+                f"*[Chapter {i} could not be generated — the model returned no "
+                f"usable text. {exc}]*"
+            )
         update_artifact(
             output_file, f"Chapter {i}: {chapter.chapter_title}", prose, level=3
         )
-        world_state = run_advance_world_state(
-            world_state,
-            chapter_plan_str,
-            prose,
-            updated_idea,
-            story_title,
-            world_bible,
-        )
+        try:
+            world_state = run_advance_world_state(
+                world_state,
+                chapter_plan_str,
+                prose,
+                updated_idea,
+                story_title,
+                world_bible,
+            )
+        except LMOutputError as exc:
+            logger.error(
+                "World-state advance failed after retries at chapter %d: %s; "
+                "keeping previous state",
+                i,
+                exc,
+            )
         update_artifact(
             output_file,
             f"World State after Chapter {i}",

--- a/story.py
+++ b/story.py
@@ -6,6 +6,7 @@ import dspy
 
 import ui
 from _compat import observe
+from lm_retry import LMOutputError, call_with_retry
 
 
 @dataclass
@@ -63,7 +64,12 @@ def run_clarify_idea(story_idea: str = None, story_title: str = None) -> tuple[s
         story_idea = ui.ask_idea()
 
     clarify_idea = dspy.ChainOfThought(ClarifyStoryIdea)
-    result = clarify_idea(story_idea=story_idea, story_title=story_title)
+    result = call_with_retry(
+        clarify_idea,
+        label="clarify_idea",
+        story_idea=story_idea,
+        story_title=story_title,
+    )
     qas = []
     for i in range(len(result.questions)):
         proposed_answer, _ = ui.review_answer(
@@ -73,11 +79,21 @@ def run_clarify_idea(story_idea: str = None, story_title: str = None) -> tuple[s
         qas.append(f"question: {result.questions[i]}\nproposed_answer: {proposed_answer}")
 
     update_idea = dspy.ChainOfThought(UpdateIdea)
-    #updated_idea = story_idea + "\n" + "\n".join([f"{qa['question']}: {qa['proposed_answer']}" for qa in qas])
-    updated_idea = update_idea(story_idea=story_idea, qas=qas).updated_idea
+    updated_idea = call_with_retry(
+        update_idea,
+        fields="updated_idea",
+        label="update_idea",
+        story_idea=story_idea,
+        qas=qas,
+    ).updated_idea
     if not story_title:
         generate_title = dspy.ChainOfThought(GenerateStoryTitle)
-        result = generate_title(story_idea=updated_idea)
+        result = call_with_retry(
+            generate_title,
+            fields="story_title",
+            label="generate_title",
+            story_idea=updated_idea,
+        )
         story_title = result.story_title
     return updated_idea, story_title
 
@@ -98,7 +114,14 @@ def run_generate_core_premise(story_idea: str) -> str:
     previous_result = ""
     core_prem_func = dspy.ChainOfThought(GenerateCorePremise)
     while True:
-        generate_core_premise = core_prem_func(story_idea=story_idea, previous_result=previous_result, feedback=feedback)
+        generate_core_premise = call_with_retry(
+            core_prem_func,
+            fields="core_premise",
+            label="core_premise",
+            story_idea=story_idea,
+            previous_result=previous_result,
+            feedback=feedback,
+        )
 
         previous_result = generate_core_premise.core_premise
         feedback, is_correct = ui.review_answer(
@@ -131,8 +154,20 @@ def run_generate_spine(story_idea: str, core_premise: str) -> str:
     feedback = ""
     previous_result = ""
     generate_spine_func = dspy.ChainOfThought(GenerateStorySpine)
+    spine_fields = [
+        "once_upon_a_time",
+        "every_day",
+        "until_one_day",
+        "because_of_that",
+        "and_because_of_that",
+        "until_finally",
+        "ever_since_that_day",
+    ]
     while True:
-        story_spine = generate_spine_func(
+        story_spine = call_with_retry(
+            generate_spine_func,
+            fields=spine_fields,
+            label="spine",
             story_idea=story_idea,
             core_premise=core_premise,
             previous_result=previous_result,
@@ -177,7 +212,10 @@ def run_generate_rules_of_the_world(story_idea: str, story_title: str, story_spi
     previous_result = ""
     generate_rules_of_the_world_func = dspy.ChainOfThought(GenerateRulesOfTheWorld)
     while True:
-        rules_of_the_world = generate_rules_of_the_world_func(
+        rules_of_the_world = call_with_retry(
+            generate_rules_of_the_world_func,
+            fields="rules_of_the_world",
+            label="rules_of_the_world",
             story_idea=story_idea,
             story_title=story_title,
             story_spine=story_spine,
@@ -216,7 +254,10 @@ def run_generate_characters(story_idea: str, story_title: str, story_spine: str,
     previous_result = ""
     generate_characters_func = dspy.ChainOfThought(GenerateCharacters)
     while True:
-        characters = generate_characters_func(
+        characters = call_with_retry(
+            generate_characters_func,
+            fields="characters",
+            label="characters",
             story_idea=story_idea,
             story_title=story_title,
             story_spine=story_spine,
@@ -257,7 +298,10 @@ def run_enhance_character(
     feedback = ""
     enhance_character_func = dspy.ChainOfThought(EnhanceCharacter)
     while True:
-        enhanced_character = enhance_character_func(
+        enhanced_character = call_with_retry(
+            enhance_character_func,
+            fields="enhanced_character",
+            label="enhance_character",
             story_idea=story_idea,
             story_title=story_title,
             story_spine=story_spine,
@@ -302,7 +346,10 @@ def run_generate_locations(
     locations_str = ""
     generate_locations_func = dspy.ChainOfThought(GenerateLocations)
     while True:
-        locations = generate_locations_func(
+        locations = call_with_retry(
+            generate_locations_func,
+            fields="locations",
+            label="locations",
             story_idea=story_idea,
             story_title=story_title,
             story_spine=story_spine,
@@ -345,7 +392,10 @@ def run_enhance_location(
     feedback = ""
     enhance_location_func = dspy.ChainOfThought(EnhanceLocation)
     while True:
-        enhanced_location = enhance_location_func(
+        enhanced_location = call_with_retry(
+            enhance_location_func,
+            fields="enhanced_location",
+            label="enhance_location",
             story_idea=story_idea,
             story_title=story_title,
             story_spine=story_spine,
@@ -388,7 +438,10 @@ def run_generate_timeline(
     timeline_str = ""
     generate_timeline_func = dspy.ChainOfThought(GenerateTimeline)
     while True:
-        timeline = generate_timeline_func(
+        timeline = call_with_retry(
+            generate_timeline_func,
+            fields="timeline",
+            label="timeline",
             story_idea=story_idea,
             story_title=story_title,
             story_spine=story_spine,
@@ -432,7 +485,10 @@ def run_generate_chapters_plan(
     feedback = ""
     generate_chapters_func = dspy.ChainOfThought(GenerateChaptersPlan)
     while True:
-        chapters = generate_chapters_func(
+        chapters = call_with_retry(
+            generate_chapters_func,
+            fields="chapters",
+            label="chapters_plan",
             story_idea=story_idea,
             story_title=story_title,
             story_spine=story_spine,
@@ -566,21 +622,30 @@ and including the current act — treat anything beyond it as not yet decided.
     random_detail = ""
     random_gen = dspy.ChainOfThought(GenerateRandomDetail)
     if random.random() < 0.33:
-        random_detail = random_gen(
-            story_idea=story_idea,
-            story_title=story_title,
-            story_spine=spine_for_draft,
-            rules_of_the_world=world_bible.rules_of_the_world,
-            characters=world_bible.characters,
-            locations=world_bible.locations,
-            timeline=world_bible.timeline,
-            chapter=chapter,
-        ).random_detail
+        try:
+            random_detail = call_with_retry(
+                random_gen,
+                fields="random_detail",
+                label=f"random_detail[ch{chapter_index}]",
+                story_idea=story_idea,
+                story_title=story_title,
+                story_spine=spine_for_draft,
+                rules_of_the_world=world_bible.rules_of_the_world,
+                characters=world_bible.characters,
+                locations=world_bible.locations,
+                timeline=world_bible.timeline,
+                chapter=chapter,
+            ).random_detail
+        except LMOutputError:
+            random_detail = ""  # best-effort flavor; carry on without it
 
     feedback = ""
     draft_chapter_func = dspy.ChainOfThought(DraftChapter)
     while True:
-        result = draft_chapter_func(
+        result = call_with_retry(
+            draft_chapter_func,
+            fields="prose",
+            label=f"draft_chapter[{chapter_index}/{total_chapters}]",
             story_idea=story_idea,
             story_title=story_title,
             story_spine=spine_for_draft,
@@ -626,7 +691,10 @@ def run_generate_story_so_far(
         )
 
     generate_story_so_far = dspy.ChainOfThought(Summarize)
-    return generate_story_so_far(
+    return call_with_retry(
+        generate_story_so_far,
+        fields="summary",
+        label="story_so_far",
         chapter_plan_so_far=chapter_plan_so_far,
         story_so_far=story_so_far,
         chapter=chapter,
@@ -645,7 +713,10 @@ def sanity_check(story_idea: str, story_title: str, story_spine: str, world_bibl
         is_consistent: bool = dspy.OutputField(desc="Whether the story_idea, story_spine, and world bible are consistent")
     
     sanity_check = dspy.ChainOfThought(SanityCheck)
-    return sanity_check(
+    return call_with_retry(
+        sanity_check,
+        fields="is_consistent",
+        label="sanity_check",
         story_idea=story_idea,
         story_title=story_title,
         story_spine=story_spine,

--- a/story_module.py
+++ b/story_module.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 import dspy
 
 from _compat import observe
+from lm_retry import LMOutputError, call_with_retry
 from story import PlanEntry, WorldBible, act_hint_for_chapter
 
 logger = logging.getLogger(__name__)
@@ -93,7 +94,10 @@ class WriteStory(dspy.Module):
         world_bible: WorldBible,
         number_of_chapters: int = 7,
     ) -> dspy.Prediction:
-        outline = self.build_outline(
+        outline = call_with_retry(
+            self.build_outline,
+            fields="chapters",
+            label="story_outline",
             story_idea=story_idea,
             story_title=story_title,
             story_spine=story_spine,
@@ -105,19 +109,30 @@ class WriteStory(dspy.Module):
         for i, spec in enumerate(outline.chapters, 1):
             hint = act_hint_for_chapter(i, total, story_spine)
             logger.info("draft_chapter[%d/%d] | %s", i, total, spec.chapter_title)
-            section = self.draft_chapter(
-                story_idea=story_idea,
-                story_title=story_title,
-                story_spine=hint["spine_through_act"],
-                act_hint=hint["label"],
-                world_bible=world_bible,
-                chapter=f"{spec.chapter_title}\n{spec.chapter_beats}",
-            )
+            try:
+                section = call_with_retry(
+                    self.draft_chapter,
+                    fields="prose",
+                    label=f"draft_chapter[{i}/{total}]",
+                    story_idea=story_idea,
+                    story_title=story_title,
+                    story_spine=hint["spine_through_act"],
+                    act_hint=hint["label"],
+                    world_bible=world_bible,
+                    chapter=f"{spec.chapter_title}\n{spec.chapter_beats}",
+                )
+                prose = section.prose
+            except LMOutputError as exc:
+                logger.error("Chapter %d could not be drafted after retries: %s", i, exc)
+                prose = (
+                    f"*[Chapter {i} could not be generated — the model returned "
+                    f"no usable text. {exc}]*"
+                )
             drafted.append(
                 DraftedChapter(
                     chapter_title=spec.chapter_title,
                     chapter_beats=spec.chapter_beats,
-                    prose=section.prose,
+                    prose=prose,
                 )
             )
         return dspy.Prediction(outline=outline.chapters, chapters=drafted)

--- a/test_lm_retry.py
+++ b/test_lm_retry.py
@@ -1,0 +1,86 @@
+import pytest
+
+from lm_retry import LMOutputError, _looks_empty, call_with_retry
+
+
+class _Pred:
+    def __init__(self, **fields):
+        self.__dict__.update(fields)
+
+
+def test_looks_empty_treats_none_blank_and_empty_containers_as_empty():
+    assert _looks_empty(None)
+    assert _looks_empty("")
+    assert _looks_empty("   \n")
+    assert _looks_empty([])
+    assert _looks_empty({})
+    assert not _looks_empty("x")
+    assert not _looks_empty(["x"])
+    assert not _looks_empty(False)  # a valid bool output is not "empty"
+    assert not _looks_empty(0)
+
+
+def test_returns_first_good_result_without_retrying():
+    calls = []
+
+    def program(**kwargs):
+        calls.append(kwargs)
+        return _Pred(prose="hello")
+
+    result = call_with_retry(program, fields="prose", label="x", a=1)
+    assert result.prose == "hello"
+    assert calls == [{"a": 1}]
+
+
+def test_retries_on_empty_field_then_succeeds():
+    attempts = []
+
+    def program(**_):
+        attempts.append(1)
+        return _Pred(prose="" if len(attempts) < 2 else "good")
+
+    result = call_with_retry(
+        program, fields="prose", label="x", backoff_seconds=0
+    )
+    assert result.prose == "good"
+    assert len(attempts) == 2
+
+
+def test_retries_on_exception_then_succeeds():
+    attempts = []
+
+    def program(**_):
+        attempts.append(1)
+        if len(attempts) < 3:
+            raise RuntimeError("boom")
+        return _Pred(prose="recovered")
+
+    result = call_with_retry(
+        program, fields="prose", label="x", backoff_seconds=0
+    )
+    assert result.prose == "recovered"
+    assert len(attempts) == 3
+
+
+def test_raises_lm_output_error_after_exhausting_attempts_on_empty():
+    def program(**_):
+        return _Pred(prose=None)
+
+    with pytest.raises(LMOutputError):
+        call_with_retry(
+            program, fields="prose", label="draft", attempts=2, backoff_seconds=0
+        )
+
+
+def test_raises_lm_output_error_after_exhausting_attempts_on_exception():
+    def program(**_):
+        raise ValueError("nope")
+
+    with pytest.raises(LMOutputError):
+        call_with_retry(program, label="step", attempts=2, backoff_seconds=0)
+
+
+def test_no_fields_means_retry_on_exceptions_only():
+    # An empty/None field is fine when no fields are required.
+    result = call_with_retry(lambda **_: _Pred(prose=None), label="x")
+    assert result.prose is None

--- a/world_state.py
+++ b/world_state.py
@@ -18,6 +18,7 @@ import dspy
 
 import ui
 from _compat import observe
+from lm_retry import call_with_retry
 from story import WorldBible, act_hint_for_chapter
 
 logger = logging.getLogger(__name__)
@@ -99,7 +100,10 @@ def run_init_world_state(
     previous_result = ""
     init_func = dspy.ChainOfThought(InitWorldState)
     while True:
-        result = init_func(
+        result = call_with_retry(
+            init_func,
+            fields="world_state",
+            label="init_world_state",
             story_idea=story_idea,
             story_title=story_title,
             story_spine=story_spine,
@@ -151,7 +155,10 @@ def run_advance_world_state(
         )
 
     advance_func = dspy.ChainOfThought(AdvanceWorldState)
-    result = advance_func(
+    result = call_with_retry(
+        advance_func,
+        fields="updated_state",
+        label="advance_world_state",
         story_idea=story_idea,
         story_title=story_title,
         world_bible=world_bible,
@@ -213,7 +220,10 @@ def run_draft_chapter_with_state(
     feedback = ""
     draft_func = dspy.ChainOfThought(DraftChapterWithState)
     while True:
-        result = draft_func(
+        result = call_with_retry(
+            draft_func,
+            fields="prose",
+            label=f"draft_chapter_ws[{chapter_index}/{total_chapters}]",
             story_idea=story_idea,
             story_title=story_title,
             story_spine=hint["spine_through_act"],


### PR DESCRIPTION
Verbose models (e.g. qwen3.6:27b) hit the token ceiling mid-structure with
the old default --max-tokens 4096; DSPy then fails to parse the structured
field and hands back None, and the pipeline dies on the next use of it
(len(None), None.story_clock, ...), losing a ~90-minute run over one bad
response.

- Bump the --max-tokens default 4096 -> 8192 (and the dspy_runtime fallbacks).
- Add lm_retry.call_with_retry: a bounded retry (3 tries, linear backoff) around
  each DSPy structured-output call that re-runs on an exception or an
  empty/None output field, and raises LMOutputError on persistent failure.
- Wrap every run_* DSPy invocation in story.py / world_state.py and both
  stages of story_module.WriteStory with call_with_retry.
- In the per-chapter loops (pipeline.py, pipeline_ws.py, story_module.forward),
  catch LMOutputError and write a visible placeholder for that chapter (and
  keep the previous story_so_far / world state) instead of crashing, so the
  artifact still renders.

https://claude.ai/code/session_01Ssyd5xstQbQN6BKtx3scj6