### PR TITLE
docs: add definition-phase docs (vision, requirements, design, decisions)

### DIFF
--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -1,0 +1,32 @@
+# Definition-phase docs (read before the implementation plan)
+
+These are the "what / why / how" documents that sit upstream of any
+implementation plan. They describe the product and its design as it stands
+today; they are intentionally concise (≈one page each) and grounded in the
+current code.
+
+## Reading order
+
+| # | Doc | Answers |
+|---|---|---|
+| 01 | [vision.md](01-vision.md) | Why does this exist? What are we building? |
+| 02 | [requirements.md](02-requirements.md) | What must it do? (PRD + functional + non-functional) |
+| 03 | [architecture.md](03-architecture.md) | How is it structured? (components, data flow, variants) |
+| 04 | [algorithms.md](04-algorithms.md) | How does each stage actually work? (algorithms) |
+| 05 | [domain-model.md](05-domain-model.md) | What are the entities and terms? |
+| 06 | [decisions-and-risks.md](06-decisions-and-risks.md) | Why these choices? What could go wrong? |
+| 07 | [acceptance-and-quality.md](07-acceptance-and-quality.md) | How do we know it works? |
+
+## What comes next (the implementation plan)
+
+The roadmap / backlog lives in:
+
+- [pipeline-known-issues.md](pipeline-known-issues.md) — prioritized issue list.
+- [handoff-pipeline-fixes.md](handoff-pipeline-fixes.md) — the action plan for it.
+- [model-implementation-comparison-2026-05-10.md](model-implementation-comparison-2026-05-10.md) — the model × variant bake-off these docs draw evidence from.
+
+Contributor/coding conventions are in the repo-root [AGENTS.md](../AGENTS.md).
+
+> Status: **pre-implementation reference**. These docs describe the system to
+> orient new contributors and frame the backlog; they are not a spec the code
+> is formally verified against.

