### PR TITLE
deepseek-v4-pro comparison run + redact api_key from logs

### DIFF
--- a/docs/model-implementation-comparison-2026-05-10.md
+++ b/docs/model-implementation-comparison-2026-05-10.md
@@ -1,4 +1,4 @@
-# Story-pipeline comparison — 3 models × 3 drafting variants
+# Story-pipeline comparison — models × drafting variants
 
 Run date: 2026-05-10. Idea: *"A nameless child, raised and trained by the Church to hunt
 demons, discovers the Church secretly breeds the very demons it sells protection from — and
@@ -8,6 +8,19 @@ Ollama, DSPy disk cache **on** (wiped per model; within a model, variant A warms
 foundation and B/C reuse it). Raw outputs: `.tmp/cmp/<model>/{A_baseline,B_worldstate,C_module}.{md,log,console}`.
 First pass used `--max-tokens 4096` — see "Cross-cutting issues" #1; archived in
 `.tmp/cmp/*_mt4096*`.
+
+> **Addendum 2026-05-12 — `deepseek-v4-pro`.** Added a fourth model: DeepSeek V4 (released
+> 2026-04-24), the **Pro** size, Thinking mode (on by default). **Variant A only**, same
+> idea/title/chapters, but run against the **hosted API** (`deepseek/deepseek-v4-pro` via
+> litellm, key in `.env`) — not Ollama — at `--max-tokens 32768`. The big token budget is
+> deliberate: DeepSeek bills reasoning tokens against the *output* cap, so a smaller
+> `--max-tokens` risks the truncation-→-`None` crash (Cross-cutting issue #1) on every step.
+> Raw output: `.tmp/cmp/deepseek_v4_pro/A_baseline.{md,log,console}`; driver:
+> `.tmp/cmp/run_deepseek.sh`. Rows tagged *deepseek-v4-pro* below; dedicated read-through and
+> recommendation note added. 45 LLM calls, ≈207k input / ≈73k output tokens (output incl.
+> reasoning); litellm has no price card for the new model yet so it logged `$0` — at
+> DeepSeek's published rates this run is well under $1. Wall-clock 43 min (vs 86 min for
+> `qwen3.6:27b` A — the hosted API has no local-VRAM bottleneck).
 
 ## The variants
 
@@ -24,6 +37,7 @@ First pass used `--max-tokens 4096` — see "Cross-cutting issues" #1; archived 
 | `qwen3:latest` | ~8B (5.2 GB) | small local baseline; the model used in earlier `runs/` |
 | `qwen3.6:27b` | ~27B (17 GB) | the newly-pulled candidate |
 | `gemma4:26b` | (17 GB) | the model that "failed miserably" before |
+| `deepseek-v4-pro` | ~1.6T MoE / 49B active — **hosted API, not local** | added 2026-05-12; DeepSeek V4 (2026-04-24), Thinking mode on by default; `deepseek/deepseek-v4-pro` via litellm, `DEEPSEEK_API_KEY` in `.env` |
 
 ## Completion / robustness
 
@@ -32,7 +46,10 @@ old default `--max-tokens 4096`: `qwen3:latest` A & B completed but **C crashed
 deterministically** (`build_outline` JSON truncated → `ValidationError` on `list[PlanEntry]`),
 and **all three `qwen3.6:27b` variants crashed** (verbose model hits the 4096 ceiling →
 truncated response → DSPy returns `None` → unguarded `len(None)` / `None.story_clock`). So
-robustness is a *pipeline* problem, not a model one — see issue #1.
+robustness is a *pipeline* problem, not a model one — see issue #1. *(2026-05-12: the
+`deepseek-v4-pro` variant-A run completed cleanly — 7 non-empty chapters, no crash — at
+`--max-tokens 32768`; that headroom is needed because Thinking-mode reasoning tokens count
+against the output cap, so a smaller budget would re-trigger issue #1 on every step.)*
 
 ## Metrics (prose only; variant B's rendered WorldState blocks excluded)
 
@@ -47,6 +64,7 @@ robustness is a *pipeline* problem, not a model one — see issue #1.
 | gemma4:26b | A | 552 s | 3,642 | 393–690 | 22 | name_drift (Vane↔High Clergy, paraphrase); protagonist unnamed |
 | gemma4:26b | B | 402 s | 3,711 | 440–583 | 16 | char_presence ('Elara' unused) |
 | gemma4:26b | C | 196 s | 3,618 | 256–619 | 24 | name_drift (Vane↔High Inquisitor) |
