### PR TITLE
Add aiorchestra story kit (issue-driven story workflow)

### DIFF
--- a/aiorchestra_story_kit/README.md
+++ b/aiorchestra_story_kit/README.md
@@ -1,0 +1,74 @@
+# aiorchestra story kit
+
+Turn an (almost) empty git repo into an **aiorchestra-driven story project**:
+every writing phase is a GitHub issue, the agent opens a PR carrying exactly one
+artifact, you review/merge it, then it files the next phase's issue. The phase
+chain mirrors the `story_writer` `write-story` skill — idea → interrogatives →
+premise → spine → world bible → chapter plan → enhancers → chapters →
+assemble & publish.
+
+Full algorithm: **[scaffold/WORKFLOW.md](scaffold/WORKFLOW.md)** — it gets
+copied into every story repo so the agent can read it there.
+
+## What's in here
+
+| Path | Purpose |
+|---|---|
+| `init_story_repo.py` | One-shot scaffolder. stdlib only; needs the `gh` CLI. |
+| `scaffold/` | Files copied verbatim into the target repo (`WORKFLOW.md`, `.aiorchestra/`, `.github/ISSUE_TEMPLATE/`, `story/`). |
+| `repo_md_templates/` | `AGENTS.md` / `CLAUDE.md` templates, rendered from the target repo's README. |
+
+## Prerequisites
+
+- `gh` CLI, authenticated, with the target repo already created on GitHub.
+- An [aiorchestra](https://github.com/ironharvy/AIOrchestra) instance running
+  somewhere with visibility into the target repo (e.g. `aiorchestra dispatch
+  --watch` on your home machine), `claude-code` provider configured.
+- Python 3.10+.
+- Optional: a `herenow-skill/` directory available next to this kit (it ships in
+  `story_writer`) — the init script vendors it into the new repo's
+  `.claude/skills/herenow/` so the "Assemble & Publish" phase can publish.
+
+## Quickstart
+
+```bash
+mkdir my-story && cd my-story && git init
+
+cat > README.md <<'EOF'
+# The Last Keeper
+
+A lighthouse keeper on a dying coast discovers the light is the only thing
+holding back something in the fog; the mainland wants the lighthouse
+decommissioned.
+EOF
+git add -A && git commit -m "seed idea"
+
+# the repo must be on GitHub before the script can open issue #1
+gh repo create my-story --private --source=. --remote=origin --push
+
+python /path/to/aiorchestra_story_kit/init_story_repo.py . --push
+```
+
+The script copies `scaffold/` in, renders `AGENTS.md` / `CLAUDE.md` from your
+README, seeds `story/idea.md` with the README text, vendors the herenow skill
+(if found), commits, ensures the `aiorchestra` / `claude` / `story` /
+`next-phase` labels exist, pushes, and opens issue **#1 — "Idea: The Last
+Keeper"** labelled `aiorchestra` + `claude` + `story`.
+
+From there: aiorchestra discovers the `aiorchestra`-labelled issue, the agent
+opens a PR with `story/idea.md` and files the next issue (`Premise: …`,
+labelled `story` + `next-phase` only). You review/merge the PR, add
+`aiorchestra` + `claude` to that next issue, and repeat down the chain.
+
+## Notes & caveats
+
+- aiorchestra's `dispatch` mode discovers issues by the **`aiorchestra`** label
+  (it isn't configurable); the agent family is resolved from the `claude` label
+  (or the configured default). The kit's `.aiorchestra/config.yaml` only
+  overrides test / review / CI / OSINT settings — not the label.
+- If you ever scaffold *into* a repo that already runs a GitHub Action on the
+  `claude` label (e.g. `story_writer`'s `agent-implement.yaml`), disable that
+  workflow first, or both will fire on the same issue.
+- The agent needs `gh` (or an equivalent) **inside the aiorchestra run** to file
+  the next phase's issue. If it can't, it writes the next-issue spec into
+  `story/STATUS.md` under a `## Next step` heading — file it yourself.

--- a/aiorchestra_story_kit/init_story_repo.py
+++ b/aiorchestra_story_kit/init_story_repo.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Scaffold an aiorchestra story repo from a one-file README idea.
+
+Run this inside (or pass the path to) a fresh git repo whose ``README.md`` holds
+the story idea. It:
+
+  - copies the kit's ``scaffold/`` into the repo (``WORKFLOW.md``,
+    ``.aiorchestra/``, ``.github/ISSUE_TEMPLATE/``, ``story/``),
+  - renders ``AGENTS.md`` / ``CLAUDE.md`` from the README,
+  - seeds ``story/idea.md`` with the README text,
+  - vendors a ``herenow-skill/`` directory (if found) into
+    ``.claude/skills/herenow/``,
+  - commits, ensures the ``aiorchestra`` / ``claude`` / ``story`` /
+    ``next-phase`` labels exist, optionally pushes, and opens issue #1
+    ("Idea: <title>").
+
+stdlib only. Requires the ``gh`` CLI on PATH and authenticated, with the target
+repo already created on GitHub. See ``../README.md`` (the kit readme) and the
+generated repo's ``WORKFLOW.md``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+KIT_DIR = Path(__file__).resolve().parent
+SCAFFOLD_DIR = KIT_DIR / "scaffold"
+TEMPLATES_DIR = KIT_DIR / "repo_md_templates"
+DEFAULT_HERENOW = KIT_DIR.parent / "herenow-skill"
+
+INPUT_LABELS = [
+    ("aiorchestra", "5319e7", "aiorchestra: discover and run this issue"),
+    ("claude", "5319e7", "Route this issue to the Claude Code agent"),
+    ("story", "0e8a16", "Part of the story phase chain"),
+    (
+        "next-phase",
+        "fbca04",
+        "Next phase drafted and queued — add `aiorchestra` + `claude` after reviewing the previous PR",
+    ),
+]
+
+
+def run(cmd: list[str], cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, cwd=cwd, check=check, text=True, capture_output=True)
+
+
+def die(msg: str) -> None:
+    print(f"error: {msg}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def parse_readme(readme: Path) -> tuple[str, str, str]:
+    """Return (title, logline, full_text) parsed from a README."""
+    text = readme.read_text(encoding="utf-8")
+    title = ""
+    logline = ""
+    for line in text.splitlines():
+        s = line.strip()
+        if not title and s.startswith("# "):
+            title = s[2:].strip()
+            continue
+        if title and not logline and s and not s.startswith("#"):
+            logline = s
+            break
+    if not title:
+        title = readme.parent.resolve().name.replace("-", " ").replace("_", " ").strip().title() or "Untitled Story"
+    if not logline:
+        logline = title
+    return title, logline, text.strip()
+
+
+def copy_scaffold(repo: Path) -> None:
+    for dirpath, _dirnames, filenames in os.walk(SCAFFOLD_DIR):
+        rel_dir = Path(dirpath).relative_to(SCAFFOLD_DIR)
+        (repo / rel_dir).mkdir(parents=True, exist_ok=True)
+        for fn in filenames:
+            rel = rel_dir / fn
+            dst = repo / rel
+            if dst.exists():
+                print(f"  skip (exists): {rel}")
+                continue
+            shutil.copy2(Path(dirpath) / fn, dst)
+            print(f"  + {rel}")
+
+
+def render(tmpl_name: str, out_path: Path, ctx: dict[str, str]) -> None:
+    if out_path.exists():
+        print(f"  skip (exists): {out_path.name}")
+        return
+    text = (TEMPLATES_DIR / tmpl_name).read_text(encoding="utf-8")
+    for key, val in ctx.items():
+        text = text.replace("{{" + key + "}}", val)
+    out_path.write_text(text, encoding="utf-8")
+    print(f"  + {out_path.name}")
+
+
+def seed_idea_file(repo: Path, seed: str) -> None:
+    idea = repo / "story" / "idea.md"
+    body = idea.read_text(encoding="utf-8") if idea.is_file() else "# Idea\n"
+    if "## Seed (from README)" in body:
+        return
+    body = body.rstrip() + "\n\n## Seed (from README)\n\n" + seed.strip() + "\n"
+    idea.write_text(body, encoding="utf-8")
+    print("  seeded story/idea.md with the README idea")
+
+
+def vendor_herenow(repo: Path, src: Path) -> None:
+    dst = repo / ".claude" / "skills" / "herenow"
+    if dst.exists():
+        print("  skip (exists): .claude/skills/herenow")
+        return
+    if not src.is_dir():
+        print(f"  note: no herenow skill at {src} — the Assemble & Publish phase will skip publishing")
+        return
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(src, dst)
+    print(f"  + .claude/skills/herenow  (from {src})")
+
+
+def git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    return run(["git", *args], cwd=repo, check=check)
+
+
+def ensure_labels(repo: Path) -> None:
+    for name, color, desc in INPUT_LABELS:
+        res = run(["gh", "label", "create", name, "--color", color, "--description", desc], cwd=repo, check=False)
+        if res.returncode == 0:
+            print(f"  label created: {name}")
+        elif "already exists" in (res.stderr + res.stdout).lower():
+            print(f"  label ok: {name}")
+        else:
+            print(f"  warn: could not create label {name!r}: {res.stderr.strip() or res.stdout.strip()}")
+
+
+def strip_front_matter(text: str) -> str:
+    if text.startswith("---"):
+        parts = text.split("---", 2)
+        if len(parts) == 3:
+            return parts[2].lstrip("\n")
+    return text
+
+
+def create_first_issue(repo: Path, title: str) -> str:
+    tmpl = (repo / ".github" / "ISSUE_TEMPLATE" / "idea.md").read_text(encoding="utf-8")
+    body = strip_front_matter(tmpl).replace("<story title>", title)
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as fh:
+        fh.write(body)
+        body_file = fh.name
+    try:
+        res = run(
+            [
+                "gh", "issue", "create",
+                "--title", f"Idea: {title}",
+                "--body-file", body_file,
+                "--label", "aiorchestra",
+                "--label", "claude",
+                "--label", "story",
+            ],
+            cwd=repo,
+        )
+    finally:
+        os.unlink(body_file)
+    out = (res.stdout or "").strip()
+    return out.splitlines()[-1] if out else "(created — see `gh issue list`)"
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Scaffold an aiorchestra story repo from a README idea.")
+    ap.add_argument("repo_path", nargs="?", default=".", help="target git repo (default: current directory)")
+    ap.add_argument(
+        "--herenow-skill",
+        default=str(DEFAULT_HERENOW),
+        help=f"path to a herenow-skill directory to vendor in (default: {DEFAULT_HERENOW})",
+    )
+    ap.add_argument("--push", action="store_true", help="git push -u <remote> HEAD after committing")
+    ap.add_argument("--remote", default="origin", help="remote name for --push (default: origin)")
+    ap.add_argument("--no-issue", action="store_true", help="don't create issue #1 (just scaffold + commit)")
+    args = ap.parse_args()
+
+    if not shutil.which("gh"):
+        die("the `gh` CLI is required and was not found on PATH")
+    if not shutil.which("git"):
+        die("git is required and was not found on PATH")
+
+    repo = Path(args.repo_path).resolve()
+    if not (repo / ".git").is_dir():
+        die(f"{repo} is not a git repository (run `git init` there first)")
+    readme = repo / "README.md"
+    if not readme.is_file():
+        die(f"{readme} not found — put your story idea in README.md first")
+
+    if not args.no_issue:
+        view = run(["gh", "repo", "view"], cwd=repo, check=False)
+        if view.returncode != 0:
+            die(
+                "`gh` can't resolve this repo on GitHub — create it and push first "
+                "(e.g. `gh repo create <name> --source=. --remote=origin --push`), or re-run with --no-issue"
+            )
+
+    title, logline, seed = parse_readme(readme)
+    print(f"title:   {title}")
+    print(f"logline: {logline}\n")
+
+    print("scaffolding files…")
+    copy_scaffold(repo)
+
+    print("rendering agent docs…")
+    ctx = {"TITLE": title, "LOGLINE": logline, "SEED": seed}
+    render("AGENTS.md.tmpl", repo / "AGENTS.md", ctx)
+    render("CLAUDE.md.tmpl", repo / "CLAUDE.md", ctx)
+
+    seed_idea_file(repo, seed)
+    vendor_herenow(repo, Path(args.herenow_skill).expanduser())
+
+    print("committing…")
+    git(repo, "add", "-A")
+    commit = git(repo, "commit", "-m", "Scaffold aiorchestra story kit", check=False)
+    if commit.returncode != 0:
+        print(f"  note: nothing committed ({commit.stderr.strip() or commit.stdout.strip()})")
+
+    print("ensuring labels…")
+    ensure_labels(repo)
+
+    if args.push:
+        print(f"pushing to {args.remote}…")
+        push = git(repo, "push", "-u", args.remote, "HEAD", check=False)
+        if push.returncode != 0:
+            print(f"  warn: push failed: {push.stderr.strip()}")
+
+    if args.no_issue:
+        print("\nDone (scaffold only). Create issue #1 yourself, e.g.:")
+        print(
+            f'  gh issue create --title "Idea: {title}" '
+            "--body-file .github/ISSUE_TEMPLATE/idea.md --label aiorchestra --label claude --label story"
+        )
+        return
+
+    print("creating issue #1…")
+    url = create_first_issue(repo, title)
+    print(f"\nDone. Issue #1: {url}")
+    print("aiorchestra (with the claude-code provider) will pick it up via the `aiorchestra` label.")
+    if not args.push:
+        print(f"Reminder: you still need to `git push -u {args.remote} HEAD`.")
+    print("After you merge issue #1's PR, add `aiorchestra` + `claude` to the `Premise: …` issue the agent files.")
+
+
+if __name__ == "__main__":
+    main()

--- a/aiorchestra_story_kit/repo_md_templates/AGENTS.md.tmpl
+++ b/aiorchestra_story_kit/repo_md_templates/AGENTS.md.tmpl
@@ -1,0 +1,50 @@
+# {{TITLE}}
+
+> {{LOGLINE}}
+
+A story project built phase-by-phase with
+[aiorchestra](https://github.com/ironharvy/AIOrchestra): each writing phase is a
+GitHub issue, the agent opens a PR with one artifact, you review and merge it,
+then the next phase's issue gets filed. **Read `WORKFLOW.md` for the full chain
+and rules** — it governs how this repo is developed.
+
+## Hard rules for anyone (human or agent) working here
+
+1. **Read `story/` first.** Before writing anything, read every file under
+   `story/`. The canonical state of the story lives there — not in issues, not
+   in PR descriptions.
+2. **One issue = one phase = one artifact.** Do the phase named in the issue
+   title (routing table in `.aiorchestra/templates/implement.md` and
+   `WORKFLOW.md`) and nothing else. Don't jump ahead.
+3. **Never break canon.** Don't contradict `story/idea.md`, `story/premise.md`,
+   `story/spine.md`, `story/world/*`, or any already-written chapter. New canon
+   — names, places, the rules of this world, events — is welcome, but it must be
+   consistent, and every new canonical fact (and every creative direction you
+   considered and rejected) goes in `story/notes.md`.
+4. **Keep the bookkeeping current.** Update `story/STATUS.md` every phase.
+   Non-terminal phases file the next phase's issue with the `story` +
+   `next-phase` labels only — a human adds `aiorchestra` + `claude` after
+   reviewing the PR. That's the gate between phases.
+5. **Story files are for the reader.** No meta commentary about phases / issues
+   / PRs inside files under `story/` except `STATUS.md` and `notes.md`.
+6. **The seed idea** (verbatim) is in `story/idea.md` under
+   `## Seed (from README)` and at the top of `README.md`.
+
+## Style
+
+_The `Idea:` phase appends the style guide here once the idea is nailed down:
+prose register, POV, tense, tone, length target (short story vs. novel), and any
+stylistic constraints. Every later phase honours it._
+
+## Tooling
+
+- `python story/_check.py` — the consistency gate aiorchestra runs at
+  `validate`: a downstream artifact with real content must not sit on top of
+  empty prerequisites, and an assembled `story/final.md` must be well-formed. It
+  does not judge prose quality.
+- `.claude/skills/herenow/` (if present) — used by the `Assemble & Publish`
+  phase to publish `story/final.md`. Anonymous publishes are claimable for 24h;
+  set `HERENOW_API_KEY` to publish under an account.
+- If `scripts/run_qa.py` is present, the `Assemble & Publish` phase also runs it
+  on `story/final.md` (name drift / character presence / cross-chapter phrase
+  reuse).

--- a/aiorchestra_story_kit/repo_md_templates/CLAUDE.md.tmpl
+++ b/aiorchestra_story_kit/repo_md_templates/CLAUDE.md.tmpl
@@ -1,0 +1,51 @@
+# {{TITLE}}
+
+> {{LOGLINE}}
+
+A story project built phase-by-phase with
+[aiorchestra](https://github.com/ironharvy/AIOrchestra): each writing phase is a
+GitHub issue, the agent opens a PR with one artifact, you review and merge it,
+then the next phase's issue gets filed. **Read `WORKFLOW.md` for the full chain
+and rules** — it governs how this repo is developed. (`AGENTS.md` has the same
+content as this file.)
+
+## Hard rules for anyone (human or agent) working here
+
+1. **Read `story/` first.** Before writing anything, read every file under
+   `story/`. The canonical state of the story lives there — not in issues, not
+   in PR descriptions.
+2. **One issue = one phase = one artifact.** Do the phase named in the issue
+   title (routing table in `.aiorchestra/templates/implement.md` and
+   `WORKFLOW.md`) and nothing else. Don't jump ahead.
+3. **Never break canon.** Don't contradict `story/idea.md`, `story/premise.md`,
+   `story/spine.md`, `story/world/*`, or any already-written chapter. New canon
+   — names, places, the rules of this world, events — is welcome, but it must be
+   consistent, and every new canonical fact (and every creative direction you
+   considered and rejected) goes in `story/notes.md`.
+4. **Keep the bookkeeping current.** Update `story/STATUS.md` every phase.
+   Non-terminal phases file the next phase's issue with the `story` +
+   `next-phase` labels only — a human adds `aiorchestra` + `claude` after
+   reviewing the PR. That's the gate between phases.
+5. **Story files are for the reader.** No meta commentary about phases / issues
+   / PRs inside files under `story/` except `STATUS.md` and `notes.md`.
+6. **The seed idea** (verbatim) is in `story/idea.md` under
+   `## Seed (from README)` and at the top of `README.md`.
+
+## Style
+
+_The `Idea:` phase appends the style guide here once the idea is nailed down:
+prose register, POV, tense, tone, length target (short story vs. novel), and any
+stylistic constraints. Every later phase honours it._
+
+## Tooling
+
+- `python story/_check.py` — the consistency gate aiorchestra runs at
+  `validate`: a downstream artifact with real content must not sit on top of
+  empty prerequisites, and an assembled `story/final.md` must be well-formed. It
+  does not judge prose quality.
+- `.claude/skills/herenow/` (if present) — used by the `Assemble & Publish`
+  phase to publish `story/final.md`. Anonymous publishes are claimable for 24h;
+  set `HERENOW_API_KEY` to publish under an account.
+- If `scripts/run_qa.py` is present, the `Assemble & Publish` phase also runs it
+  on `story/final.md` (name drift / character presence / cross-chapter phrase
+  reuse).

--- a/aiorchestra_story_kit/scaffold/.aiorchestra/config.yaml
+++ b/aiorchestra_story_kit/scaffold/.aiorchestra/config.yaml
@@ -1,0 +1,30 @@
+# aiorchestra config for an aiorchestra story repo.
+# Layered on top of aiorchestra's built-in defaults — only the overrides below.
+# Full workflow: ../WORKFLOW.md
+#
+# Note: the discovery label is NOT set here. `aiorchestra dispatch` discovers
+# issues by the `aiorchestra` label (not configurable); `aiorchestra run --repo`
+# uses the default agent-family label (`claude`, matching `ai.provider`). Story
+# phase issues carry `aiorchestra` + `claude` (+ a cosmetic `story` tag).
+
+ai:
+  provider: "claude-code"
+  model: "claude-opus-4-6"
+  max_retries: 2
+  skip_permissions: true
+
+# "Tests" here = a stdlib consistency check on the story/ tree, not pytest.
+test:
+  command: "python story/_check.py"
+  lint_command: 'python -c "pass"'
+
+review:
+  enabled: true
+  provider: "claude-code"
+
+# This is a prose repo — no CI checks, no OSINT enrichment.
+ci:
+  enabled: false
+
+osint:
+  enabled: false

--- a/aiorchestra_story_kit/scaffold/.aiorchestra/templates/fix_review.md
+++ b/aiorchestra_story_kit/scaffold/.aiorchestra/templates/fix_review.md
@@ -1,0 +1,19 @@
+The editorial review flagged issues with your change for issue #{number}.
+
+Issue #{number}: {title}
+
+{body}
+
+Review feedback:
+
+{errors}
+
+Address each point with the smallest correct change, keeping everything consistent with the rest of `story/`:
+
+- continuity / canon contradiction → fix the changed artifact. Never rewrite the canon files (`story/idea.md`, `story/premise.md`, `story/spine.md`, `story/world/*`, earlier chapters) to match a mistake; if the canon itself is the problem, that is a separate `Revise — …` issue, not this one.
+- "doesn't deliver the phase" → produce the artifact the issue title asks for.
+- style / pacing notes → revise the prose; follow the `## Style` section in `AGENTS.md`.
+- process hygiene (STATUS / notes not updated, wrong labels on the next issue, meta commentary in story files) → fix it.
+- never weaken `story/_check.py` or `.aiorchestra/` config to resolve feedback.
+
+Do NOT run tests — just fix it.

--- a/aiorchestra_story_kit/scaffold/.aiorchestra/templates/fix_validation.md
+++ b/aiorchestra_story_kit/scaffold/.aiorchestra/templates/fix_validation.md
@@ -1,0 +1,18 @@
+Your previous change for issue #{number} failed the story consistency check.
+
+Issue #{number}: {title}
+
+{body}
+
+Check output:
+
+{errors}
+
+Fix it with the smallest correct change:
+
+- "prerequisite X is empty/placeholder" → the artifact you wrote depends on a `story/` file that has no real content. Do NOT fake the prerequisite and do NOT weaken `story/_check.py`. If the prerequisite genuinely has not been written yet, this phase should not run yet — output `NEEDS_CLARIFICATION: <which prerequisite phase still needs to be done>` and make no changes.
+- "story/final.md missing the `## Final Story` section" / "too short" → assemble it properly per the `Assemble & Publish` instructions in `.aiorchestra/templates/implement.md`.
+- "story/chapters/<file> is suspiciously short" → that chapter is a stub; draft it as a full chapter.
+- anything else → address exactly what the message says, touching only what is needed.
+
+Do NOT run tests — just fix it. Keep `story/STATUS.md` accurate.

--- a/aiorchestra_story_kit/scaffold/.aiorchestra/templates/implement.md
+++ b/aiorchestra_story_kit/scaffold/.aiorchestra/templates/implement.md
@@ -1,0 +1,56 @@
+You are developing a story in this repository, one phase at a time, driven by aiorchestra. Implement the following GitHub issue — and only this issue.
+
+Issue #{number}: {title}
+
+{body}
+{osint_context}{comments_section}
+
+## First, always
+
+1. Read `WORKFLOW.md` (repo root), `AGENTS.md`, and `CLAUDE.md`.
+2. Read **every** file under `story/` — the canonical state of the story lives there, not in issues or PRs.
+3. Identify which phase this is from the issue-title prefix (table below). Do that phase and nothing else: one issue = one phase = exactly one new/updated story artifact (plus `story/STATUS.md`, plus — for non-terminal phases — filing the next issue).
+
+Do NOT run tests — aiorchestra runs the validation gate (`python story/_check.py`) separately.
+
+## Phase routing — by issue-title prefix
+
+- `Idea:` → Refine `story/idea.md`. It must contain: the seed idea (already present under `## Seed (from README)`), then exactly **5 interrogative questions** that probe and sharpen the idea, each with a **proposed answer** and an **accepted answer** (use the proposed answer unless the issue body overrides it; if the issue body supplies answers, use those), and enough foundation for the Premise phase. Also append a `## Style` section to `AGENTS.md` *and* `CLAUDE.md`: prose register, POV, tense, tone, length target (short story vs. novel), and any stylistic constraints implied by the idea — every later phase relies on it.
+- `Premise:` → Write `story/premise.md`: one tight **Core Premise** paragraph covering the central conflict, the protagonist's goal and motivation, the stakes, the setting and tone, and the thematic undercurrent. Built from `story/idea.md`.
+- `Spine:` → Write `story/spine.md`: the six-beat template, one to three sentences per beat — `Once upon a time…` (status quo / world), `Every day…` (the routine), `One day…` (inciting incident), `Because of that…` (first consequence), `Because of that…` (escalation / complications), `Until finally…` (climax / resolution). Abstract; names not required yet. Built from `story/premise.md`.
+- `World Bible — Rules:` → Write `story/world/rules.md`: the rules and systems governing the world — magic, technology, science, law, etiquette, societal norms, and any loopholes characters might exploit. Built from `story/premise.md` + `story/spine.md`.
+- `World Bible — Characters:` → Write `story/world/characters.md`: every significant character — full name, physical description, relationships to other characters, role, aspirations, flaws. Major characters get detailed entries; minor ones get a line or two. Built from the premise, the spine, and `story/world/rules.md`.
+- `World Bible — Locations:` → Write `story/world/locations.md`: every significant place — physical description and climate, who lives/works there, geographic relationship to other places, atmosphere, significance to the plot. Built from the above plus `story/world/characters.md`.
+- `World Bible — Timeline:` → Write `story/world/timeline.md`: a chronological sequence of major events, from backstory through the story's conclusion. Built from all of `story/world/`.
+- `Chapter Plan:` → Write `story/chapter_plan.md`: a plan across **three acts** — Act 1 (Setup: characters, world, inciting incident), Act 2 (Confrontation: rising action, complications, midpoint shift), Act 3 (Resolution: climax, falling action, resolution). 3-5 chapters per act (~9-15 total). One concise sentence per chapter describing its key event/purpose, numbered consecutively. Built from `story/premise.md` + `story/world/`.
+- `Enhancers:` → Write `story/enhancers.md`: for each chapter in `story/chapter_plan.md`, note which narrative enhancers apply and how — Tension (build/release points), Mystery (where to plant questions, where to reveal answers), Theme alignment (where themes surface), Setup/Payoff tracker (what setups need payoffs, and in which chapter), Emotional curve (the emotional trajectory across chapters), Twist generator (where reversals land), Easter-egg injector (subtle callbacks / hidden connections). Built from `story/chapter_plan.md` + `story/world/`.
+- `Chapters:` → Draft **every** chapter listed in `story/chapter_plan.md`, in order, each to its own file `story/chapters/NN-slug.md` (zero-padded number, e.g. `01-the-fog-comes-in.md`). For each chapter use the world bible, the chapter plan, the enhancers guide, and a short "story so far" recap of the chapters you have already written this run for continuity. Roughly 1 chapter in 3 (~35%) gets exactly one woven-in flourish — a long vivid scenery passage, a quirky but fitting object, a strange atmospheric detail, a revealing character tic, or a small surprising bit of background — placed naturally, never telegraphed. Each chapter: a creative title, full immersive prose with dialogue and description, consistent characterisation and world detail, pacing suited to its position in the arc. Substantial chapters, not paragraph summaries. *If `story/idea.md` clearly calls for a long novel rather than a short story, do NOT draft all chapters here — instead see "Advancing the chain" and file one `Chapter NN:` issue per chapter.*
+- `Chapter NN:` → Draft just chapter `NN` from `story/chapter_plan.md` to `story/chapters/NN-slug.md`, same rules as above, using the already-written chapters in `story/chapters/` for continuity.
+- `Assemble & Publish:` → Build `story/final.md` with these sections, in order: a `# <story title>` heading, `## Core Premise` (from `story/premise.md`), `## Spine` (from `story/spine.md`), `## World Bible` (Rules / Characters / Locations / Timeline subsections from `story/world/`), `## Chapter Plan` (from `story/chapter_plan.md`), `## Enhancers Guide` (from `story/enhancers.md`), `## Final Story` (every chapter, in order, with its title and full prose). If `scripts/run_qa.py` exists in this repo, run it on `story/final.md` and fix any clear issues it reports (name drift, missing characters, cross-chapter phrase reuse) before finishing. Then publish: follow `.claude/skills/herenow/SKILL.md` to publish `story/final.md`, and record the returned `site_url` and `claim_url` in `story/STATUS.md` and in your final summary (which becomes the PR body). If `.claude/skills/herenow/` is not present, skip publishing and note that in `story/STATUS.md`. This is the terminal phase — do NOT file another issue.
+- `Revise — <path>:` → Edit only the file named in the title (e.g. `Revise — story/chapters/03-the-mainland-letter.md: pacing drags mid-scene`), following the issue body's notes, keeping everything consistent with the rest of `story/`. Do NOT file another issue; this is a touch-up, not a chain step.
+
+If the title doesn't match any prefix above, treat the issue body as the spec, change as little as possible, and do not file a follow-up issue.
+
+## Standing rules
+
+- Never contradict established canon: `story/idea.md`, `story/premise.md`, `story/spine.md`, `story/world/*`, and any already-written chapters. New canon is fine and encouraged, but it must be consistent — and every new canonical fact, plus every creative direction you considered and rejected, goes in `story/notes.md` (append, with a short issue/date note).
+- Update `story/STATUS.md`: mark this phase done (note "PR pending"), and keep the table accurate.
+- Honour the `## Style` section in `AGENTS.md`.
+- Keep prose for the reader: no meta commentary about phases, issues, or PRs inside the story files — `story/STATUS.md` and `story/notes.md` are the place for process notes.
+
+## Advancing the chain
+
+When you finish a phase that is **not** `Assemble & Publish:` and **not** `Revise — …:`, file the next phase's issue yourself:
+
+1. Determine the next issue's title from the chain in `WORKFLOW.md` (e.g. after `Premise:` comes `Spine: <same story title>`; after the `Chapters:` phase comes `Assemble & Publish: <story title>`). If `story/idea.md` calls for a long novel, the chain after `Enhancers:` is `Chapter 01: …`, `Chapter 02: …`, … (titles from `story/chapter_plan.md`), then `Assemble & Publish:`.
+2. Build the body from the matching file in `.github/ISSUE_TEMPLATE/` — strip its YAML front matter, then fill in the story title and a short "where we are" pointer listing the relevant `story/` files the next phase should read.
+3. Create it with the `gh` CLI, labelled `story` and `next-phase` **only** — never add `aiorchestra` or `claude` (a human adds those after reviewing this PR; that is the gate between phases). For example: `gh issue create --title "Spine: <story title>" --body-file <tmpfile> --label story --label next-phase`. Record the new issue's number/URL in your final summary.
+4. If `gh` is unavailable or fails, do not block: write the full next-issue spec (title + body) into `story/STATUS.md` under a `## Next step` heading so a human can file it.
+
+## Clarification protocol
+
+If this issue's prerequisites are materially missing or self-contradictory in a way that would force a wrong implementation, do NOT guess. Output a single line:
+
+    NEEDS_CLARIFICATION: <your question>
+
+and make NO file changes — aiorchestra will post the question on the issue and pause until a human answers. Use this only for genuine blockers; resolve ordinary creative choices yourself and log them in `story/notes.md`.

--- a/aiorchestra_story_kit/scaffold/.aiorchestra/templates/review.md
+++ b/aiorchestra_story_kit/scaffold/.aiorchestra/templates/review.md
@@ -1,0 +1,17 @@
+You are an editor reviewing a pull request for a story repo that is built phase-by-phase (see `WORKFLOW.md`). The diff below is for issue #{number}: {title}.
+
+This is prose and story-structure work, not code. Judge the changed artifact on:
+
+- **Brief adherence** — does it deliver the phase named in the issue title? (A `Premise:` PR is one Core Premise paragraph, not an outline; a `Chapters:` PR is full prose chapters, not summaries; a `World Bible — Characters:` PR is the character roster, not locations.)
+- **Canon & continuity** — nothing in the diff contradicts `story/idea.md`, `story/premise.md`, `story/spine.md`, `story/world/*`, or earlier chapters. Names, places, world rules, and the timeline stay consistent. New canon is fine if it is consistent and logged in `story/notes.md`.
+- **Style** — matches the `## Style` section in `AGENTS.md` (POV, tense, register, tone). For prose: varied sentence rhythm, concrete scenes over exposition dumps, no purple boilerplate, no phrasing reused across chapters.
+- **Structure & pacing** — for chapters: the chapter delivers the beat assigned to it in `story/chapter_plan.md` / `story/enhancers.md`; pacing suits its position in the arc. For plans / world docs: complete, internally consistent, usable by the next phase.
+- **Process hygiene** — `story/STATUS.md` updated; `story/notes.md` updated with any new canon and rejected directions; no meta commentary about phases / issues / PRs leaking into the story files; for a non-terminal phase, the next phase's issue was filed with `story` + `next-phase` labels only.
+- **Shortcut anti-patterns** — flag if the diff weakens `story/_check.py`, deletes prerequisite content to dodge that check, or edits `.aiorchestra/` config to make a check pass.
+
+Quote specific lines when you flag something. If it's solid, respond with exactly: LGTM
+Otherwise, describe what needs to change, clearly and specifically.
+
+```diff
+{diff}
+```

--- a/aiorchestra_story_kit/scaffold/.github/ISSUE_TEMPLATE/assemble-and-publish.md
+++ b/aiorchestra_story_kit/scaffold/.github/ISSUE_TEMPLATE/assemble-and-publish.md
@@ -1,0 +1,15 @@
+---
+name: "Phase 11 — Assemble & Publish"
+about: "Compile story/final.md and publish it"
+title: "Assemble & Publish: <story title>"
+labels: ["aiorchestra", "claude", "story"]
+---
+**Phase 11, terminal (see `WORKFLOW.md`).** Build `story/final.md` with sections in order: a `# <story title>` heading, `## Core Premise`, `## Spine`, `## World Bible` (Rules / Characters / Locations / Timeline), `## Chapter Plan`, `## Enhancers Guide`, `## Final Story` (every chapter with its title and full prose, in order).
+
+If `scripts/run_qa.py` exists in the repo, run it on `story/final.md` and fix clear issues (name drift, character presence, cross-chapter phrase reuse).
+
+Then publish: follow `.claude/skills/herenow/SKILL.md` to publish `story/final.md`; record the returned `site_url` and `claim_url` in `story/STATUS.md` and the PR body. If `.claude/skills/herenow/` is not present, skip publishing and say so in `story/STATUS.md`. Anonymous publishes are claimable for 24h; set `HERENOW_API_KEY` in the run's environment to publish under an account.
+
+Do **not** file a follow-up issue — this is the end of the chain.
+
+Read first: everything in `story/`.

--- a/aiorchestra_story_kit/scaffold/.github/ISSUE_TEMPLATE/chapter-plan.md
+++ b/aiorchestra_story_kit/scaffold/.github/ISSUE_TEMPLATE/chapter-plan.md
@@ -1,0 +1,11 @@
+---
+name: "Phase 8 — Chapter Plan"
+about: "Write the 3-act chapter plan"
+title: "Chapter Plan: <story title>"
+labels: ["aiorchestra", "claude", "story"]
+---
+**Phase 8 (see `WORKFLOW.md`).** Write `story/chapter_plan.md`: a plan across three acts — Act 1 (Setup), Act 2 (Confrontation), Act 3 (Resolution); 3-5 chapters per act (~9-15 total); one concise sentence per chapter describing its key event/purpose, numbered consecutively.
+
+Read first: `story/premise.md`, all of `story/world/`.
+
+_When done, file `Enhancers: <story title>` with the `story` + `next-phase` labels only._

--- a/aiorchestra_story_kit/scaffold/.github/ISSUE_TEMPLATE/chapters.md
+++ b/aiorchestra_story_kit/scaffold/.github/ISSUE_TEMPLATE/chapters.md
@@ -1,0 +1,13 @@
+---
+name: "Phase 10 — Chapters"
+about: "Draft all chapters (short story) — or use one Chapter NN issue per chapter for a novel"
+title: "Chapters: <story title>"
+labels: ["aiorchestra", "claude", "story"]
+---
+**Phase 10 (see `WORKFLOW.md`).** Draft every chapter in `story/chapter_plan.md`, in order, each to `story/chapters/NN-slug.md`. Use the world bible, the chapter plan, the enhancers guide, and a running "story so far" recap for continuity. Roughly 1 chapter in 3 gets exactly one woven-in flourish (long scenery passage / quirky object / strange atmospheric detail / character tic / surprising background), placed naturally. Each chapter: creative title, full immersive prose with dialogue and description, consistent canon, pacing suited to its position. Substantial chapters, not summaries.
+
+For novel-length work, file one `Chapter 01: <title>`, `Chapter 02: <title>`, … instead and draft one chapter per issue.
+
+Read first: everything in `story/`.
+
+_When done, file `Assemble & Publish: <story title>` with the `story` + `next-phase` labels only._

--- a/aiorchestra_story_kit/scaffold/.github/ISSUE_TEMPLATE/enhancers.md
+++ b/aiorchestra_story_kit/scaffold/.github/ISSUE_TEMPLATE/enhancers.md
@@ -1,0 +1,11 @@
+---
+name: "Phase 9 — Enhancers Guide"
+about: "Assign narrative enhancers per chapter"
+title: "Enhancers: <story title>"
+labels: ["aiorchestra", "claude", "story"]
+---
+**Phase 9 (see `WORKFLOW.md`).** Write `story/enhancers.md`: for each chapter in `story/chapter_plan.md`, note which enhancers apply and how — Tension, Mystery (plant/reveal), Theme alignment, Setup/Payoff tracker, Emotional curve, Twist generator, Easter-egg injector.
+
+Read first: `story/chapter_plan.md`, all of `story/world/`.
+
+_When done, file `Chapters: <story title>` (or, for a long novel, `Chapter 01: …`) with the `story` + `next-phase` labels only._

--- a/aiorchestra_story_kit/scaffold/.github/ISSUE_TEMPLATE/idea.md
+++ b/aiorchestra_story_kit/scaffold/.github/ISSUE_TEMPLATE/idea.md
@@ -1,0 +1,19 @@
+---
+name: "Phase 1 — Idea"
+about: "Capture the idea and answer the 5 interrogative questions"
+title: "Idea: <story title>"
+labels: ["aiorchestra", "claude", "story"]
+---
+**Phase 1 of the chain (see `WORKFLOW.md`).** Refine `story/idea.md`.
+
+The seed idea is already in `story/idea.md` under `## Seed (from README)` (and at the top of `README.md`).
+
+Produce, in `story/idea.md`:
+- the 5 interrogative questions that probe and sharpen the idea, each with a **proposed answer** and an **accepted answer** (use the proposed answer unless overridden below);
+- enough of a foundation that the Premise phase can write the Core Premise.
+
+Also append a `## Style` section to `AGENTS.md` *and* `CLAUDE.md`: prose register, POV, tense, tone, length target (short story vs. novel), and any stylistic constraints.
+
+**Human overrides (optional):** answer any of the 5 questions yourself by editing this issue before adding the `aiorchestra` label, or leave blank to accept the agent's proposed answers.
+
+_When done, file `Premise: <story title>` with the `story` + `next-phase` labels only._

--- a/aiorchestra_story_kit/scaffold/.github/ISSUE_TEMPLATE/premise.md
+++ b/aiorchestra_story_kit/scaffold/.github/ISSUE_TEMPLATE/premise.md
@@ -1,0 +1,11 @@
+---
+name: "Phase 2 — Premise"
+about: "Write the Core Premise paragraph"
+title: "Premise: <story title>"
+labels: ["aiorchestra", "claude", "story"]
+---
+**Phase 2 (see `WORKFLOW.md`).** From `story/idea.md`, write `story/premise.md`: one tight **Core Premise** paragraph — central conflict, the protagonist's goal and motivation, the stakes, the setting and tone, the thematic undercurrent.
+
+Read first: `story/idea.md`, `AGENTS.md` (`## Style`).
+
+_When done, file `Spine: <story title>` with the `story` + `next-phase` labels only._

--- a/aiorchestra_story_kit/scaffold/.github/ISSUE_TEMPLATE/revise.md
+++ b/aiorchestra_story_kit/scaffold/.github/ISSUE_TEMPLATE/revise.md
@@ -1,0 +1,14 @@
+---
+name: "Revision"
+about: "Touch up one existing story file"
+title: "Revise — <path/to/file>: <short note>"
+labels: ["aiorchestra", "claude", "story"]
+---
+**Revision (see `WORKFLOW.md`).** Edit only the file named in the title, per the notes below, keeping everything consistent with the rest of `story/`. This does not advance the phase chain — do not file a follow-up issue.
+
+**File:** `story/...`
+
+**What to change:**
+- 
+
+Read first: the named file and its prerequisites.

--- a/aiorchestra_story_kit/scaffold/.github/ISSUE_TEMPLATE/spine.md
+++ b/aiorchestra_story_kit/scaffold/.github/ISSUE_TEMPLATE/spine.md
@@ -1,0 +1,11 @@
+---
+name: "Phase 3 — Spine"
+about: "Write the six-beat narrative spine"
+title: "Spine: <story title>"
+labels: ["aiorchestra", "claude", "story"]
+---
+**Phase 3 (see `WORKFLOW.md`).** From `story/premise.md`, write `story/spine.md`: the six-beat template — `Once upon a time…`, `Every day…`, `One day…`, `Because of that…`, `Because of that…`, `Until finally…`. One to three sentences per beat; abstract (names not required yet).
+
+Read first: `story/premise.md`, `story/idea.md`.
+
+_When done, file `World Bible — Rules: <story title>` with the `story` + `next-phase` labels only._

--- a/aiorchestra_story_kit/scaffold/.github/ISSUE_TEMPLATE/world-bible-characters.md
+++ b/aiorchestra_story_kit/scaffold/.github/ISSUE_TEMPLATE/world-bible-characters.md
@@ -1,0 +1,11 @@
+---
+name: "Phase 5 — World Bible: Characters"
+about: "Write the character roster and bios"
+title: "World Bible — Characters: <story title>"
+labels: ["aiorchestra", "claude", "story"]
+---
+**Phase 5 (see `WORKFLOW.md`).** Write `story/world/characters.md`: every significant character — full name, physical description, relationships, role, aspirations, flaws. Major characters get detailed entries; minor ones get a line or two.
+
+Read first: `story/premise.md`, `story/spine.md`, `story/world/rules.md`.
+
+_When done, file `World Bible — Locations: <story title>` with the `story` + `next-phase` labels only._

--- a/aiorchestra_story_kit/scaffold/.github/ISSUE_TEMPLATE/world-bible-locations.md
+++ b/aiorchestra_story_kit/scaffold/.github/ISSUE_TEMPLATE/world-bible-locations.md
@@ -1,0 +1,11 @@
+---
+name: "Phase 6 — World Bible: Locations"
+about: "Write the significant locations"
+title: "World Bible — Locations: <story title>"
+labels: ["aiorchestra", "claude", "story"]
+---
+**Phase 6 (see `WORKFLOW.md`).** Write `story/world/locations.md`: every significant place — description, climate, who lives/works there, geography relative to other places, atmosphere, plot significance.
+
+Read first: `story/premise.md`, `story/spine.md`, `story/world/rules.md`, `story/world/characters.md`.
+
+_When done, file `World Bible — Timeline: <story title>` with the `story` + `next-phase` labels only._

--- a/aiorchestra_story_kit/scaffold/.github/ISSUE_TEMPLATE/world-bible-rules.md
+++ b/aiorchestra_story_kit/scaffold/.github/ISSUE_TEMPLATE/world-bible-rules.md
@@ -1,0 +1,11 @@
+---
+name: "Phase 4 — World Bible: Rules"
+about: "Write the rules and systems of the world"
+title: "World Bible — Rules: <story title>"
+labels: ["aiorchestra", "claude", "story"]
+---
+**Phase 4 (see `WORKFLOW.md`).** Write `story/world/rules.md`: the rules and systems governing the world — magic, technology, science, law, etiquette, societal norms, and any loopholes characters might exploit.
+
+Read first: `story/premise.md`, `story/spine.md`.
+
+_When done, file `World Bible — Characters: <story title>` with the `story` + `next-phase` labels only._

--- a/aiorchestra_story_kit/scaffold/.github/ISSUE_TEMPLATE/world-bible-timeline.md
+++ b/aiorchestra_story_kit/scaffold/.github/ISSUE_TEMPLATE/world-bible-timeline.md
@@ -1,0 +1,11 @@
+---
+name: "Phase 7 — World Bible: Timeline"
+about: "Write the chronological event timeline"
+title: "World Bible — Timeline: <story title>"
+labels: ["aiorchestra", "claude", "story"]
+---
+**Phase 7 (see `WORKFLOW.md`).** Write `story/world/timeline.md`: a chronological sequence of major events, from backstory through the story's conclusion.
+
+Read first: all of `story/world/`, `story/spine.md`, `story/premise.md`.
+
+_When done, file `Chapter Plan: <story title>` with the `story` + `next-phase` labels only._

--- a/aiorchestra_story_kit/scaffold/WORKFLOW.md
+++ b/aiorchestra_story_kit/scaffold/WORKFLOW.md
@@ -1,0 +1,119 @@
+# Workflow — how this story repo is built
+
+This repo is driven by [aiorchestra](https://github.com/ironharvy/AIOrchestra):
+every writing phase is a GitHub issue, the agent opens a PR with exactly one
+artifact, an editorial review pass runs, you merge it, then the next phase's
+issue is filed. The phase chain mirrors the `story_writer` `write-story` skill.
+
+## The phase chain
+
+| # | Issue title | Reads | Produces (one artifact) | On finish, files |
+|---|---|---|---|---|
+| 1 | `Idea: <story>` | `story/idea.md` (seed), `README.md` | `story/idea.md` — idea + the 5 interrogative questions, each with a proposed answer and an accepted answer; also appends a `## Style` section to `AGENTS.md` / `CLAUDE.md` | `Premise: <story>` |
+| 2 | `Premise: <story>` | `story/idea.md` | `story/premise.md` — the Core Premise paragraph (central conflict, protagonist goal/motivation, stakes, setting, tone, theme) | `Spine: <story>` |
+| 3 | `Spine: <story>` | `story/premise.md` | `story/spine.md` — the six-beat template (Once upon a time… / Every day… / One day… / Because of that… / Because of that… / Until finally…) | `World Bible — Rules: <story>` |
+| 4 | `World Bible — Rules: <story>` | `story/premise.md`, `story/spine.md` | `story/world/rules.md` — rules/systems of the world (magic, tech, science, law, etiquette, societal norms, exploitable loopholes) | `World Bible — Characters: <story>` |
+| 5 | `World Bible — Characters: <story>` | the above + `story/world/rules.md` | `story/world/characters.md` — every significant character (full name, physical description, relationships, role, aspirations, flaws; majors detailed, minors brief) | `World Bible — Locations: <story>` |
+| 6 | `World Bible — Locations: <story>` | the above + `story/world/characters.md` | `story/world/locations.md` — every significant place (description, climate, who's there, geography, atmosphere, plot significance) | `World Bible — Timeline: <story>` |
+| 7 | `World Bible — Timeline: <story>` | all of `story/world/` | `story/world/timeline.md` — chronological major events, backstory through ending | `Chapter Plan: <story>` |
+| 8 | `Chapter Plan: <story>` | `story/premise.md`, `story/world/` | `story/chapter_plan.md` — 3 acts (Setup / Confrontation / Resolution), 3-5 chapters each (~9-15 total), one sentence per chapter, numbered | `Enhancers: <story>` |
+| 9 | `Enhancers: <story>` | `story/chapter_plan.md`, `story/world/` | `story/enhancers.md` — per-chapter assignment of: Tension, Mystery (plant/reveal), Theme alignment, Setup/Payoff tracker, Emotional curve, Twist generator, Easter-egg injector | `Chapters: <story>` |
+| 10 | `Chapters: <story>` *(or `Chapter NN: <chapter title>` per chapter for long works)* | everything in `story/` | `story/chapters/NN-slug.md` per chapter | `Assemble & Publish: <story>` |
+| 11 | `Assemble & Publish: <story>` | all chapters + foundation files | `story/final.md` (sections: Core Premise / Spine / World Bible / Chapter Plan / Enhancers / Final Story), then publishes it | — (terminal) |
+| — | `Revise — <path>: <note>` | the named file + its prerequisites | the named file | — (does not advance the chain) |
+
+`Chapters` is one issue for short stories. For novel-length work (e.g.
+`story/idea.md` calls for a long book) the agent instead files one `Chapter NN:
+<title>` issue per chapter in `story/chapter_plan.md`, in order — each advancing
+to the next, the last advancing to `Assemble & Publish`.
+
+## How a phase runs
+
+1. aiorchestra's `discover` stage finds the issue (it carries the `aiorchestra`
+   label, plus `claude` so it routes to the Claude Code agent).
+2. `prepare` makes a branch `claude/<issue-number>`.
+3. `implement` invokes the agent with `.aiorchestra/templates/implement.md`,
+   which routes on the issue-title prefix to exactly one phase. The agent reads
+   every file under `story/`, writes the one artifact, updates `story/STATUS.md`,
+   and (unless this is the terminal phase) files the next issue.
+4. `validate` runs `python story/_check.py` — the consistency gate (below).
+5. `publish` pushes and opens a PR.
+6. `review` runs `.aiorchestra/templates/review.md` — an editorial pass on the
+   diff. Failures re-invoke the agent with the feedback appended.
+7. **You** read the PR, edit the artifact directly if you want, and merge it.
+8. **You** add `aiorchestra` + `claude` to the next phase's issue. aiorchestra
+   picks it up — back to step 1.
+
+### Why the next issue isn't auto-triggered
+
+The agent files the next phase's issue with **`story` + `next-phase`** labels
+only — *not* `aiorchestra` / `claude`. So it sits idle. That's deliberate: it
+gives you a gate after every artifact (read the prose, fix continuity, change
+direction) before the chain moves on. To advance, add `aiorchestra` + `claude`
+to that issue.
+
+If the agent can't run `gh` during its run, it instead writes the full
+next-issue spec (title + body) into `story/STATUS.md` under a `## Next step`
+heading — file it yourself with `gh issue create`.
+
+## Clarification
+
+If a phase's prerequisites are materially missing or self-contradictory in a way
+that would force a wrong implementation, the agent emits
+`NEEDS_CLARIFICATION: <question>` and makes no changes; aiorchestra posts the
+question on the issue and defers it until you answer and clear the
+`needs-clarification` label. The agent should *not* use this for ordinary
+creative choices — it makes those itself and logs them in `story/notes.md`.
+
+## Canon & continuity rules
+
+(Also in `AGENTS.md` / `CLAUDE.md`.)
+
+- The canonical story state lives in `story/`, never in issue/PR text.
+- Before writing anything, read every file under `story/`.
+- New canon (names, places, the rules of the world, events) is welcome, but it
+  must not contradict `story/idea.md`, `story/premise.md`, `story/spine.md`,
+  `story/world/*`, or earlier chapters. Log every new canonical fact and every
+  rejected creative direction in `story/notes.md`.
+- One issue = one phase = one artifact. Don't jump ahead.
+- Chapter drafting: each chapter uses the world bible + chapter plan + enhancers
+  guide + a short "story so far" recap of prior chapters for continuity. Roughly
+  1 chapter in 3 (~35%) gets exactly one woven-in flourish — a long vivid
+  scenery passage, a quirky but fitting object, a strange atmospheric detail, a
+  revealing character tic, or a small surprising bit of background — placed
+  naturally, never telegraphed.
+
+## The validation gate (`story/_check.py`)
+
+A light, stdlib-only consistency check, run at `validate`:
+
+- If a downstream artifact has real content, its prerequisites must too
+  (e.g. a non-empty `story/chapter_plan.md` requires non-empty
+  `story/premise.md`, `story/spine.md`, and all four `story/world/*.md`).
+- If `story/chapters/` contains any chapter, `story/chapter_plan.md` must be
+  non-empty (and each chapter file must not be near-empty).
+- If `story/final.md` exists it must be non-trivial and contain a
+  `## Final Story` section.
+
+It does *not* judge prose quality. If you've vendored `story_writer`'s
+`scripts/run_qa.py` into this repo, the Assemble phase also runs it (name drift
+/ character presence / cross-chapter phrase reuse) and addresses findings.
+
+## Publishing
+
+The `Assemble & Publish` phase builds `story/final.md`, then follows
+`.claude/skills/herenow/SKILL.md` to publish it and records the resulting
+`site_url` / `claim_url` in the PR body and in `story/STATUS.md`. An anonymous
+publish is claimable for 24h; set `HERENOW_API_KEY` in the aiorchestra run's
+environment to publish under an account. If the herenow skill isn't present in
+the repo, the phase just leaves `story/final.md` and notes that publishing was
+skipped.
+
+## Prerequisites recap
+
+- aiorchestra running somewhere with visibility into this repo, `claude-code`
+  provider configured.
+- `gh` available **inside the aiorchestra run** (for filing the next issue) and
+  authenticated.
+- For publishing: `.claude/skills/herenow/` present (the kit's init script
+  vendors it) and, optionally, `HERENOW_API_KEY` in the environment.

--- a/aiorchestra_story_kit/scaffold/story/STATUS.md
+++ b/aiorchestra_story_kit/scaffold/story/STATUS.md
@@ -1,0 +1,21 @@
+# Status
+
+| # | Phase | State | Artifact | PR | Notes |
+|---|---|---|---|---|---|
+| 1 | Idea | todo | `story/idea.md` (+ `## Style` in `AGENTS.md` / `CLAUDE.md`) | | |
+| 2 | Premise | todo | `story/premise.md` | | |
+| 3 | Spine | todo | `story/spine.md` | | |
+| 4 | World Bible — Rules | todo | `story/world/rules.md` | | |
+| 5 | World Bible — Characters | todo | `story/world/characters.md` | | |
+| 6 | World Bible — Locations | todo | `story/world/locations.md` | | |
+| 7 | World Bible — Timeline | todo | `story/world/timeline.md` | | |
+| 8 | Chapter Plan | todo | `story/chapter_plan.md` | | |
+| 9 | Enhancers Guide | todo | `story/enhancers.md` | | |
+| 10 | Chapters | todo | `story/chapters/NN-slug.md` | | |
+| 11 | Assemble & Publish | todo | `story/final.md` (+ published URL) | | |
+
+States: `todo` → `in-pr` (artifact written, PR open) → `done` (PR merged).
+
+## Next step
+
+_Issue #1 (`Idea: …`) is filed and labelled `aiorchestra` + `claude` + `story`. Once it runs and you merge its PR, add `aiorchestra` + `claude` to the `Premise: …` issue the agent files._

--- a/aiorchestra_story_kit/scaffold/story/_check.py
+++ b/aiorchestra_story_kit/scaffold/story/_check.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Lightweight consistency gate for an aiorchestra story repo.
+
+Run by aiorchestra at the ``validate`` stage. stdlib only. Does NOT judge prose
+quality — only that the ``story/`` tree is internally consistent: a downstream
+artifact that has real content must not sit on top of empty / placeholder
+prerequisites, and an assembled ``story/final.md`` must be well-formed.
+
+Exit 0 = ok; exit 1 = inconsistency (details on stderr).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent  # the story/ directory
+
+PLACEHOLDER_MARKER = "fills this in"
+MIN_CONTENT_CHARS = 80
+MIN_CHAPTER_BYTES = 200
+MIN_FINAL_BYTES = 500
+
+WORLD_FILES = [
+    "world/rules.md",
+    "world/characters.md",
+    "world/locations.md",
+    "world/timeline.md",
+]
+
+# (artifact, prerequisites): if the artifact has real content, each prereq must too.
+DEPS: list[tuple[str, list[str]]] = [
+    ("premise.md", ["idea.md"]),
+    ("spine.md", ["premise.md"]),
+    ("world/rules.md", ["premise.md", "spine.md"]),
+    ("world/characters.md", ["premise.md", "spine.md", "world/rules.md"]),
+    ("world/locations.md", ["premise.md", "spine.md", "world/rules.md", "world/characters.md"]),
+    (
+        "world/timeline.md",
+        ["premise.md", "spine.md", "world/rules.md", "world/characters.md", "world/locations.md"],
+    ),
+    ("chapter_plan.md", ["premise.md", "spine.md", *WORLD_FILES]),
+    ("enhancers.md", ["chapter_plan.md", *WORLD_FILES]),
+]
+
+
+def content_len(rel: str) -> int:
+    """Length of a story file with markdown noise and placeholder text stripped."""
+    path = ROOT / rel
+    if not path.is_file():
+        return 0
+    kept: list[str] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        s = line.strip()
+        if not s or s.startswith(("#", "<!--", "|")):
+            continue
+        if s.startswith("_") and s.endswith("_"):  # italic placeholder note
+            continue
+        if PLACEHOLDER_MARKER in s:
+            continue
+        if s.startswith("- **") and s.endswith("—"):  # empty spine beat
+            continue
+        kept.append(s)
+    return len("\n".join(kept))
+
+
+def has_content(rel: str) -> bool:
+    return content_len(rel) >= MIN_CONTENT_CHARS
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    for artifact, prereqs in DEPS:
+        if not has_content(artifact):
+            continue
+        for pre in prereqs:
+            if not has_content(pre):
+                errors.append(f"story/{artifact} has content but prerequisite story/{pre} is empty/placeholder")
+
+    chapters_dir = ROOT / "chapters"
+    chapter_files = sorted(chapters_dir.glob("*.md")) if chapters_dir.is_dir() else []
+    if chapter_files:
+        if not has_content("chapter_plan.md"):
+            errors.append("story/chapters/ has chapters but story/chapter_plan.md is empty/placeholder")
+        for cf in chapter_files:
+            if cf.stat().st_size < MIN_CHAPTER_BYTES:
+                errors.append(f"story/chapters/{cf.name} is suspiciously short (< {MIN_CHAPTER_BYTES} bytes)")
+
+    final = ROOT / "final.md"
+    if final.is_file():
+        text = final.read_text(encoding="utf-8")
+        if len(text) < MIN_FINAL_BYTES:
+            errors.append("story/final.md exists but is too short to be the assembled story")
+        if "## Final Story" not in text:
+            errors.append("story/final.md is missing the `## Final Story` section")
+
+    if errors:
+        print("story/_check.py: consistency check failed:", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+
+    print("story/_check.py: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/aiorchestra_story_kit/scaffold/story/chapter_plan.md
+++ b/aiorchestra_story_kit/scaffold/story/chapter_plan.md
@@ -1,0 +1,9 @@
+# Chapter Plan
+
+_Phase 8 (`Chapter Plan:`) fills this in: three acts (Setup / Confrontation / Resolution), 3-5 chapters per act (~9-15 total), one sentence per chapter, numbered consecutively. Built from `story/premise.md` + `story/world/`. See `WORKFLOW.md`._
+
+## Act 1 — Setup
+
+## Act 2 — Confrontation
+
+## Act 3 — Resolution

--- a/aiorchestra_story_kit/scaffold/story/chapters/.gitkeep
+++ b/aiorchestra_story_kit/scaffold/story/chapters/.gitkeep
@@ -1,0 +1,1 @@
+Chapters land here as story/chapters/NN-slug.md (e.g. 01-the-fog-comes-in.md), written by the Chapters phase.

--- a/aiorchestra_story_kit/scaffold/story/enhancers.md
+++ b/aiorchestra_story_kit/scaffold/story/enhancers.md
@@ -1,0 +1,3 @@
+# Enhancers Guide
+
+_Phase 9 (`Enhancers:`) fills this in: per chapter — Tension, Mystery (plant/reveal), Theme alignment, Setup/Payoff tracker, Emotional curve, Twist generator, Easter-egg injector. Built from `story/chapter_plan.md` + `story/world/`. See `WORKFLOW.md`._

--- a/aiorchestra_story_kit/scaffold/story/idea.md
+++ b/aiorchestra_story_kit/scaffold/story/idea.md
@@ -1,0 +1,9 @@
+# Idea
+
+_Phase 1 (`Idea:`) fills this in: the idea, the 5 interrogative questions with proposed and accepted answers, and enough foundation for the Premise phase. See `WORKFLOW.md`._
+
+## Interrogative questions
+
+_Five questions that probe and sharpen the idea, each with a proposed answer and an accepted answer — added by the Idea phase._
+
+<!-- The seed idea (from README.md) is appended below by the scaffolder. -->

--- a/aiorchestra_story_kit/scaffold/story/notes.md
+++ b/aiorchestra_story_kit/scaffold/story/notes.md
@@ -1,0 +1,7 @@
+# Notes — decisions log & rejected directions
+
+Append-only working notes. Every phase that establishes new canon (names, places, world rules, events) or rejects a creative direction records it here with a short issue/date reference. The files under `story/` are the canon; this file is the running commentary on how it got that way.
+
+## Decisions
+
+## Rejected directions

--- a/aiorchestra_story_kit/scaffold/story/premise.md
+++ b/aiorchestra_story_kit/scaffold/story/premise.md
@@ -1,0 +1,3 @@
+# Core Premise
+
+_Phase 2 (`Premise:`) fills this in: one tight paragraph — central conflict, protagonist goal and motivation, stakes, setting and tone, thematic undercurrent. Built from `story/idea.md`. See `WORKFLOW.md`._

--- a/aiorchestra_story_kit/scaffold/story/spine.md
+++ b/aiorchestra_story_kit/scaffold/story/spine.md
@@ -1,0 +1,10 @@
+# Narrative Spine
+
+_Phase 3 (`Spine:`) fills this in. Built from `story/premise.md`. See `WORKFLOW.md`._
+
+- **Once upon a time…** —
+- **Every day…** —
+- **One day…** —
+- **Because of that…** —
+- **Because of that…** —
+- **Until finally…** —

--- a/aiorchestra_story_kit/scaffold/story/world/characters.md
+++ b/aiorchestra_story_kit/scaffold/story/world/characters.md
@@ -1,0 +1,3 @@
+# World Bible — Characters
+
+_Phase 5 (`World Bible — Characters:`) fills this in: every significant character — full name, physical description, relationships, role, aspirations, flaws. Majors detailed, minors brief. Built from `story/premise.md`, `story/spine.md`, `story/world/rules.md`. See `WORKFLOW.md`._

--- a/aiorchestra_story_kit/scaffold/story/world/locations.md
+++ b/aiorchestra_story_kit/scaffold/story/world/locations.md
@@ -1,0 +1,3 @@
+# World Bible — Locations
+
+_Phase 6 (`World Bible — Locations:`) fills this in: every significant place — description, climate, inhabitants, geography, atmosphere, plot significance. Built from `story/premise.md`, `story/spine.md`, `story/world/rules.md`, `story/world/characters.md`. See `WORKFLOW.md`._

--- a/aiorchestra_story_kit/scaffold/story/world/rules.md
+++ b/aiorchestra_story_kit/scaffold/story/world/rules.md
@@ -1,0 +1,3 @@
+# World Bible — Rules of the World
+
+_Phase 4 (`World Bible — Rules:`) fills this in: magic, technology, science, law, etiquette, societal norms, and any loopholes characters might exploit. Built from `story/premise.md` + `story/spine.md`. See `WORKFLOW.md`._

--- a/aiorchestra_story_kit/scaffold/story/world/timeline.md
+++ b/aiorchestra_story_kit/scaffold/story/world/timeline.md
@@ -1,0 +1,3 @@
+# World Bible — Plot Timeline
+
+_Phase 7 (`World Bible — Timeline:`) fills this in: a chronological sequence of major events, from backstory through the conclusion. Built from all of `story/world/`. See `WORKFLOW.md`._


### PR DESCRIPTION
## Summary

Adds `aiorchestra_story_kit/` — a portable kit that turns an (almost) empty git repo into an **aiorchestra-driven story project**. Each writing phase is a GitHub issue; the agent opens a PR carrying exactly one artifact; you review/merge it; the agent files the next phase's issue. The phase chain mirrors the `write-story` skill: idea → 5 interrogatives → premise → spine → world bible (Rules → Characters → Locations → Timeline) → 3-act chapter plan → enhancers guide → chapters (~35% random-detail injection) → assemble & publish. The DSPy repo itself is unchanged — this only adds the new directory.

## What's included

- **`init_story_repo.py`** — stdlib-only scaffolder (needs the `gh` CLI). Parses the target repo's `README.md` → title/logline/seed, copies `scaffold/` in, renders `AGENTS.md`/`CLAUDE.md`, seeds `story/idea.md`, vendors `herenow-skill/` (if found alongside the kit) into `.claude/skills/herenow/`, commits, ensures the `aiorchestra`/`claude`/`story`/`next-phase` labels exist, optionally pushes, and opens issue #1 (`Idea: <title>`). `--no-issue` / `--push` / `--herenow-skill` / `--remote` flags.
- **`scaffold/.aiorchestra/config.yaml`** — layered over aiorchestra's defaults: `claude-code` provider, `test.command: python story/_check.py`, review on, CI/OSINT off. Discovery label is intentionally not overridden (see note below).
- **`scaffold/.aiorchestra/templates/`** — `implement.md` (phase-routing prompt: ports the `write-story` stages, plus the chain-advancement rule and the `NEEDS_CLARIFICATION:` protocol), `review.md` (editorial pass, not code review), `fix_validation.md`, `fix_review.md`. Placeholders match aiorchestra's actual template vars (`{number}`, `{title}`, `{body}`, `{osint_context}`, `{comments_section}`, `{errors}`, `{diff}`).
- **`scaffold/.github/ISSUE_TEMPLATE/`** — 12 templates, one per phase (incl. the four `World Bible — …` issues and a `Revise — …` template); human-clicked ones carry `aiorchestra` + `claude` + `story`.
- **`scaffold/story/`** — skeletons for every artifact (`idea`, `premise`, `spine`, `world/{rules,characters,locations,timeline}`, `chapter_plan`, `enhancers`, `chapters/.gitkeep`, `notes`, `STATUS`) + **`_check.py`**, the consistency gate run at `validate` (prerequisites must be non-empty before downstream artifacts; chapters require a non-empty plan; `final.md` must contain a `## Final Story` section). It does not judge prose.
- **`scaffold/WORKFLOW.md`** — the full algorithm doc (lands in every story repo); plus the kit's own `README.md` and `repo_md_templates/{AGENTS,CLAUDE}.md.tmpl`.

## How a phase advances

The agent files the next phase's issue with `story` + `next-phase` labels **only** — not `aiorchestra`/`claude`. So it sits idle until you've reviewed/merged the current PR and add `aiorchestra` + `claude` to it. That's the deliberate human gate between phases. If `gh` isn't available inside the aiorchestra run, the agent writes the next-issue spec into `story/STATUS.md` under `## Next step` instead.

## Note on the trigger label

aiorchestra's `dispatch` mode discovers issues by the hardcoded `aiorchestra` label (only the agent-*family* label, default `claude`, is configurable). So phase issues carry `aiorchestra` + `claude` for triggering and a cosmetic `story` tag for filtering. There's no collision with a `claude`-triggered GitHub Action because the kit scaffolds *fresh* repos; the `story_writer`-into-itself edge case (where `agent-implement.yaml` would also fire) is flagged in `WORKFLOW.md` and the kit `README.md`.

## Caveats

- `init_story_repo.py` and `story/_check.py` are **untested** — there was no local repo to exercise them against. The `gh` flow and the aiorchestra config/template schema were derived from the `aiorchestra` repo's README and `templates/`.
- No changes to existing files; 35 new files under `aiorchestra_story_kit/`.

## Test plan

- [ ] Smoke-test `init_story_repo.py` against a fresh repo with a one-paragraph README; confirm scaffold layout, rendered `AGENTS.md`/`CLAUDE.md`, seeded `story/idea.md`, labels created, issue #1 opened.
- [ ] Run `python story/_check.py` in the freshly scaffolded repo → exit 0; then with a fake `chapter_plan.md` containing content but empty `premise.md` → exit 1.
- [ ] Confirm aiorchestra picks up issue #1 (`aiorchestra` + `claude`), runs `implement.md`, and the resulting PR contains `story/idea.md` + `## Style` appended to `AGENTS.md`/`CLAUDE.md` + a filed `Premise: …` issue labelled `story` + `next-phase`.
- [ ] Verify the `.aiorchestra/templates/*.md` placeholders render correctly under the running aiorchestra version (no `KeyError` on unknown `{...}`).

https://claude.ai/code/session_01U9bATmxLL9izwkRXG29qp4