--- a/docs/01-vision.md
+++ b/docs/01-vision.md
@@ -1,0 +1,63 @@
+# 01 · Vision / Product Brief
+
+## Problem
+
+Turning a one-line story idea into a coherent, multi-chapter story by hand is
+slow, and naive "write me a story" LLM prompts produce shapeless prose with no
+through-line, drifting names, and forgotten characters. There is no
+local-first, inspectable pipeline that takes an idea through the same structured
+steps a human author would (premise → arc → world → outline → draft) and that
+checks its own output.
+
+## What we are building
+
+**Story Writer** — a local-first [DSPy](https://dspy.ai) pipeline that turns a
+one-line idea into a structured multi-chapter story, running against Ollama (or
+any DSPy-supported LLM), with optional image generation and Langfuse tracing.
+
+It works in two phases:
+
+1. **Foundation** — clarify the idea, derive a core premise, a story spine
+   (Pixar 7-step), a world bible (rules / locations / timeline / characters),
+   and a per-chapter plan.
+2. **Drafting + QA** — draft each chapter on top of that foundation, then run
+   post-generation quality checks (phrase reuse, name drift, character
+   presence, chapter length, POV consistency).
+
+## Target users
+
+- **Hobbyist / indie writers** who want a structured first draft from an idea,
+  on their own hardware, with no per-token cost.
+- **Pipeline tinkerers / researchers** experimenting with multi-step LLM
+  generation, prompt structure, and quality evaluation (the repo ships three
+  drafting variants and a model bake-off for exactly this).
+
+## Goals
+
+- One idea in → one readable, structured, multi-chapter story out.
+- **Local-first**: usable fully offline against Ollama; no API key required.
+- **Inspectable**: every intermediate artifact (premise, spine, bible, plan) is
+  written to the output incrementally, so an interrupted run keeps its work.
+- **Self-checking**: automated QA surfaces the common failure modes.
+- **Model-portable**: the same pipeline runs across local and hosted models.
+
+## Non-goals
+
+- Not a polished, publication-ready editor or a GUI app (CLI + Rich prompts).
+- Not a chat assistant or general-purpose writing tool.
+- Not cloud-first or multi-tenant; no accounts, no hosting.
+- Not aiming for a single "best" algorithm — the three drafting variants are
+  kept in parallel for comparison, not collapsed.
+
+## Success criteria
+
+- A 7-chapter run completes without crashing on the recommended config and
+  produces 7 non-empty chapters with a named protagonist and a real ending.
+- The QA suite passes (no spurious fails) on a good run and flags the known
+  failure modes on a bad one.
+- A new contributor can read these docs + `AGENTS.md` and run the pipeline.
+
+## Guiding principles
+
+Local-first · incremental, inspectable artifacts · human-in-the-loop review at
+each step · structure before prose · check what you generate.

--- a/docs/02-requirements.md
+++ b/docs/02-requirements.md
@@ -1,0 +1,87 @@
+# 02 · Requirements (PRD + Functional + Non-Functional)
+
+Scope-setting companion to [01-vision.md](01-vision.md). IDs are for reference,
+not formal traceability.
+
+## Personas & primary use cases
+
+- **Author** — has an idea, wants a structured draft. Runs interactively
+  (`story.py`) answering clarifying questions, or non-interactively
+  (`mymain.py --idea ... --title ...`).
+- **Tinkerer** — compares drafting strategies / models. Runs the three variants
+  (`mymain.py`, `mymain_ws.py`, `mymain_module.py`) and the QA scripts.
+
+## User stories
+
+- As an author, I give a one-line idea and get a multi-chapter story file.
+- As an author, I review and correct each foundation step before it locks in.
+- As an author, an interrupted run keeps everything produced so far.
+- As a tinkerer, I run the same idea through different models/variants and get a
+  comparable QA report for each.
+
+## Functional requirements
+
+**Input & config**
+- FR-1 Accept a story idea, optional title, and chapter count (default 7).
+- FR-2 Accept model / provider / token / context / cache config via CLI flags
+  and `.env`; default to local Ollama.
+
+**Foundation**
+- FR-3 Clarify the idea via generated questions + proposed answers, then fold
+  answers back into an updated idea; generate a title if none given.
+- FR-4 Generate a core premise.
+- FR-5 Generate a story spine using the Pixar 7-step formula.
+- FR-6 Generate a world bible: rules of the world, locations (+ enhanced),
+  timeline, characters (+ enhanced).
+- FR-7 Run a consistency sanity check across idea / spine / world bible.
+- FR-8 Generate a per-chapter plan (title + beats) for N chapters.
+
+**Drafting (three variants, shared foundation)**
+- FR-9 **Variant A (baseline)** — draft each chapter from its beats + a rolling
+  "story so far" text summary; map each chapter to a 3-act slice of the spine.
+- FR-10 **Variant B (world-state)** — maintain a structured `WorldState`
+  (clock / characters / locations / threads / objects / recent events), updated
+  after each chapter and fed into the next draft.
+- FR-11 **Variant C (module)** — draft each chapter independently from its own
+  outline beats + world bible + act-sliced spine.
+
+**Human-in-the-loop**
+- FR-12 In interactive mode, present each generated step for review; allow
+  free-text feedback that regenerates the step, or acceptance.
+
+**Output**
+- FR-13 Write all artifacts (params, idea, premise, spine, bible, plan,
+  chapters) incrementally to a markdown file in a defined section layout.
+- FR-14 Optionally generate images.
+- FR-15 Render the markdown artifact to standalone HTML.
+
+**Quality**
+- FR-16 Provide a QA suite over the output: cross-chapter phrase reuse, name
+  drift, character presence, chapter length.
+- FR-17 Provide an LLM-backed POV-consistency check.
+- FR-18 Provide a post-generation linter that replaces placeholder/misspelled
+  character references in chapter prose only.
+
+## Non-functional requirements
+
+- NFR-1 **Local-first / offline** — must run fully against local Ollama with no
+  API key.
+- NFR-2 **Model-portable** — work across DSPy-supported LLMs (local + hosted);
+  no hard dependency on one model's quirks.
+- NFR-3 **Inspectable & incremental** — intermediate artifacts persisted as they
+  are produced; an interrupted run retains prior output.
+- NFR-4 **Observability** — structured logging with verbosity levels; optional
+  Langfuse tracing via `@observe()`.
+- NFR-5 **Resource budget** — runnable on a single consumer GPU; context window
+  configurable (`--num-ctx`); recommended quality config documented.
+- NFR-6 **Robustness** *(target; partially unmet)* — a single bad/truncated LM
+  response should not crash a long run. See risk R-1 in
+  [06-decisions-and-risks.md](06-decisions-and-risks.md).
+- NFR-7 **Code quality** — conventions enforced per `AGENTS.md` (≤50-line
+  functions, type hints, separation of UI/business logic, tests with `MockLM`).
+
+## Out of scope
+
+GUI/editor · accounts/multi-tenancy · cloud hosting · publication-grade
+formatting · automatic acceptance of foundation steps without review (in
+interactive mode).

--- a/docs/03-architecture.md
+++ b/docs/03-architecture.md
@@ -1,0 +1,71 @@
+# 03 · Architecture / High-Level Design
+
+How the pieces fit. Algorithms are in [04-algorithms.md](04-algorithms.md).
+
+## Data flow
+
+```
+idea ─▶ clarify ─▶ premise ─▶ spine (Pixar 7-step)
+                                  │
+                                  ▼
+                      world bible: rules · locations(+enhance)
+                                   · timeline · characters(+enhance)
+                                  │
+                                  ▼
+                         sanity check ─▶ chapter plan (N × {title, beats})
+                                  │
+              ┌───────────────────┼────────────────────┐
+              ▼                   ▼                    ▼
+     A: enhance_chapter    B: WorldState        C: independent
+     + story-so-far        init/advance/draft   per-chapter draft
+              └───────────────────┼────────────────────┘
+                                  ▼
+                     markdown artifact (incremental)
+                                  ▼
+              QA suite · POV check · linter · HTML render
+```
+
+Foundation is identical across variants; the variants differ only in how
+chapters are drafted (inter-chapter continuity strategy).
+
+## Components
+
+| Layer | Module(s) | Responsibility |
+|---|---|---|
+| Entry points | `mymain.py` (A), `mymain_ws.py` (B), `mymain_module.py` (C), `story.py` (interactive) | Parse args, configure runtime/logging, kick off a run |
+| Orchestration | `pipeline.py` (A), `pipeline_ws.py` (B), `pipeline_module.py` (C) | Sequence the stages, log steps, write artifacts |
+| Story modules | `story.py` | DSPy signatures + `run_*` functions for every foundation/draft step; `act_hint_for_chapter` |
+| World state | `world_state.py`, `story_module.py` | Variant B/C drafting state + signatures |
+| Quality | `qa.py`, `pov_check.py`, `story_linter.py` | Post-generation checks + prose lint |
+| Runtime | `dspy_runtime.py`, `dspy_optimization.py` | `DSPyConfig` / `configure_dspy`; module loading/optimization |
+| Output | `artifact.py` | `initialize_artifact`, `update_artifact` (incremental markdown) |
+| UI | `ui.py` | Rich prompts/review (kept out of pipeline logic) |
+| Cross-cutting | `logging_config.py`, `_compat.py`, `exceptions.py`, `image_gen.py` | Logging, Langfuse `@observe()` fallback, errors, images |
+| Scripts | `scripts/` | `run_qa.py`, `check_pov.py`, `lint_story.py`, `render_story.py`, `word_count.py`, `optimize_text_pipeline.py` |
+
+## The three drafting variants
+
+| Variant | Entry / pipeline | Inter-chapter continuity |
+|---|---|---|
+| **A · baseline** *(default)* | `mymain.py` / `pipeline.py` | per-chapter `enhance_chapter` + rolling text "story so far" |
+| **B · world-state** | `mymain_ws.py` / `pipeline_ws.py` + `world_state.py` | structured `WorldState`, updated each chapter |
+| **C · module** | `mymain_module.py` / `pipeline_module.py` + `story_module.py` | none — each chapter drafted independently from its own outline |
+
+## External dependencies & runtime
+
+- **LLM via DSPy** — default provider `ollama` (expected at
+  `http://localhost:11434`), model `qwen3`; any DSPy/litellm model works
+  (e.g. hosted `deepseek-v4-pro`).
+- **Pydantic / dataclasses** — typed pipeline state and structured LM I/O.
+- **Rich** — interactive review UI.
+- **Langfuse** *(optional)* — tracing via `@observe()`; no-op shim if absent.
+- **Replicate** *(optional)* — image generation.
+- **Config** — CLI flags + `.env` (`API_KEY`, `DEEPSEEK_API_KEY`,
+  `DSPY_CACHE_DIR`, `LANGFUSE_*`). DSPy disk/memory cache on by default.
+
+## Artifact format (output markdown)
+
+`# Story` → `## Generation Parameters / Story Title / Core Premise / Spine` →
+`## World bible` (`### Rules / Locations / Timeline / Characters`, with
+`#### Location N` / `#### Character N`) → `## Chapters Plan` → `## Final Story`
+(`### Chapter N: <title>`). The QA/linter parsers key off exactly this layout.

--- a/docs/04-algorithms.md
+++ b/docs/04-algorithms.md
@@ -1,0 +1,109 @@
+# 04 · Detailed Design & Algorithms
+
+The "how" of each stage. Components are in [03-architecture.md](03-architecture.md).
+
+## Human-in-the-loop review loop (foundation steps)
+
+Most `run_*` functions in `story.py` share one pattern: generate with a DSPy
+`ChainOfThought`, show the result via `ui.review_answer`, and loop on free-text
+feedback until the user accepts. Feedback and the previous result are fed back
+into the signature as inputs, so regeneration is correction-aware.
+
+```
+while True:
+    result = predict(..., previous_result=prev, feedback=feedback)
+    feedback, ok = ui.review_answer(label, result)
+    if ok: return result
+```
+
+## Foundation
+
+- **Clarify idea** (`run_clarify_idea`) — generate clarifying questions +
+  proposed answers; user reviews each; fold Q&A into an `updated_idea`; generate
+  a title if none.
+- **Core premise** (`run_generate_core_premise`) — single field, review loop.
+- **Spine** (`run_generate_spine`) — **Pixar 7-step formula**, one output field
+  per beat: `once_upon_a_time`, `every_day`, `until_one_day`, `because_of_that`,
+  `and_because_of_that`, `until_finally`, `ever_since_that_day`. Stored as the 7
+  beats joined by newlines (this newline order matters — the act slicer indexes
+  into it).
+- **World bible** (`build_world_bible`) — rules → locations (each enhanced) →
+  timeline → characters (each enhanced). Result is a `WorldBible`.
+- **Sanity check** (`sanity_check`) — LM returns a boolean: are idea / spine /
+  bible consistent? Pipeline A aborts the run if false.
+- **Chapter plan** (`run_generate_chapters_plan`) — N × `PlanEntry`
+  (`chapter_title`, `chapter_beats`).
+
+## Act assignment & spine slicing (`act_hint_for_chapter`)
+
+Maps 1-indexed chapter `i` of `n` onto a 3-act structure so a chapter only ever
+sees spine beats up to and including its own act (prevents later-act
+foreshadowing leaking into early chapters).
+
+1. **Split chapters** ≈ 25 / 50 / 25: `a1 = a3 = ceil(n/4)`, `a2 = n − a1 − a3`,
+   with at least one chapter per act for `n ≥ 3`; special-cased for `n = 2`
+   (1/0/1) and `n = 1` (all act 1).
+2. **Assign act**: `i ≤ a1` → act 1; `i ≤ a1+a2` → act 2; else act 3.
+3. **Slice spine** by beat index — act 1 → beats[:3], act 2 → beats[:5],
+   act 3 → beats[:7] — using the Pixar ordering above. Returns
+   `{act, label, spine_through_act}`.
+
+## Variant A — baseline (`pipeline.py` + `run_enhance_chapter`)
+
+For each chapter: compute the act hint, optionally (≈33% chance) generate a
+"random detail" to enrich the scene, then draft prose from the act-sliced spine
++ world bible + the rolling **story-so-far** summary. After each chapter,
+`run_generate_story_so_far` summarizes the plan-so-far + prior summary + new
+chapter into an updated summary that feeds the next draft. The draft signature
+instructs: treat the bible as reference (don't reuse its phrasing verbatim),
+include a concrete friction beat, end on action not aphorism, vary rhythm,
+respect the current act and don't foreshadow later ones.
+
+## Variant B — world-state (`world_state.py`)
+
+- `WorldState` = clock + characters + locations + plot threads + key objects +
+  recent events.
+- `run_init_world_state` — translate the static bible into the opening snapshot
+  (recent_events empty).
+- `run_advance_world_state` — fold a freshly written chapter into a new state
+  (positions, knowledge, threads, clock, objects; append + condense recent
+  events).
+- `run_draft_chapter_with_state` — draft from bible + current state + act slice;
+  must honour the state and not contradict it. Because the state carries the
+  protagonist's name into chapter 1, B avoids variant A's "unnamed cold open".
+
+## Variant C — module (`story_module.py`)
+
+Builds its own outline and drafts each chapter independently from its outline
+beats + world bible + act-sliced spine. No inter-chapter state → most prose, but
+voice/POV can drift chapter-to-chapter.
+
+## QA suite (`qa.py`) — pure text checks
+
+Parses the artifact by its heading layout. Each check returns `Finding(check,
+severity, message)` with severity `info | warn | fail`.
+
+| Check | Algorithm | Severity |
+|---|---|---|
+| `cross_chapter_phrase_reuse` | 5-gram sets per chapter; report grams appearing in ≥2 chapters (excluding bible grams), top 10 | warn (+info) |
+| `name_drift` | Proper-noun regex over prose; flag forms sharing a canonical character's first token but differing in full form; skips strict prefixes and generic `The/A/An` | warn (+info) |
+| `character_presence` | Each canonical character (from the `### Characters` numbered list, skipping bold-only motivation bullets) must appear by full name or first token | fail (+info) |
+| `chapter_length` | Chapters under `CHAPTER_MIN_WORDS` (80) fail — catches empty/truncated chapters | fail (+info) |
+
+## POV consistency (`pov_check.py`) — LLM-backed
+
+Sends all chapters to the LM, which classifies each chapter's *narration only*
+(ignoring dialogue/letters) as `first_person | third_person | mixed | other`.
+The dominant decisive POV is the mode; chapters that are `mixed`, or decisive
+but disagree with the dominant, are flagged `fail`. Catches drift `name_drift`
+cannot (e.g. ch5 first-person in an otherwise third-person book).
+
+## Prose linter (`story_linter.py`) — LLM-backed find/replace
+
+Given the `### Characters` section + chapter prose, the LM returns verbatim
+find/replace pairs for placeholder references ("the protagonist") and
+misspelled/inconsistent canonical names. `validate` drops pairs whose `find`
+isn't in the prose, are trivial, or duplicate. `apply` rewrites **chapter prose
+only** — the region under `## Final Story` — using word-boundary-aware patterns,
+leaving the bible/plan/spine untouched. Counts are written to a
+`.replacements.json` sidecar.

--- a/docs/05-domain-model.md
+++ b/docs/05-domain-model.md
@@ -1,0 +1,50 @@
+# 05 · Domain Model & Glossary
+
+## Entities
+
+| Entity | Defined in | Fields | Notes |
+|---|---|---|---|
+| `WorldBible` | `story.py` | `story_title`, `rules_of_the_world: list[str]`, `characters: list[str]`, `locations: list[str]`, `timeline: list[str]` | Static canon produced in the foundation phase. Characters/locations are enhanced free-text strings, not structured records. |
+| `PlanEntry` | `story.py` | `chapter_title`, `chapter_beats` | One entry per planned chapter. |
+| `Character` | `story.py` | `name`, `description`, `role`, `relationships: list[str]`, `arc` | A structured character dataclass; the live `WorldBible.characters` currently holds strings rather than these. |
+| `WorldState` | `world_state.py` | `story_clock`, `characters: list[str]`, `locations: list[str]`, `plot_threads: list[str]`, `key_objects: list[str]`, `recent_events: list[str]` | Variant B only. The *mutable* counterpart to the static bible; evolves per chapter. |
+| `Finding` | `qa.py` | `check`, `severity` (`info`/`warn`/`fail`), `message` | One QA observation. |
+| `Replacement` | `story_linter.py` | `find`, `replace`, `reason` | One verbatim prose edit proposed by the linter. |
+| `ChapterPOV` | `pov_check.py` | `chapter`, `pov` (`first_person`/`third_person`/`mixed`/`other`), `note` | One chapter's classified narration POV. |
+| `DSPyConfig` | `dspy_runtime.py` | model / api_key / max_tokens / num_ctx / cache flags / cache_dir | Runtime LM configuration. |
+
+## Relationships
+
+```
+Idea ─┬─▶ CorePremise ─▶ Spine ─▶ WorldBible ─▶ [PlanEntry]
+      │                                              │
+      │                                  ┌───────────┴───────────┐
+      └────────────────────────────────▶│ Chapter prose (×N)    │
+                                         └───────────┬───────────┘
+                          WorldState (B) evolves alongside chapters
+                          Finding / ChapterPOV / Replacement describe finished prose
+```
+
+## Glossary
+
+- **Idea** — the one-line input prompt; refined into an *updated idea* by the
+  clarify step.
+- **Core premise** — the story's central dramatic engine in a few sentences.
+- **Spine** — the narrative arc as the **Pixar 7-step** beats (once upon a
+  time → every day → until one day → because of that → and because of that →
+  until finally → ever since that day).
+- **World bible** — the *static* canon: rules, locations, timeline, characters.
+  Reference material for drafting, not to be quoted verbatim.
+- **World state** — the *mutable* snapshot of where the story stands now
+  (variant B): clock, character/location state, open threads, objects, recent
+  events.
+- **Chapter plan** — ordered list of `{title, beats}` per chapter.
+- **Story so far** — variant A's rolling plain-text summary threaded between
+  chapter drafts.
+- **Act hint / spine slice** — the 3-act mapping for a chapter and the spine
+  beats it is allowed to see (see [04-algorithms.md](04-algorithms.md)).
+- **Variant A / B / C** — baseline / world-state / module drafting strategies.
+- **Finding** — a single QA result with a severity.
+- **Drift** — a name/POV that diverges from the established canon across
+  chapters (name drift = spelling/form; POV drift = narration person).
+- **Artifact** — the incrementally-written output markdown file.

--- a/docs/06-decisions-and-risks.md
+++ b/docs/06-decisions-and-risks.md
@@ -1,0 +1,48 @@
+# 06 · Decisions, Constraints & Risks
+
+## Architecture decisions (ADRs, condensed)
+
+| # | Decision | Why | Trade-off |
+|---|---|---|---|
+| D-1 | **DSPy** as the LLM framework | Typed signatures + structured outputs + provider-agnostic (litellm) + `@observe()` tracing | Couples the codebase to DSPy's parsing; truncated output → `None` is a sharp edge (R-1). |
+| D-2 | **Local-first, Ollama default** | No per-token cost, offline, privacy; fits hobbyist users | Quality ceiling/latency bound by local hardware; big models are slow (~90 min/story). |
+| D-3 | **Pixar 7-step spine** | Cheap, well-known arc skeleton that maps cleanly onto 3 acts | Imposes one story shape; not ideal for every genre. |
+| D-4 | **3-act spine slicing** (`act_hint_for_chapter`) | Stops later-act beats from leaking into early chapters | Heuristic 25/50/25 split; coarse for very short/long books. |
+| D-5 | **Human-in-the-loop review loops** | Author corrects each foundation step before it locks in | Interactive runs need attention; non-interactive runs auto-accept. |
+| D-6 | **Incremental artifact writes** | Interrupted runs keep their work; everything is inspectable | The single markdown file doubles as the data format; QA parsers are coupled to its heading layout. |
+| D-7 | **Three drafting variants kept in parallel** | Lets us compare continuity strategies empirically (the bake-off) | Triplicated drafting code/entry points to maintain. |
+| D-8 | **Separate post-generation QA** (text + LLM checks) | Catch the common failure modes without changing the generator | QA only flags; nothing auto-acts on findings yet. |
+
+## Constraints
+
+- Must run fully offline against local Ollama (`http://localhost:11434`).
+- Output is a single markdown file in the layout in
+  [03-architecture.md](03-architecture.md); tools depend on it.
+- Spine is exactly 7 newline-separated beats in Pixar order (the slicer indexes
+  positions 3 and 5).
+- Code conventions in `AGENTS.md` are mandatory (≤50-line functions, typed,
+  UI/business-logic separation).
+
+## Assumptions
+
+- The configured model can follow structured-output instructions reasonably.
+- The chosen `--max-tokens` / `--num-ctx` leave headroom for the model's
+  verbosity (the recommended quality config is `qwen3.6:27b`, `--num-ctx 24576`,
+  `--max-tokens 8192`).
+- The protagonist's name reliably appears by chapter 2 (used by the linter fix).
+
+## Risk register
+
+Full detail and priority order: [pipeline-known-issues.md](pipeline-known-issues.md);
+action plan: [handoff-pipeline-fixes.md](handoff-pipeline-fixes.md).
+
+| # | Risk | Impact | Mitigation / status |
+|---|---|---|---|
+| R-1 | Truncated/`None` LM output crashes the whole run (no retry/guard) | A 90-min run dies at chapter 6 | **Open, highest priority.** Workaround: `--max-tokens 8192`. Real fix: raise default + retry + `None`-guard + checkpoint/resume. |
+| R-2 | Chapter-1 cold open has no protagonist name (variant A/C) | Literal "the protagonist"/"the child" in prose | Linter (`story_linter.py`) patches it; cleaner fix: name in foundation / feed into ch1 (as B does). |
+| R-3 | Model-tic phrase repetition leaks across chapters | Lower prose quality | QA flags it; no anti-repetition feedback into the drafter yet. |
+| R-4 | QA false positives (`character_presence` bold-bullet parse, `name_drift` paraphrases) | Spurious fails erode trust | Partly addressed (bold-only bullets skipped, drift is `warn`). |
+| R-5 | POV / pronoun drift across chapters (esp. variant C) | Inconsistent narration | `pov_check.py` added; not folded into the main QA run. |
+| R-6 | No character-name uniqueness check in the bible | Two characters share a name (seen with `deepseek-v4-pro`) | **Open.** Add a foundation-stage uniqueness check. |
+| R-7 | Variant A can duplicate/loop late beats (summary-only continuity) | Repeated climax across ch5–7 | **Open.** Feed prior chapter's closing beats as "already happened"; or adjacent-chapter overlap check. |
+| R-8 | QA parsers coupled to the markdown heading layout | A layout change silently breaks checks | Keep artifact format stable; covered by tests. |

--- a/docs/07-acceptance-and-quality.md
+++ b/docs/07-acceptance-and-quality.md
@@ -1,0 +1,63 @@
+# 07 · Acceptance Criteria & Quality Strategy
+
+How we decide a run — and the system — is good enough.
+
+## Definition of done (one story run)
+
+A run on the recommended config is acceptable when:
+
+1. It **completes without crashing** and writes all artifact sections.
+2. It produces **N non-empty chapters** (none below the length floor, 80 words).
+3. The **protagonist is named** in chapter 1 (no "the protagonist"/"the child"
+   placeholders left in prose).
+4. The story has a **real ending** (the spine's final beats are dramatized, not
+   gestured at).
+5. The **QA suite reports no real fails** (parser-artifact fails don't count).
+6. **Narration POV is consistent** across chapters (no unexplained drift).
+
+## QA gates (automated)
+
+Run after generation:
+
+```bash
+python scripts/run_qa.py path/to/story.md      # phrase reuse, name drift, presence, length
+python scripts/check_pov.py path/to/story.md    # LLM POV consistency
+python scripts/lint_story.py path/to/story.md   # placeholder/misspelling fixes (writes sidecar)
+python scripts/word_count.py path/to/story.md   # top repeated content words
+```
+
+| Gate | Source | Pass condition |
+|---|---|---|
+| Chapter length | `qa.check_chapter_length` | every chapter ≥ 80 words |
+| Character presence | `qa.check_character_presence` | every canonical character appears in prose |
+| Name drift | `qa.check_name_drift` | no real misspelled-name variants (warn-level) |
+| Phrase reuse | `qa.check_cross_chapter_phrase_reuse` | repeated-5-gram count low (warn-level) |
+| POV consistency | `pov_check` | no `mixed` chapter; none disagreeing with the dominant POV |
+
+Severity meaning: `fail` = must fix, `warn` = inspect, `info` = context.
+
+## Read-through rubric (human, 1–5 each)
+
+From the bake-off methodology — score every run on:
+**continuity · coherence · structure · prose · plot-thread tracking.**
+Used to compare models/variants beyond what automated QA can see (see
+[model-implementation-comparison-2026-05-10.md](model-implementation-comparison-2026-05-10.md)).
+
+## Test strategy (code)
+
+- **Framework:** `pytest` (`pytest -q`). CI runs in `.github/workflows/ci.yml`.
+- **LLM isolation:** unit tests configure a `MockLM` and assert on parsed
+  outputs / Pydantic validation rather than calling a real model.
+- **Coverage today:** `test_qa.py`, `test_pov_check.py`, `test_story_linter.py`,
+  `test_story_module.py`, `test_world_state.py`. New checks/algorithms should
+  ship with tests mirroring this pattern.
+- **Static quality:** `ruff` (lint + format), and optionally `pylint` / `radon`
+  / `vulture` per `AGENTS.md`.
+
+## Model bake-off (release-level validation)
+
+Before changing the default model/variant, re-run the matrix (models × variants)
+on a fixed idea/title/chapter count and compare: completion/robustness, prose
+word counts, repeated-5-gram counts, real QA fails, and the read-through rubric.
+Driver and raw outputs live under `.tmp/cmp/` (gitignored); methodology and the
+last results are in the comparison doc above.


### PR DESCRIPTION
Add the pre-implementation document set that sits upstream of the
implementation plan: vision/brief, requirements (PRD + functional +
non-functional), architecture, algorithms, domain model/glossary,
decisions & risks, and acceptance/quality strategy. Grounded in the
current pipeline, QA, and bake-off; indexed by docs/00-overview.md and
cross-linked to the existing known-issues/handoff backlog.

https://claude.ai/code/session_01LTctrPPopJMKMLDpeNfw1o