+| **deepseek-v4-pro** *(hosted, Thinking)* | **A** | **43 min** | **10,761** | 898–2,161 | 28 | — QA clean (char_presence ✓, name_drift ✓); *but* QA misses two real ones — ch3 lurches to "he/him", and the cast has **two characters named Elara** (the text even lampshades it) |
 
 (B's *raw* file word counts are ~2× higher because the per-chapter "World State after Chapter
 N" blocks are rendered into the artifact. Wall-clock for B/C is short because they reuse the
@@ -77,6 +95,54 @@ cached foundation; the 27B's foundation alone is ~45–50 min.)
   full first person** ("I stepped through the fracture… my collarbone…", "Cinder" ×0), ch6
   reverts to third person but says "the protagonist" ×12, ch7 = "Cinder". Each chapter drafted
   independently → POV/name drift the `name_drift` QA can't detect.
+
+### deepseek-v4-pro (hosted, Thinking) — best prose tested; the back third stutters *(added 2026-05-12)*
+- **A (baseline)** — 3.5 / 4 / 3.5 / **4.5** / 4. The strongest sentence-level prose of any
+  run here — figurative without being purple, dense with concrete sensory detail ("the road
+  to Thornwood was a tongue of packed dirt licking through blackthorn and mud", a headman whose
+  "back [is] a question mark", "coins that clinked soft as regret"), and it carries real
+  motifs: the seamstress's button-eyed doll (glimpsed in a hut in ch1 → clutched on the altar
+  in ch5 → carried by the freed demon in ch7 → tucked into the orphan's belt, "a relic of
+  their own"), the candle in the skull-cup that "burned without consuming", the falchion
+  *Silence* whose hum shifts from "hymn" to "howl" as the protagonist de-conditions. The
+  premise is dramatized hard (the "extraordinary tithe" of children, the Bleeding Chamber, the
+  heart-relic, the cells behind the Tithe Vault, Isidor's 34-year ledger of vanished names),
+  and the ending is genuinely distinctive: Elara insists in ch3 that there is "no third path"
+  — destroy the Church and unleash the feral surge, or be hunted — and ch7 *is* the third
+  path: the orphan founds an order of "binders" who leash feral demons without blood sacrifice,
+  at the cost of channelling the demon's terror back into themselves, ending on a knife-edge
+  ("the moors waited, screaming, to see if the new order would hold"). Distinctive choice:
+  **the protagonist is never named** — "the nameless orphan" / "the orphan" throughout — and
+  here that reads as thematic intent (a husked weapon reclaiming a self), not the unnamed-cold-
+  open *bug* that A has on `qwen3.6:27b`. **Real flaws**, none of which QA catches:
+  - **POV drift in ch3** — chapters 1–2 and 4–7 narrate the orphan as "they/them"; **ch3
+    abruptly switches to "he/him"** ("The steeple swallowed him whole…") and back. Same family
+    as the `qwen3.6:27b` variant-C voice drift, in variant A this time — exactly Cross-cutting
+    issue #3.
+  - **Two characters named Elara** — "Sister Elara", the scarred Remnant exorcist, *and* the
+    mute Thornwood seamstress (the world bible names her Elara too). Ch5 has the exorcist say
+    of the seamstress "Her name is Elara," which only highlights the collision. A world-bible
+    name-uniqueness check would catch this; `name_drift` can't (it's a collision, not drift).
+  - **The back third duplicates beats.** Ch5 ("The Tithe of Bodies") already storms the
+    Bleeding Chamber, kills the ritualists, severs the main tether, the orphan seizes the
+    heart-relic, the demons go feral, they flee up the bone stair. Ch6 ("The Heart of Ash")
+    then does *the same things again* (kill ritualists incl. Marcellus, seize the heart-relic
+    "from its nest of desiccated flesh", tethers snap, ferals erupt, "Run", up the bone stair)
+    plus the cathedral reveal — and ch7 *opens by replaying ch6's cliffhanger* (the relic
+    sizzling on the altar, the first spider-limbed feral crawling out). The per-chapter draft +
+    rolling-text-summary continuity (variant A) let the model pull ch6's climax into ch5 and
+    then loop. Ch6 is also the runt at ~900 words and reads more like a breathless recap than a
+    chapter; Marcellus, built up over five chapters, dies almost in passing.
+  - Minor: the unburning candle is set up vividly in ch2, referenced in ch4, and never
+    actually explained — an evocative loose thread. A few tics ("with the economy of long
+    practice" ×2, "Silence's hum dropped to a…" ×2, "rain-soaked slate" / "rain-slate" eyes
+    used for *two* characters).
+- **Vs `qwen3.6:27b` A** (4.5 / 4.5 / 4.5 / 4 / 4): roughly a wash on overall quality, with
+  opposite strengths. `qwen3.6:27b` is the more *disciplined* draft — even chapter lengths, no
+  pronoun drift, no beat duplication, and it names its protagonist (Cinder); its prose is crisp
+  but plainer. `deepseek-v4-pro` writes markedly better prose and a more surprising ending but
+  has a sloppier spine in the back third. Also: ~2× faster (43 vs 86 min) and cheap — but it's
+  a hosted API, so it loses on the project's local-first axis.
 
 ### gemma4:26b — *not* a miserable failure anymore; ~8B-tier
 - **A** — 3.5 / 3.5 / 3.5 / 2.5 / 3. Coherent: "the Hunter" (never named — "Elara" sits unused
@@ -133,6 +199,18 @@ cached foundation; the 27B's foundation alone is ~45–50 min.)
      chapter-to-chapter (first person in ch5, "the protagonist" in ch6). Not worth keeping as
      a user-facing mode unless it also threads POV/style state between chapters — at which
      point it converges on B.
+4. **`deepseek-v4-pro` (added 2026-05-12): the "I want the best prose and don't mind a hosted
+   API" option — not the local default.** On variant A it matched `qwen3.6:27b` on overall
+   quality (≈ a wash) while writing distinctly better prose and a more surprising ending, in
+   half the wall-clock (43 vs 86 min) for well under $1. But it's a hosted API (against the
+   project's local-first grain), it drifts the protagonist's pronoun in ch3, and its back
+   third stutters (ch5/ch6 beat duplication, ch6→ch7 cliffhanger replay) — the same
+   per-chapter-drafting weakness, just dressed in better sentences. So: keep **`qwen3.6:27b`**
+   as the default *local* model; reach for **`deepseek-v4-pro`** when you want a max-quality
+   pass and a network call is acceptable. The pipeline fixes below (esp. #1's `None`-guard,
+   #3's POV check, and a new world-bible name-uniqueness check) matter for *both* — and run
+   `deepseek` with a generous `--max-tokens` (32768 here) since its reasoning tokens eat the
+   output budget.
 
 ## Cross-cutting issues (independent of model & variant — worth fixing before the next bake-off)
 
@@ -148,7 +226,9 @@ cached foundation; the 27B's foundation alone is ~45–50 min.)
    "the protagonist" ch6) goes unflagged while `name_drift` fires on harmless paraphrases
    ("High Cardinal Vane" ↔ "High Clergy") and on WorldState-block parsing artifacts
    ("Renn\n\nThe Sanctum"). Add a check for narrator-person consistency and protagonist-naming
-   consistency across chapters.
+   consistency across chapters. *(Reconfirmed 2026-05-12: `deepseek-v4-pro` variant A narrates
+   the protagonist as "they/them" in every chapter except ch3, which switches to "he/him" —
+   same blind spot, different model and variant.)*
 4. **QA still doesn't flag empty / very-short prose** (pre-existing — `runs/demo-hollow` ch3
    was empty and passed R1–R6). Add a hard rule: chapter prose below N words fails.
 5. **Variant B leaks pipeline scaffolding into the artifact** — the "#### World State after
@@ -160,3 +240,17 @@ cached foundation; the 27B's foundation alone is ~45–50 min.)
    into…" (qwen3.6:27b) and "kaleidoscopic nightmare of overlapping…" (gemma4:26b) recur
    across all three variants. Feeding prior chapters' sentences into the drafter as
    negative/avoid context would suppress the worst tics.
+8. **Nothing enforces character-name uniqueness in the world bible** *(new, found 2026-05-12)*.
+   `deepseek-v4-pro` produced a bible/draft with **two characters named Elara** — the Remnant
+   exorcist and the Thornwood seamstress — and the prose ended up lampshading it ("Her name is
+   Elara," said the other Elara). Add a foundation-stage check that the `#### Character N`
+   blocks have distinct names (warn on near-duplicates / first-name collisions). `name_drift`
+   can't see this — it's a collision, not drift.
+9. **Variant A's per-chapter drafting can duplicate/loop late beats** *(new, found 2026-05-12)*.
+   With only a rolling text summary for continuity, `deepseek-v4-pro` pulled ch6's climax
+   (storm the chamber → kill ritualists → seize the heart-relic → tethers snap → ferals surge →
+   flee up the stair) into ch5, then ch6 re-ran it, and ch7 opened by replaying ch6's
+   cliffhanger. Worth: (a) feeding the *prior chapter's actual closing beats* (not just a
+   summary) into the next draft as "already happened, do not repeat", and/or (b) a QA check for
+   high n-gram/event overlap between adjacent chapters. (Variant B's structured `WorldState`
+   would also have caught "the heart-relic is already in the protagonist's possession".)

--- a/dspy_runtime.py
+++ b/dspy_runtime.py
@@ -89,6 +89,17 @@ def _log_ollama_runtime(model_name: str, num_ctx: int | None) -> None:
         logger.warning("Ollama runtime probe failed: %s", exc)
 
 
+_SECRET_KWARG_NAMES = frozenset({"api_key", "apikey", "api_base_key", "secret", "token", "authorization"})
+
+
+def _redact_secrets(kwargs: dict) -> dict:
+    """Return a shallow copy of ``kwargs`` with credential-bearing values masked, for logging."""
+    return {
+        k: ("***redacted***" if k.lower() in _SECRET_KWARG_NAMES and v else v)
+        for k, v in kwargs.items()
+    }
+
+
 def configure_dspy(config: DSPyConfig) -> None:
     """Configure DSPy LM and optional instrumentation."""
     kwargs: dict[str, str] = {}
@@ -130,7 +141,7 @@ def configure_dspy(config: DSPyConfig) -> None:
         cache=config.cache,
         **kwargs,
     )
-    logger.info("DSPy LM kwargs=%s", lm.kwargs)
+    logger.info("DSPy LM kwargs=%s", _redact_secrets(lm.kwargs))
     _log_ollama_runtime(config.model_name, config.num_ctx)
 
     if os.environ.get("LANGFUSE_PUBLIC_KEY") and DSPyInstrumentor is not None:


### PR DESCRIPTION
Two related changes from running DeepSeek V4 through the pipeline.

## 1. `fix: redact api_key from DSPy LM kwargs log line`
`configure_dspy` logged `lm.kwargs` at INFO, which includes `api_key` when one is passed (came up running against the DeepSeek hosted API via `--api-key` / `DEEPSEEK_API_KEY`). Now masked via a `_redact_secrets` helper before logging; the other config log line never carried the key. Verified `pytest test_world_state.py test_story_module.py` still passes.

## 2. `docs: add deepseek-v4-pro to the model/variant comparison`
Follow-up run (2026-05-12) on `docs/model-implementation-comparison-2026-05-10.md`: DeepSeek V4 (Thinking mode, on by default), the **Pro** size, **variant A only**, same idea/title/7 chapters, via the **hosted API** (`deepseek/deepseek-v4-pro` via litellm) at `--max-tokens 32768` — the big budget is deliberate, since DeepSeek bills reasoning tokens against the output cap and a smaller cap re-triggers the truncation→`None` crash. Raw output + driver in `.tmp/cmp/deepseek_v4_pro/` and `.tmp/cmp/run_deepseek.sh` (gitignored, like the rest of the bake-off outputs).

Findings folded into the doc:
- models + metrics tables get a `deepseek-v4-pro` row; new read-through subsection; 4th recommendation point.
- **≈ a wash on overall quality vs `qwen3.6:27b` A, opposite strengths** — DeepSeek writes the best sentence-level prose tested and a more surprising ending (the "third path": founds an order of demon-binders); deliberately keeps the protagonist nameless ("the orphan") as thematic intent. But it's a hosted API (not local-first), it drifts the protagonist's pronoun to "he/him" in ch3 only, and the back third stutters (ch5 & ch6 both: storm chamber → kill ritualists → seize heart-relic → ferals surge → flee; ch7 replays ch6's cliffhanger). Recommendation: keep `qwen3.6:27b` as the default *local* model; reach for `deepseek-v4-pro` for a max-quality pass when a network call is OK.
- two new cross-cutting issues: **#8** nothing enforces character-name uniqueness in the world bible (it produced two characters named Elara — the prose even lampshades it); **#9** variant A's draft-from-summary can duplicate/loop late beats — feed the prior chapter's actual closing beats (not just a summary) as "already happened", and/or QA-check adjacent-chapter overlap.

No code changes in (2); docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)