### PR TITLE
feat(bench): unified scorecard + executable Definition of Done

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,10 @@ python scripts/optimize_text_pipeline.py \
 
 ### Benchmark Harness (Goal Function)
 ```bash
-python -m bench.criteria .tmp/story.md     # Tier-1 deterministic scorecard against bench/eval-spec.md
+python scripts/evaluate.py .tmp/story.md             # unified scorecard (Tier-1; no model)
+python scripts/evaluate.py .tmp/story.md --with-llm   # + Tier-2 POV / prose lint (needs DSPy)
+python -m bench.evaluate .tmp/story.md               # Tier-1 JSON only, no dspy import
+python -m bench.criteria .tmp/story.md               # Tier-1 deterministic scorecard
 ```
 Full multi-fixture / multi-generator harness lives in `bench/` (in progress).
 
@@ -310,14 +313,15 @@ def test_specific_function():
 
 **Goal function & benchmark:**
 - `bench/eval-spec.md` — Tier-1/2/3 evaluation spec (the objective function).
-- `bench/criteria.py` — Tier-1 deterministic runner; wraps `qa.run_all` with the spec's 300-word floor + budgets.
+- `bench/criteria.py` — Tier-1 deterministic runner; wraps `qa.run_all` + the structure/placeholder/word-band checks with the spec's soft budgets (length thresholds live in `qa.py`).
+- `bench/evaluate.py` — the **unified scorecard** (executable Definition of Done): Tier-1 + the LLM-backed Tier-2 POV / prose-lint gates → one JSON `FullScorecard` with `ship` / `complete`.
 - `bench/rubric.md` — Tier-3 qualitative rubric.
 
 **Post-generation analysis:**
-- `qa.py` — name-drift, character-presence, chapter-length, cross-chapter 5-gram phrase reuse, content-word over-repetition.
+- `qa.py` — deterministic checks: chapter-length (+ word-band), character-presence, name-drift, cross-chapter 5-gram phrase reuse, structural completeness, protagonist-placeholder.
 - `pov_check.py` — LLM-judged POV consistency.
 - `story_linter.py` — placeholder/canonical-name lint pass.
-- `scripts/` — CLI wrappers (`run_qa.py`, `check_pov.py`, `lint_story.py`, `word_count.py`, `render_story.py`, `optimize_text_pipeline.py`, `fetch_langfuse_traces.py`).
+- `scripts/` — CLI wrappers (`evaluate.py` [unified scorecard], `run_qa.py`, `check_pov.py`, `lint_story.py`, `word_count.py`, `render_story.py`, `optimize_text_pipeline.py`, `fetch_langfuse_traces.py`).
 
 **Tests** (`tests/`):
 - `tests/test_registry.py` — registry/protocol contract (no LLM).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,7 +314,8 @@ def test_specific_function():
 **Goal function & benchmark:**
 - `bench/eval-spec.md` — Tier-1/2/3 evaluation spec (the objective function).
 - `bench/criteria.py` — Tier-1 deterministic runner; wraps `qa.run_all` + the structure/placeholder/word-band checks with the spec's soft budgets (length thresholds live in `qa.py`).
-- `bench/evaluate.py` — the **unified scorecard** (executable Definition of Done): Tier-1 + the LLM-backed Tier-2 POV / prose-lint gates → one JSON `FullScorecard` with `ship` / `complete`.
+- `bench/judge.py` — LLM Tier-2/3 judges: continuity/contradictions (T2.3), premise fidelity (T2.4), and the six-axis rubric. `check_*` functions accept injected verdicts (testable without a model).
+- `bench/evaluate.py` — the **unified scorecard** (executable Definition of Done): Tier-1 + the LLM-backed Tier-2/3 judges → one JSON `FullScorecard` with `ship` / `complete`. Judge config/injection via `JudgeInputs`.
 - `bench/rubric.md` — Tier-3 qualitative rubric.
 
 **Post-generation analysis:**

--- a/bench/README.md
+++ b/bench/README.md
@@ -15,15 +15,16 @@ checks + Tier-3 qualitative rubric) lives in [`eval-spec.md`](eval-spec.md).
 | `eval-spec.md` | The spec — what "good" means. Source of truth. |
 | `rubric.md` | Tier-3 qualitative axes for the LLM judge. |
 | `criteria.py` | Tier-1 deterministic runner (wraps `qa.py`); emits a JSON `Scorecard`. |
+| `evaluate.py` | **Unified scorecard** for one draft: Tier-1 + LLM Tier-2 (POV + prose lint) → a `FullScorecard` with `ship`/`complete`. The executable Definition of Done. |
 | `fixtures/` | Idea fixtures: one JSON per (title, idea, chapter count, niche). |
 | `run.py` | Drives `(fixture × strategy)` end-to-end against your configured LLM. |
 | `score.py` | Walks a run directory, applies `criteria.py`, writes `results.md`. |
 
-Tier-2 / Tier-3 LLM-judge implementations are stubs — the harness today
-scores deterministic gates only. The Tier-1 budgets (chapter length,
-character presence, name drift, phrase reuse) catch the most common
-failure modes well enough to start ranking. The judge wiring is the
-next obvious extension.
+`criteria.py` / `score.py` stay **deterministic-only** — they rank many
+stories fast without a model. `evaluate.py` is the **single-draft, full-DoD**
+verdict: it adds the Tier-2 POV check (`pov_check.py`) and the advisory prose
+linter (`story_linter.py`). T2.3 continuity, T2.4 premise fidelity, and the
+Tier-3 rubric are still stubs — that judge wiring is the next extension.
 
 ## Quickstart
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -15,16 +15,19 @@ checks + Tier-3 qualitative rubric) lives in [`eval-spec.md`](eval-spec.md).
 | `eval-spec.md` | The spec — what "good" means. Source of truth. |
 | `rubric.md` | Tier-3 qualitative axes for the LLM judge. |
 | `criteria.py` | Tier-1 deterministic runner (wraps `qa.py`); emits a JSON `Scorecard`. |
-| `evaluate.py` | **Unified scorecard** for one draft: Tier-1 + LLM Tier-2 (POV + prose lint) → a `FullScorecard` with `ship`/`complete`. The executable Definition of Done. |
+| `judge.py` | LLM Tier-2/3 judges: continuity (T2.3), premise fidelity (T2.4), and the six-axis rubric. Pure logic + `check_*` functions that accept injected verdicts. |
+| `evaluate.py` | **Unified scorecard** for one draft: Tier-1 + the Tier-2/3 judges → a `FullScorecard` with `ship`/`complete`. The executable Definition of Done. |
 | `fixtures/` | Idea fixtures: one JSON per (title, idea, chapter count, niche). |
 | `run.py` | Drives `(fixture × strategy)` end-to-end against your configured LLM. |
 | `score.py` | Walks a run directory, applies `criteria.py`, writes `results.md`. |
 
 `criteria.py` / `score.py` stay **deterministic-only** — they rank many
 stories fast without a model. `evaluate.py` is the **single-draft, full-DoD**
-verdict: it adds the Tier-2 POV check (`pov_check.py`) and the advisory prose
-linter (`story_linter.py`). T2.3 continuity, T2.4 premise fidelity, and the
-Tier-3 rubric are still stubs — that judge wiring is the next extension.
+verdict: it adds the Tier-2 POV check (`pov_check.py`), the continuity /
+premise-fidelity judges and the Tier-3 rubric (`bench/judge.py`), and the
+advisory prose linter (`story_linter.py`). Run it with
+`scripts/evaluate.py --with-llm --idea "..."`. Remaining judge work:
+per-axis rubric decomposition and calibrating the judge against human scores.
 
 ## Quickstart
 

--- a/bench/criteria.py
+++ b/bench/criteria.py
@@ -1,13 +1,14 @@
 """Deterministic Tier-1 checks from bench/eval-spec.md.
 
-Thin wrapper over the existing `qa.py` and `pov_check.py` modules — those
-already implement the same algorithms (chapter length, character presence,
-name drift, cross-chapter phrase reuse, POV classification). This module
-applies the spec's thresholds (hard floor 300 words vs qa.py's runtime
-default 80, 5-gram budget of 5, etc.) and emits a scorecard.
+Thin wrapper over the deterministic checks in `qa.py` (chapter length + word
+band, character presence, name drift, cross-chapter phrase reuse, structural
+completeness, protagonist-placeholder). The length thresholds live in `qa.py`
+(the single source of truth): a hard floor of 80 words FAILs as broken, and
+the 300–2500 target band WARNs as thin/bloated. This module bundles those into
+a scorecard with the spec's soft budgets.
 
-Tier-2/Tier-3 LLM-judge checks are out of scope here — they'll plug in
-later via a `bench/judge.py` once the prompt + judge model are chosen.
+The LLM-backed gates (Tier-2 POV / prose lint, Tier-3 rubric) are out of scope
+here. `bench/evaluate.py` is the unified scorecard that adds them.
 """
 from __future__ import annotations
 
@@ -17,9 +18,8 @@ from pathlib import Path
 
 import qa
 
-# Thresholds from bench/eval-spec.md
-HARD_CHAPTER_FLOOR = 300         # T1.1 gate
-TARGET_CHAPTER_BAND = (800, 2500)  # T1.1 warn outside (not yet enforced)
+# Soft budgets from bench/eval-spec.md (T1.3 / T1.4). Length thresholds are
+# qa.CHAPTER_MIN_WORDS (hard floor) and qa.CHAPTER_TARGET_BAND (warn band).
 NAME_DRIFT_BUDGET = 2            # T1.3
 PHRASE_REUSE_BUDGET = 5          # T1.4
 
@@ -42,10 +42,13 @@ def score(story_md_path: Path) -> Scorecard:
     Returns a Scorecard with separated FAILs and WARNs plus per-budget
     counts. `ship=True` only if zero Tier-1 FAILs and every budget respected.
     """
-    findings = qa.run_all(story_md_path)
-    # T1.1 in qa.py uses default min_words=80; re-run with spec floor of 300
+    # run_all covers length (hard floor 80), presence, drift, phrase reuse.
+    # The remaining deterministic gates from the spec are added explicitly.
     text = Path(story_md_path).read_text(encoding="utf-8")
-    findings.extend(qa.check_chapter_length(text, min_words=HARD_CHAPTER_FLOOR))
+    findings = qa.run_all(story_md_path)
+    findings.extend(qa.check_structure(text))
+    findings.extend(qa.check_placeholder_protagonist(text))
+    findings.extend(qa.check_chapter_band(text))
 
     fails: list[dict] = []
     warns: list[dict] = []
@@ -54,9 +57,10 @@ def score(story_md_path: Path) -> Scorecard:
 
     for f in findings:
         record = {"check": f.check, "severity": f.severity, "message": f.message}
-        if f.check == "name_drift":
+        # Count only real (warn-level) budget hits, not the "no drift" info line.
+        if f.check == "name_drift" and f.severity == "warn":
             drift_count += 1
-        if f.check == "cross_chapter_phrase_reuse":
+        if f.check == "cross_chapter_phrase_reuse" and f.severity == "warn":
             reuse_count += 1
         if f.severity == "fail":
             fails.append(record)

--- a/bench/eval-spec.md
+++ b/bench/eval-spec.md
@@ -44,13 +44,16 @@ surrounding `*`/`_` emphasis stripped (`**Cinder**, a runaway` → `Cinder`).
 
 Fast, free, reproducible. These are gates: a `FAIL` here blocks shipping.
 
-### T1.1 Chapter length — `FAIL`
-Every chapter's prose must be at least a hard floor and should fall in a
-target band.
-- **Hard floor (gate): 300 words.** Below this the chapter is empty/truncated.
-- **Target band (warn outside): 800–2500 words.** Thin ~250-word chapters
-  are the classic fast-model failure; bloated >3000-word chapters usually
-  mean the outline collapsed into one chapter.
+### T1.1 Chapter length — `FAIL` (floor) / `WARN` (band)
+Every chapter's prose must clear a hard floor and should fall in a target band.
+- **Hard floor (gate, `FAIL`): 80 words.** Below this the chapter is
+  empty/truncated/broken. (Source of truth: `qa.CHAPTER_MIN_WORDS`.)
+- **Target band (`WARN` outside): 300–2500 words.** (`qa.CHAPTER_TARGET_BAND`.)
+  Thin `<300`-word chapters are the classic fast-model output; bloated
+  `>2500` chapters usually mean the outline collapsed into one chapter. These
+  warn but do **not** block shipping — `qwen3:latest` writes ~250-word
+  chapters and is a supported smoke model, so "thin" is a quality signal, not
+  "broken". Tighten the band per project if you want a stricter quality bar.
 
 ### T1.2 Character presence — `FAIL`
 Every canonical character must appear in the manuscript prose at least once.
@@ -87,6 +90,13 @@ Heuristics can't read. Use the local Ollama model as the judge first;
 only escalate to the hosted fallback if the local judge gives
 unstable/garbled verdicts. Always feed the judge the *narration only*
 instruction so quoted dialogue doesn't confound it.
+
+> **Status.** `bench/evaluate.py` (CLI: `scripts/evaluate.py --with-llm`)
+> wires **T2.1 POV consistency** (via `pov_check.py`) and the advisory prose
+> linter (via `story_linter.py`). The *literal* half of **T2.2** (the bare
+> word "protagonist" in prose) is caught deterministically in Tier-1
+> (`qa.check_placeholder_protagonist`); the subtler naming cases plus **T2.3
+> continuity** and **T2.4 premise fidelity** are not implemented yet.
 
 ### T2.1 POV / narrator consistency — `FAIL` on within-chapter shift
 Ask the judge to classify each chapter's **dominant narration POV** —
@@ -142,6 +152,14 @@ A draft is shippable iff **all** hold:
 
 Emit one machine-readable scorecard per draft (JSON: each check → severity
 + message, plus rubric scores and a final `ship: true|false`).
+
+> **Implemented today** (`bench/evaluate.py`): the Tier-1 gates + budgets,
+> Tier-2 POV (T2.1), and the advisory linter. The scorecard reports `ship`
+> over the *automated* gates plus a `complete` flag (false until every
+> required gate runs) — so a deterministic-only pass reports
+> `tier1_clean=true, complete=false, ship=false`. T2.3/T2.4 and the full
+> Tier-3 rubric are pending; "real ending" is surfaced as a `manual` check
+> until the Tier-3 judge lands.
 
 ---
 

--- a/bench/eval-spec.md
+++ b/bench/eval-spec.md
@@ -12,7 +12,8 @@ and signature phrases repeated in every chapter. Each one exists because a
 model actually shipped that defect.
 
 This file is the source of truth that `bench/criteria.py` (deterministic
-Tier-1 checks) and the (still-stubbed) LLM judge for Tier-2/3 implement.
+Tier-1 checks) and `bench/judge.py` (the Tier-2/3 LLM judges) implement, wired
+together by `bench/evaluate.py`.
 
 ---
 
@@ -92,11 +93,12 @@ unstable/garbled verdicts. Always feed the judge the *narration only*
 instruction so quoted dialogue doesn't confound it.
 
 > **Status.** `bench/evaluate.py` (CLI: `scripts/evaluate.py --with-llm`)
-> wires **T2.1 POV consistency** (via `pov_check.py`) and the advisory prose
-> linter (via `story_linter.py`). The *literal* half of **T2.2** (the bare
-> word "protagonist" in prose) is caught deterministically in Tier-1
-> (`qa.check_placeholder_protagonist`); the subtler naming cases plus **T2.3
-> continuity** and **T2.4 premise fidelity** are not implemented yet.
+> wires **T2.1 POV consistency** (via `pov_check.py`), **T2.3 continuity** and
+> **T2.4 premise fidelity** (via `bench/judge.py`), and the advisory prose
+> linter (via `story_linter.py`). The *literal* half of **T2.2** (the bare word
+> "protagonist" in prose) is caught deterministically in Tier-1
+> (`qa.check_placeholder_protagonist`); the subtler T2.2 naming cases are
+> handled by the linter. Premise fidelity needs the original idea (`--idea`).
 
 ### T2.1 POV / narrator consistency — `FAIL` on within-chapter shift
 Ask the judge to classify each chapter's **dominant narration POV** —
@@ -153,13 +155,14 @@ A draft is shippable iff **all** hold:
 Emit one machine-readable scorecard per draft (JSON: each check → severity
 + message, plus rubric scores and a final `ship: true|false`).
 
-> **Implemented today** (`bench/evaluate.py`): the Tier-1 gates + budgets,
-> Tier-2 POV (T2.1), and the advisory linter. The scorecard reports `ship`
-> over the *automated* gates plus a `complete` flag (false until every
-> required gate runs) — so a deterministic-only pass reports
-> `tier1_clean=true, complete=false, ship=false`. T2.3/T2.4 and the full
-> Tier-3 rubric are pending; "real ending" is surfaced as a `manual` check
-> until the Tier-3 judge lands.
+> **Implemented today** (`bench/evaluate.py`): the Tier-1 gates + budgets, the
+> Tier-2 judges (POV, continuity, premise fidelity) + the advisory linter, and
+> the Tier-3 six-axis rubric. The scorecard reports `ship` over the evaluated
+> gates plus a `complete` flag (false until every required gate runs) — so a
+> deterministic-only pass reports `tier1_clean=true, complete=false,
+> ship=false`. "Real ending" is judged by the rubric when it runs (a `manual`
+> check otherwise). Remaining: per-axis rubric decomposition and judge
+> calibration against human scores.
 
 ---
 

--- a/bench/evaluate.py
+++ b/bench/evaluate.py
@@ -1,0 +1,246 @@
+"""Unified story scorecard — the executable Definition of Done.
+
+Composes the deterministic Tier-1 checks (:mod:`qa`) with the LLM-backed
+Tier-2 checks (:mod:`pov_check` POV consistency and :mod:`story_linter`
+placeholder/name lint, run in detection mode) into a single machine-readable
+scorecard per draft, per ``bench/eval-spec.md``.
+
+Tier-1 runs with no model. Tier-2 needs a configured DSPy LM: pass
+``run_llm=True`` (the ``scripts/evaluate.py --with-llm`` path) or inject
+precomputed results (used by tests). A draft only reports ``ship=True`` when
+every evaluated gate is clean *and* every required gate actually ran
+(``complete=True``) — a deterministic-only pass reports ``tier1_clean=True``
+but ``ship=False`` because POV could not be checked.
+
+Tier-3 (the qualitative rubric) is not implemented yet; the "real ending"
+Definition-of-Done item is reported as a ``manual`` check until it lands.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+import qa
+from qa import Finding
+
+PASS, FAIL, WARN, SKIPPED, MANUAL = "pass", "fail", "warn", "skipped", "manual"
+
+# Soft budgets from bench/eval-spec.md (T1.3 / T1.4).
+NAME_DRIFT_BUDGET = 2
+PHRASE_REUSE_BUDGET = 5
+
+# Tier-1 deterministic gates, in report order.
+TIER1_GATES = (
+    "structure",
+    "chapter_length",
+    "chapter_band",
+    "placeholder_protagonist",
+    "character_presence",
+    "name_drift",
+    "cross_chapter_phrase_reuse",
+)
+
+_REAL_ENDING_MANUAL = (
+    "Real ending dramatizes the spine's final beats (Tier-3 judge / human read)"
+)
+
+
+@dataclass
+class Gate:
+    """One evaluated gate: its tier, status, and any fail/warn messages."""
+
+    gate: str
+    tier: int
+    status: str  # pass | fail | warn | skipped
+    messages: list[str] = field(default_factory=list)
+
+
+@dataclass
+class FullScorecard:
+    """The unified verdict for one draft."""
+
+    ship: bool
+    complete: bool
+    tier1_clean: bool
+    gates: list[Gate]
+    budgets: dict[str, dict]
+    definition_of_done: list[dict]
+    manual_checks: list[str]
+    not_evaluated: list[str]
+    fails: list[dict]
+    warns: list[dict]
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), indent=2)
+
+
+def _gate_from_findings(name: str, tier: int, findings: list[Finding]) -> Gate:
+    """Collapse the findings for one check into a single gate status."""
+    relevant = [f for f in findings if f.check == name]
+    if any(f.severity == "fail" for f in relevant):
+        status = FAIL
+    elif any(f.severity == "warn" for f in relevant):
+        status = WARN
+    else:
+        status = PASS
+    messages = [f.message for f in relevant if f.severity in ("fail", "warn")]
+    return Gate(gate=name, tier=tier, status=status, messages=messages)
+
+
+def _tier1_findings(text: str) -> list[Finding]:
+    """Run every deterministic check that backs a Tier-1 gate."""
+    return [
+        *qa.check_structure(text),
+        *qa.check_chapter_length(text),
+        *qa.check_chapter_band(text),
+        *qa.check_placeholder_protagonist(text),
+        *qa.check_character_presence(text),
+        *qa.check_name_drift(text),
+        *qa.check_cross_chapter_phrase_reuse(text),
+    ]
+
+
+def _budgets(findings: list[Finding]) -> dict[str, dict]:
+    """Count warn-level drift / reuse findings against their soft budgets."""
+    drift = sum(
+        1 for f in findings if f.check == "name_drift" and f.severity == "warn"
+    )
+    reuse = sum(
+        1
+        for f in findings
+        if f.check == "cross_chapter_phrase_reuse" and f.severity == "warn"
+    )
+    return {
+        "name_drift": {
+            "count": drift, "budget": NAME_DRIFT_BUDGET, "over": drift > NAME_DRIFT_BUDGET,
+        },
+        "phrase_reuse": {
+            "count": reuse, "budget": PHRASE_REUSE_BUDGET, "over": reuse > PHRASE_REUSE_BUDGET,
+        },
+    }
+
+
+def _pov_gate(
+    chapters: dict[str, str],
+    pov_classifications: list | None,
+    run_llm: bool,
+) -> Gate:
+    """Tier-2 POV consistency, or a skipped gate when no model is available."""
+    if pov_classifications is None and not run_llm:
+        return Gate("pov_consistency", 2, SKIPPED, ["needs a model (run with --with-llm)"])
+    import pov_check
+
+    findings = pov_check.check_pov_consistency(chapters, pov_classifications)
+    return _gate_from_findings("pov_consistency", 2, findings)
+
+
+def _linter_gate(
+    text: str,
+    linter_replacements: list | None,
+    run_llm: bool,
+) -> Gate:
+    """Tier-2 prose lint in *detection* mode — advisory (warn), never mutating."""
+    if linter_replacements is None and not run_llm:
+        return Gate("prose_linter", 2, SKIPPED, ["needs a model (run with --with-llm)"])
+    replacements = linter_replacements
+    if replacements is None:
+        import story_linter
+
+        proposed = story_linter.lint(text)
+        _, joined = story_linter._extract_inputs(text)
+        replacements = story_linter.validate(proposed, joined)
+    if not replacements:
+        return Gate("prose_linter", 2, PASS, [])
+    messages = [
+        f"{r.find!r} -> {r.replace!r}" + (f" ({r.reason})" if r.reason else "")
+        for r in replacements
+    ]
+    return Gate("prose_linter", 2, WARN, messages)
+
+
+def _definition_of_done(by_name: dict[str, Gate], tier1_clean: bool) -> list[dict]:
+    """Map docs/07 Definition-of-Done items onto the gates that enforce them."""
+
+    def status(name: str) -> str:
+        gate = by_name.get(name)
+        return gate.status if gate is not None else SKIPPED
+
+    return [
+        {"item": "All required sections present", "status": status("structure"), "gate": "structure"},
+        {"item": "N non-empty chapters (>= hard floor)", "status": status("chapter_length"), "gate": "chapter_length"},
+        {"item": "Protagonist named in prose (no placeholders)", "status": status("placeholder_protagonist"), "gate": "placeholder_protagonist"},
+        {"item": "Real ending dramatizes the spine's final beats", "status": MANUAL, "gate": None},
+        {"item": "No real QA fails", "status": PASS if tier1_clean else FAIL, "gate": "tier1"},
+        {"item": "POV consistent across chapters", "status": status("pov_consistency"), "gate": "pov_consistency"},
+    ]
+
+
+def evaluate(
+    text: str,
+    *,
+    pov_classifications: list | None = None,
+    linter_replacements: list | None = None,
+    run_llm: bool = False,
+) -> FullScorecard:
+    """Score one story markdown string against the full Definition of Done.
+
+    ``pov_classifications`` / ``linter_replacements`` inject precomputed Tier-2
+    results (tests pass these to avoid an LM). When both are ``None`` and
+    ``run_llm`` is ``False``, the Tier-2 gates report ``skipped``.
+    """
+    chapters = qa.split_chapters(text)
+    findings = _tier1_findings(text)
+    gates = [_gate_from_findings(name, 1, findings) for name in TIER1_GATES]
+    gates.append(_pov_gate(chapters, pov_classifications, run_llm))
+    gates.append(_linter_gate(text, linter_replacements, run_llm))
+    return _summarize(gates, _budgets(findings))
+
+
+def _summarize(gates: list[Gate], budgets: dict[str, dict]) -> FullScorecard:
+    """Derive the ship / complete / tier1 verdict from the evaluated gates."""
+    over_budget = any(b["over"] for b in budgets.values())
+    fails = [_row(g) for g in gates if g.status == FAIL]
+    warns = [_row(g) for g in gates if g.status == WARN]
+    not_evaluated = [g.gate for g in gates if g.status == SKIPPED]
+    tier1_clean = not any(g.status == FAIL for g in gates if g.tier == 1) and not over_budget
+    complete = not not_evaluated
+    return FullScorecard(
+        ship=not fails and not over_budget and complete,
+        complete=complete,
+        tier1_clean=tier1_clean,
+        gates=gates,
+        budgets=budgets,
+        definition_of_done=_definition_of_done({g.gate: g for g in gates}, tier1_clean),
+        manual_checks=[_REAL_ENDING_MANUAL],
+        not_evaluated=not_evaluated,
+        fails=fails,
+        warns=warns,
+    )
+
+
+def _row(gate: Gate) -> dict:
+    return {"gate": gate.gate, "tier": gate.tier, "messages": gate.messages}
+
+
+def evaluate_path(path: Path, **kwargs) -> FullScorecard:
+    """Read a story markdown file and evaluate it. See :func:`evaluate`."""
+    return evaluate(Path(path).read_text(encoding="utf-8"), **kwargs)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Deterministic (Tier-1) scorecard CLI. For Tier-2 use scripts/evaluate.py."""
+    parser = argparse.ArgumentParser(
+        description="Deterministic Tier-1 story scorecard. "
+        "For the LLM-backed Tier-2 gates run scripts/evaluate.py --with-llm.",
+    )
+    parser.add_argument("story", type=Path, help="story markdown file")
+    args = parser.parse_args(argv)
+    card = evaluate_path(args.story)
+    print(card.to_json())
+    return 0 if card.tier1_clean else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/evaluate.py
+++ b/bench/evaluate.py
@@ -1,19 +1,23 @@
 """Unified story scorecard — the executable Definition of Done.
 
 Composes the deterministic Tier-1 checks (:mod:`qa`) with the LLM-backed
-Tier-2 checks (:mod:`pov_check` POV consistency and :mod:`story_linter`
-placeholder/name lint, run in detection mode) into a single machine-readable
-scorecard per draft, per ``bench/eval-spec.md``.
+Tier-2 / Tier-3 judges into a single machine-readable scorecard per draft, per
+``bench/eval-spec.md``:
 
-Tier-1 runs with no model. Tier-2 needs a configured DSPy LM: pass
-``run_llm=True`` (the ``scripts/evaluate.py --with-llm`` path) or inject
+- Tier-2: POV consistency (:mod:`pov_check`), prose lint (:mod:`story_linter`,
+  detection mode), continuity / contradictions and premise fidelity
+  (:mod:`bench.judge`).
+- Tier-3: the six-axis qualitative rubric (:mod:`bench.judge`).
+
+Tier-1 runs with no model. The LLM gates need a configured DSPy LM: set
+``JudgeInputs.run_llm`` (the ``scripts/evaluate.py --with-llm`` path) or inject
 precomputed results (used by tests). A draft only reports ``ship=True`` when
 every evaluated gate is clean *and* every required gate actually ran
 (``complete=True``) — a deterministic-only pass reports ``tier1_clean=True``
-but ``ship=False`` because POV could not be checked.
+but ``ship=False`` because the judges could not run.
 
-Tier-3 (the qualitative rubric) is not implemented yet; the "real ending"
-Definition-of-Done item is reported as a ``manual`` check until it lands.
+When the rubric runs, the "real ending" Definition-of-Done item is judged by
+it; otherwise that item is reported as a ``manual`` check.
 """
 from __future__ import annotations
 
@@ -42,9 +46,25 @@ TIER1_GATES = (
     "cross_chapter_phrase_reuse",
 )
 
-_REAL_ENDING_MANUAL = (
-    "Real ending dramatizes the spine's final beats (Tier-3 judge / human read)"
-)
+
+@dataclass
+class JudgeInputs:
+    """Configuration + injection seams for the LLM-backed gates.
+
+    ``run_llm`` turns the Tier-2/3 judges on; ``idea`` is required for the
+    premise-fidelity gate. The ``*_classifications`` / ``*_replacements`` /
+    ``contradictions`` / ``premise_verdict`` / ``rubric_scores`` fields inject
+    precomputed results so tests (and cached runs) can skip the model.
+    """
+
+    idea: str | None = None
+    run_llm: bool = False
+    rubric_samples: int = 1
+    pov_classifications: list | None = None
+    linter_replacements: list | None = None
+    contradictions: list | None = None
+    premise_verdict: object | None = None
+    rubric_scores: list | None = None
 
 
 @dataclass
@@ -160,6 +180,53 @@ def _linter_gate(
     return Gate("prose_linter", 2, WARN, messages)
 
 
+def _continuity_gate(
+    chapters: dict[str, str],
+    cast: str,
+    contradictions: list | None,
+    run_llm: bool,
+) -> Gate:
+    """Tier-2 continuity / contradiction judge."""
+    if contradictions is None and not run_llm:
+        return Gate("continuity", 2, SKIPPED, ["needs a model (run with --with-llm)"])
+    import bench.judge as judge
+
+    findings = judge.check_continuity(chapters, cast, contradictions)
+    return _gate_from_findings("continuity", 2, findings)
+
+
+def _premise_gate(
+    idea: str | None,
+    chapters: dict[str, str],
+    verdict: object | None,
+    run_llm: bool,
+) -> Gate:
+    """Tier-2 premise-fidelity judge (needs the original idea)."""
+    if verdict is None and not run_llm:
+        return Gate("premise_fidelity", 2, SKIPPED, ["needs a model (run with --with-llm)"])
+    if verdict is None and not idea:
+        return Gate("premise_fidelity", 2, SKIPPED, ["needs the original idea (pass --idea)"])
+    import bench.judge as judge
+
+    findings = judge.check_premise_fidelity(idea or "", chapters, verdict)
+    return _gate_from_findings("premise_fidelity", 2, findings)
+
+
+def _rubric_gate(
+    chapters: dict[str, str],
+    scores: list | None,
+    samples: int,
+    run_llm: bool,
+) -> Gate:
+    """Tier-3 six-axis qualitative rubric judge."""
+    if scores is None and not run_llm:
+        return Gate("rubric", 3, SKIPPED, ["needs a model (run with --with-llm)"])
+    import bench.judge as judge
+
+    findings = judge.check_rubric(chapters, scores, samples=samples)
+    return _gate_from_findings("rubric", 3, findings)
+
+
 def _definition_of_done(by_name: dict[str, Gate], tier1_clean: bool) -> list[dict]:
     """Map docs/07 Definition-of-Done items onto the gates that enforce them."""
 
@@ -167,34 +234,38 @@ def _definition_of_done(by_name: dict[str, Gate], tier1_clean: bool) -> list[dic
         gate = by_name.get(name)
         return gate.status if gate is not None else SKIPPED
 
+    # "Real ending" is judged by the Tier-3 rubric when it ran; otherwise manual.
+    rubric = by_name.get("rubric")
+    ending = rubric.status if rubric is not None and rubric.status != SKIPPED else MANUAL
+
     return [
         {"item": "All required sections present", "status": status("structure"), "gate": "structure"},
         {"item": "N non-empty chapters (>= hard floor)", "status": status("chapter_length"), "gate": "chapter_length"},
         {"item": "Protagonist named in prose (no placeholders)", "status": status("placeholder_protagonist"), "gate": "placeholder_protagonist"},
-        {"item": "Real ending dramatizes the spine's final beats", "status": MANUAL, "gate": None},
+        {"item": "Real ending dramatizes the spine's final beats", "status": ending, "gate": "rubric"},
         {"item": "No real QA fails", "status": PASS if tier1_clean else FAIL, "gate": "tier1"},
         {"item": "POV consistent across chapters", "status": status("pov_consistency"), "gate": "pov_consistency"},
+        {"item": "Story dramatizes the premise", "status": status("premise_fidelity"), "gate": "premise_fidelity"},
     ]
 
 
-def evaluate(
-    text: str,
-    *,
-    pov_classifications: list | None = None,
-    linter_replacements: list | None = None,
-    run_llm: bool = False,
-) -> FullScorecard:
+def evaluate(text: str, judge: JudgeInputs | None = None) -> FullScorecard:
     """Score one story markdown string against the full Definition of Done.
 
-    ``pov_classifications`` / ``linter_replacements`` inject precomputed Tier-2
-    results (tests pass these to avoid an LM). When both are ``None`` and
-    ``run_llm`` is ``False``, the Tier-2 gates report ``skipped``.
+    ``judge`` carries the LLM-gate config + injection seams (see
+    :class:`JudgeInputs`). With its defaults (no model, nothing injected) the
+    Tier-2/3 gates report ``skipped`` and only Tier-1 is decided.
     """
+    judge = judge or JudgeInputs()
     chapters = qa.split_chapters(text)
+    cast = qa._section(text, 3, "Characters")
     findings = _tier1_findings(text)
     gates = [_gate_from_findings(name, 1, findings) for name in TIER1_GATES]
-    gates.append(_pov_gate(chapters, pov_classifications, run_llm))
-    gates.append(_linter_gate(text, linter_replacements, run_llm))
+    gates.append(_pov_gate(chapters, judge.pov_classifications, judge.run_llm))
+    gates.append(_linter_gate(text, judge.linter_replacements, judge.run_llm))
+    gates.append(_continuity_gate(chapters, cast, judge.contradictions, judge.run_llm))
+    gates.append(_premise_gate(judge.idea, chapters, judge.premise_verdict, judge.run_llm))
+    gates.append(_rubric_gate(chapters, judge.rubric_scores, judge.rubric_samples, judge.run_llm))
     return _summarize(gates, _budgets(findings))
 
 
@@ -206,14 +277,15 @@ def _summarize(gates: list[Gate], budgets: dict[str, dict]) -> FullScorecard:
     not_evaluated = [g.gate for g in gates if g.status == SKIPPED]
     tier1_clean = not any(g.status == FAIL for g in gates if g.tier == 1) and not over_budget
     complete = not not_evaluated
+    dod = _definition_of_done({g.gate: g for g in gates}, tier1_clean)
     return FullScorecard(
         ship=not fails and not over_budget and complete,
         complete=complete,
         tier1_clean=tier1_clean,
         gates=gates,
         budgets=budgets,
-        definition_of_done=_definition_of_done({g.gate: g for g in gates}, tier1_clean),
-        manual_checks=[_REAL_ENDING_MANUAL],
+        definition_of_done=dod,
+        manual_checks=[d["item"] for d in dod if d["status"] == MANUAL],
         not_evaluated=not_evaluated,
         fails=fails,
         warns=warns,
@@ -224,9 +296,9 @@ def _row(gate: Gate) -> dict:
     return {"gate": gate.gate, "tier": gate.tier, "messages": gate.messages}
 
 
-def evaluate_path(path: Path, **kwargs) -> FullScorecard:
+def evaluate_path(path: Path, judge: JudgeInputs | None = None) -> FullScorecard:
     """Read a story markdown file and evaluate it. See :func:`evaluate`."""
-    return evaluate(Path(path).read_text(encoding="utf-8"), **kwargs)
+    return evaluate(Path(path).read_text(encoding="utf-8"), judge)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/bench/judge.py
+++ b/bench/judge.py
@@ -1,0 +1,333 @@
+"""LLM-backed Tier-2 / Tier-3 judges for the story scorecard.
+
+Implements the parts of ``bench/eval-spec.md`` that "heuristics can't read":
+
+- **T2.3 continuity** — factual contradictions across the manuscript
+  (timeline, trait flips, name collisions, teleporting locations). Hard
+  contradictions FAIL; minor wobble WARNs.
+- **T2.4 premise fidelity** — does the story dramatize the user's original
+  idea, or drift into a generic tale? Off-premise FAILs.
+- **Tier-3 rubric** — the six craft axes (arc, ending, agency, scene-vs-
+  summary, prose, cohesion) scored 1–5. Below the ship threshold FAILs.
+
+Each judge follows the :mod:`pov_check` template: the DSPy signature is nested
+in the calling function so ``import dspy`` stays lazy and this module is
+importable (and the gates testable) without a model. Public ``check_*``
+functions accept precomputed results so callers/tests can inject a verdict
+instead of calling the LM.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from qa import Finding
+
+logger = logging.getLogger(__name__)
+
+RUBRIC_AXES = (
+    "arc_structure",
+    "ending",
+    "character_agency",
+    "scene_vs_summary",
+    "prose_quality",
+    "cohesion",
+)
+RUBRIC_MIN_AVG = 4.0          # ship threshold (eval-spec Tier-3)
+RUBRIC_MIN_AXIS = 3           # no single axis may fall below this
+PREMISE_MIN_SCORE = 3         # below this the story has drifted off-idea
+
+
+@dataclass
+class Contradiction:
+    """One factual contradiction found in the manuscript."""
+
+    kind: str       # timeline | trait | name_collision | location | death | ...
+    severity: str   # "hard" | "minor"
+    detail: str
+
+
+@dataclass
+class PremiseVerdict:
+    """Whether the manuscript dramatizes the user's original idea."""
+
+    dramatizes: bool
+    score: int      # 1–5 fidelity
+    note: str = ""
+
+
+@dataclass
+class AxisScore:
+    """A single Tier-3 rubric axis score."""
+
+    axis: str       # one of RUBRIC_AXES
+    score: int      # 1–5
+    note: str = ""
+
+
+def _format_chapters(chapters: dict[str, str]) -> str:
+    return "\n\n".join(f"### {title}\n\n{body}" for title, body in chapters.items())
+
+
+def _note(text: str) -> str:
+    return f" — {text}" if text else ""
+
+
+# --- coercion (robust to dict / object / dataclass LM outputs) ---------------
+
+def _coerce_contradiction(item: object) -> Contradiction | None:
+    if isinstance(item, Contradiction):
+        kind, severity, detail = item.kind, item.severity, item.detail
+    elif isinstance(item, dict):
+        kind = item.get("kind") or ""
+        severity = item.get("severity") or ""
+        detail = item.get("detail") or item.get("description") or ""
+    else:
+        kind = getattr(item, "kind", "") or ""
+        severity = getattr(item, "severity", "") or ""
+        detail = getattr(item, "detail", "") or ""
+    detail = str(detail).strip()
+    if not detail:
+        return None
+    severity = str(severity).strip().lower()
+    if severity not in ("hard", "minor"):
+        severity = "hard"  # surface unknown severities rather than hide them
+    return Contradiction(kind=str(kind).strip() or "unspecified", severity=severity, detail=detail)
+
+
+def _coerce_premise(obj: object) -> PremiseVerdict:
+    if isinstance(obj, PremiseVerdict):
+        return obj
+    if isinstance(obj, dict):
+        dramatizes, score, note = obj.get("dramatizes"), obj.get("score"), obj.get("note") or ""
+    else:
+        dramatizes = getattr(obj, "dramatizes", None)
+        score = getattr(obj, "score", None)
+        note = getattr(obj, "note", "") or ""
+    try:
+        score_int = max(0, min(5, int(score)))
+    except (TypeError, ValueError):
+        score_int = 0
+    return PremiseVerdict(dramatizes=bool(dramatizes), score=score_int, note=str(note).strip())
+
+
+def _coerce_axis(item: object) -> AxisScore | None:
+    if isinstance(item, AxisScore):
+        axis, score, note = item.axis, item.score, item.note
+    elif isinstance(item, dict):
+        axis, score, note = item.get("axis") or "", item.get("score"), item.get("note") or ""
+    else:
+        axis = getattr(item, "axis", "") or ""
+        score = getattr(item, "score", None)
+        note = getattr(item, "note", "") or ""
+    axis = str(axis).strip().lower().replace(" ", "_").replace("-", "_")
+    if axis not in RUBRIC_AXES:
+        logger.warning("judge: unknown rubric axis %r; dropping", axis)
+        return None
+    try:
+        score_int = max(1, min(5, int(score)))
+    except (TypeError, ValueError):
+        logger.warning("judge: non-int score %r for axis %r; dropping", score, axis)
+        return None
+    return AxisScore(axis=axis, score=score_int, note=str(note).strip())
+
+
+# --- T2.3 continuity --------------------------------------------------------
+
+def find_contradictions(cast: str, chapters: dict[str, str]) -> list[Contradiction]:
+    """Ask the LM for factual contradictions across the manuscript."""
+    import dspy
+
+    class FindContradictions(dspy.Signature):
+        """List factual contradictions across a manuscript.
+
+        Given the cast list and the chapters in order, identify facts that
+        cannot both be true: a character dead/absent then acting; physical
+        traits or relationships that flip; a timeline that doesn't add up; two
+        *distinct* characters sharing one name (a collision, not a nickname); a
+        location or object that teleports. Judge explicit facts only — do not
+        invent contradictions from deliberate mystery or normal scene changes.
+        Classify each as 'hard' (a real logical contradiction) or 'minor' (a
+        forgivable wobble). Return an empty list if the manuscript is consistent.
+        """
+
+        cast: str = dspy.InputField(desc="Canonical cast list (names + descriptions).")
+        chapters_text: str = dspy.InputField(desc="Chapters in order: '### <label>' then prose.")
+        contradictions: list[Contradiction] = dspy.OutputField(
+            desc="Factual contradictions; [] if consistent."
+        )
+
+    result = dspy.ChainOfThought(FindContradictions)(
+        cast=cast, chapters_text=_format_chapters(chapters)
+    )
+    out: list[Contradiction] = []
+    for item in result.contradictions or []:
+        coerced = _coerce_contradiction(item)
+        if coerced is None:
+            logger.warning("judge: dropping malformed contradiction: %r", item)
+            continue
+        out.append(coerced)
+    return out
+
+
+def check_continuity(
+    chapters: dict[str, str],
+    cast: str,
+    contradictions: list[Contradiction] | None = None,
+) -> list[Finding]:
+    """Hard contradictions FAIL; minor ones WARN. ``contradictions`` injects."""
+    if not chapters:
+        return []
+    if contradictions is None:
+        contradictions = find_contradictions(cast, chapters)
+    findings = [
+        Finding(
+            check="continuity",
+            severity="fail" if c.severity == "hard" else "warn",
+            message=f"{c.kind}: {c.detail}",
+        )
+        for c in contradictions
+    ]
+    if not findings:
+        findings.append(Finding(
+            check="continuity", severity="info", message="no contradictions found"
+        ))
+    return findings
+
+
+# --- T2.4 premise fidelity --------------------------------------------------
+
+def judge_premise_fidelity(idea: str, chapters: dict[str, str]) -> PremiseVerdict:
+    """Ask the LM whether the manuscript dramatizes the user's idea."""
+    import dspy
+
+    class JudgePremiseFidelity(dspy.Signature):
+        """Decide whether a manuscript dramatizes the user's original idea.
+
+        Given the one-line story idea the user asked for and the full
+        manuscript, decide whether the story dramatizes *that premise* — its
+        central conflict, world, and stakes — versus drifting into a generic
+        tale that ignores the idea. Detail may diverge; what matters is that the
+        user's core idea is on the page and load-bearing. Return ``dramatizes``
+        (True/False), a 1–5 ``score`` (5 = the idea is the spine of the story;
+        1 = absent), and a one-phrase note.
+        """
+
+        idea: str = dspy.InputField(desc="The user's original one-line story idea.")
+        manuscript: str = dspy.InputField(desc="The full manuscript prose.")
+        verdict: PremiseVerdict = dspy.OutputField(desc="dramatizes / score 1-5 / note.")
+
+    result = dspy.ChainOfThought(JudgePremiseFidelity)(
+        idea=idea, manuscript=_format_chapters(chapters)
+    )
+    return _coerce_premise(result.verdict)
+
+
+def check_premise_fidelity(
+    idea: str,
+    chapters: dict[str, str],
+    verdict: PremiseVerdict | None = None,
+) -> list[Finding]:
+    """Off-premise (not dramatized or score < threshold) FAILs. ``verdict`` injects."""
+    if not chapters:
+        return []
+    if verdict is None:
+        verdict = judge_premise_fidelity(idea, chapters)
+    if verdict.dramatizes and verdict.score >= PREMISE_MIN_SCORE:
+        return [Finding(
+            check="premise_fidelity",
+            severity="info",
+            message=f"dramatizes premise (score {verdict.score}/5){_note(verdict.note)}",
+        )]
+    return [Finding(
+        check="premise_fidelity",
+        severity="fail",
+        message=f"drifts off-premise (score {verdict.score}/5){_note(verdict.note)}",
+    )]
+
+
+# --- Tier-3 rubric ----------------------------------------------------------
+
+def _score_rubric_once(chapters: dict[str, str]) -> list[AxisScore]:
+    import dspy
+
+    class ScoreRubric(dspy.Signature):
+        """Score a manuscript on six craft axes, 1 (worst) to 5 (best).
+
+        Judge the *narration* (ignore the quality of quoted dialogue). Score
+        each axis independently against its anchors:
+        - arc_structure: 1 episodic/shapeless ... 5 setup->rising->climax->resolution
+        - ending: 1 stops/fizzles/deus-ex-machina ... 5 earned, lands the promise
+        - character_agency: 1 events happen to passive figures ... 5 choices drive plot
+        - scene_vs_summary: 1 tells/summarizes ... 5 dramatizes key beats in scene
+        - prose_quality: 1 flat/repetitive/garbled ... 5 varied, controlled, few tics
+        - cohesion: 1 threads dropped/setups unpaid ... 5 setups pay off, threads resolve
+
+        Be calibrated and critical: reserve 5 for genuinely excellent work and 1
+        for broken work. Return one entry per axis with a one-phrase note.
+        """
+
+        manuscript: str = dspy.InputField(desc="The full manuscript prose.")
+        scores: list[AxisScore] = dspy.OutputField(
+            desc="One {axis, score 1-5, note} per rubric axis."
+        )
+
+    result = dspy.ChainOfThought(ScoreRubric)(manuscript=_format_chapters(chapters))
+    out: list[AxisScore] = []
+    for item in result.scores or []:
+        coerced = _coerce_axis(item)
+        if coerced is not None:
+            out.append(coerced)
+    return out
+
+
+def _median_axes(runs: list[list[AxisScore]]) -> list[AxisScore]:
+    """Aggregate repeated rubric runs by per-axis median (variance control)."""
+    from statistics import median
+
+    scores: dict[str, list[int]] = {}
+    notes: dict[str, str] = {}
+    for run in runs:
+        for axis_score in run:
+            scores.setdefault(axis_score.axis, []).append(axis_score.score)
+            notes.setdefault(axis_score.axis, axis_score.note)
+    return [
+        AxisScore(axis=axis, score=max(1, min(5, round(median(scores[axis])))), note=notes.get(axis, ""))
+        for axis in RUBRIC_AXES
+        if axis in scores
+    ]
+
+
+def score_rubric(chapters: dict[str, str], samples: int = 1) -> list[AxisScore]:
+    """Score the rubric; with ``samples`` > 1, take the per-axis median."""
+    if not chapters:
+        return []
+    runs = [_score_rubric_once(chapters) for _ in range(max(1, samples))]
+    return runs[0] if len(runs) == 1 else _median_axes(runs)
+
+
+def check_rubric(
+    chapters: dict[str, str],
+    scores: list[AxisScore] | None = None,
+    samples: int = 1,
+    min_avg: float = RUBRIC_MIN_AVG,
+    min_axis: int = RUBRIC_MIN_AXIS,
+) -> list[Finding]:
+    """FAIL if rubric average < ``min_avg`` or any axis < ``min_axis``."""
+    if not chapters:
+        return []
+    if scores is None:
+        scores = score_rubric(chapters, samples=samples)
+    if not scores:
+        return [Finding(check="rubric", severity="warn", message="rubric judge returned no scores")]
+    by_axis = {s.axis: s.score for s in scores}
+    avg = sum(by_axis.values()) / len(by_axis)
+    below = sorted(axis for axis, score in by_axis.items() if score < min_axis)
+    detail = ", ".join(f"{s.axis}={s.score}" for s in scores)
+    if avg < min_avg or below:
+        return [Finding(
+            check="rubric",
+            severity="fail",
+            message=f"avg {avg:.1f} (need >= {min_avg}); below {min_axis}: {below or 'none'} [{detail}]",
+        )]
+    return [Finding(check="rubric", severity="info", message=f"avg {avg:.1f} [{detail}]")]

--- a/bench/rubric.md
+++ b/bench/rubric.md
@@ -1,6 +1,7 @@
 # Tier-3 Qualitative Rubric (LLM judge, 1–5)
 
-Used by the (stubbed) Tier-3 judge in the bench harness. Threshold to ship:
+Scored by the Tier-3 judge in `bench/judge.py` (`score_rubric` / `check_rubric`),
+wired into the scorecard by `bench/evaluate.py`. Threshold to ship:
 **average ≥ 4.0 with no axis below 3.**
 
 | Axis | 1 | 5 |

--- a/docs/07-acceptance-and-quality.md
+++ b/docs/07-acceptance-and-quality.md
@@ -7,32 +7,62 @@ How we decide a run — and the system — is good enough.
 A run on the recommended config is acceptable when:
 
 1. It **completes without crashing** and writes all artifact sections.
-2. It produces **N non-empty chapters** (none below the length floor, 80 words).
+2. It produces **N non-empty chapters** (none below the hard floor of 80 words;
+   thin `<300` / bloated `>2500` chapters warn but don't block).
 3. The **protagonist is named** in chapter 1 (no "the protagonist"/"the child"
    placeholders left in prose).
 4. The story has a **real ending** (the spine's final beats are dramatized, not
-   gestured at).
+   gestured at). *Not automatable yet — a `manual` check pending the Tier-3
+   judge.*
 5. The **QA suite reports no real fails** (parser-artifact fails don't count).
 6. **Narration POV is consistent** across chapters (no unexplained drift).
 
-## QA gates (automated)
+## The unified scorecard (executable Definition of Done)
 
-Run after generation:
+One command turns the list above into a machine-readable verdict:
 
 ```bash
-python scripts/run_qa.py path/to/story.md      # phrase reuse, name drift, presence, length
-python scripts/check_pov.py path/to/story.md    # LLM POV consistency
-python scripts/lint_story.py path/to/story.md   # placeholder/misspelling fixes (writes sidecar)
-python scripts/word_count.py path/to/story.md   # top repeated content words
+python scripts/evaluate.py path/to/story.md             # Tier-1 only (no model)
+python scripts/evaluate.py path/to/story.md --with-llm  # + Tier-2 POV & prose lint
+python -m bench.evaluate   path/to/story.md             # Tier-1 only, no dspy needed (JSON)
 ```
 
-| Gate | Source | Pass condition |
-|---|---|---|
-| Chapter length | `qa.check_chapter_length` | every chapter ≥ 80 words |
-| Character presence | `qa.check_character_presence` | every canonical character appears in prose |
-| Name drift | `qa.check_name_drift` | no real misspelled-name variants (warn-level) |
-| Phrase reuse | `qa.check_cross_chapter_phrase_reuse` | repeated-5-gram count low (warn-level) |
-| POV consistency | `pov_check` | no `mixed` chapter; none disagreeing with the dominant POV |
+It runs the deterministic Tier-1 gates plus (with `--with-llm`) the LLM-backed
+Tier-2 gates, and writes a `<story>.scorecard.json` sidecar. Three top-level
+verdicts:
+
+- **`tier1_clean`** — no deterministic FAIL and budgets respected.
+- **`complete`** — every required gate actually ran (Tier-2 not skipped).
+- **`ship`** — `tier1_clean` **and** `complete`. A deterministic-only run is
+  honest: `ship=false` because POV couldn't be checked.
+
+Each Definition-of-Done item maps to a gate:
+
+| DoD item | Gate | Tier | Severity |
+|---|---|---|---|
+| All required sections present | `structure` | 1 | fail |
+| N non-empty chapters (≥ 80 words) | `chapter_length` | 1 | fail |
+| Chapters in target band (300–2500) | `chapter_band` | 1 | warn |
+| Protagonist named (no placeholders) | `placeholder_protagonist` | 1 | fail |
+| Every cast member appears | `character_presence` | 1 | fail |
+| No misspelled-name drift | `name_drift` | 1 | warn (budget ≤ 2) |
+| Low cross-chapter phrase reuse | `cross_chapter_phrase_reuse` | 1 | warn (budget ≤ 5) |
+| POV consistent across chapters | `pov_consistency` | 2 | fail |
+| Placeholders / canonical-name lint | `prose_linter` | 2 | warn (advisory) |
+| **Real ending dramatizes the spine** | — | 3 | **manual** |
+
+Length thresholds live in `qa.py` (`CHAPTER_MIN_WORDS` = 80 hard floor;
+`CHAPTER_TARGET_BAND` = 300–2500) — the single source of truth shared by
+`bench/criteria.py`, `bench/evaluate.py`, and `bench/eval-spec.md`.
+
+### Lower-level tools (building blocks)
+
+```bash
+python scripts/run_qa.py path/to/story.md      # the original 4 deterministic checks
+python scripts/check_pov.py path/to/story.md    # LLM POV consistency only
+python scripts/lint_story.py path/to/story.md   # placeholder/misspelling fixes (writes + applies)
+python scripts/word_count.py path/to/story.md   # top repeated content words
+```
 
 Severity meaning: `fail` = must fix, `warn` = inspect, `info` = context.
 

--- a/docs/07-acceptance-and-quality.md
+++ b/docs/07-acceptance-and-quality.md
@@ -12,8 +12,8 @@ A run on the recommended config is acceptable when:
 3. The **protagonist is named** in chapter 1 (no "the protagonist"/"the child"
    placeholders left in prose).
 4. The story has a **real ending** (the spine's final beats are dramatized, not
-   gestured at). *Not automatable yet — a `manual` check pending the Tier-3
-   judge.*
+   gestured at). Judged by the Tier-3 `rubric` (`ending` axis) when it runs;
+   reported as a `manual` check otherwise.
 5. The **QA suite reports no real fails** (parser-artifact fails don't count).
 6. **Narration POV is consistent** across chapters (no unexplained drift).
 
@@ -49,7 +49,10 @@ Each Definition-of-Done item maps to a gate:
 | Low cross-chapter phrase reuse | `cross_chapter_phrase_reuse` | 1 | warn (budget ≤ 5) |
 | POV consistent across chapters | `pov_consistency` | 2 | fail |
 | Placeholders / canonical-name lint | `prose_linter` | 2 | warn (advisory) |
-| **Real ending dramatizes the spine** | — | 3 | **manual** |
+| No factual contradictions | `continuity` | 2 | fail (hard) / warn (minor) |
+| Story dramatizes the premise | `premise_fidelity` | 2 | fail (needs `--idea`) |
+| **Real ending dramatizes the spine** | `rubric` | 3 | fail (rubric-judged; `manual` if not run) |
+| Six-axis quality bar (avg ≥ 4, no axis < 3) | `rubric` | 3 | fail |
 
 Length thresholds live in `qa.py` (`CHAPTER_MIN_WORDS` = 80 hard floor;
 `CHAPTER_TARGET_BAND` = 300–2500) — the single source of truth shared by
@@ -66,11 +69,15 @@ python scripts/word_count.py path/to/story.md   # top repeated content words
 
 Severity meaning: `fail` = must fix, `warn` = inspect, `info` = context.
 
-## Read-through rubric (human, 1–5 each)
+## Read-through rubric (1–5 each)
 
-From the bake-off methodology — score every run on:
-**continuity · coherence · structure · prose · plot-thread tracking.**
-Used to compare models/variants beyond what automated QA can see (see
+The six-axis rubric (arc · ending · agency · scene-vs-summary · prose ·
+cohesion, defined in [bench/rubric.md](../bench/rubric.md)) is now scored by
+the Tier-3 LLM judge (`bench/judge.py`, via `scripts/evaluate.py --with-llm`),
+not only by hand. For variance control, pass `--rubric-samples N` to score the
+rubric N times and take the per-axis median; prefer an independent judge model
+(different from the generator). A human read-through over the same axes is still
+the gold standard for comparing models/variants (see
 [model-implementation-comparison-2026-05-10.md](model-implementation-comparison-2026-05-10.md)).
 
 ## Test strategy (code)
@@ -79,8 +86,10 @@ Used to compare models/variants beyond what automated QA can see (see
 - **LLM isolation:** unit tests configure a `MockLM` and assert on parsed
   outputs / Pydantic validation rather than calling a real model.
 - **Coverage today:** `test_qa.py`, `test_pov_check.py`, `test_story_linter.py`,
-  `test_story_module.py`, `test_world_state.py`. New checks/algorithms should
-  ship with tests mirroring this pattern.
+  `test_story_module.py`, `test_world_state.py`, `tests/test_evaluate.py`
+  (scorecard wiring), `tests/test_judge.py` (judge logic), `tests/test_bench.py`.
+  The judge tests inject precomputed verdicts so the gate logic is covered
+  without a model. New checks/algorithms should ship with tests mirroring this.
 - **Static quality:** `ruff` (lint + format), and optionally `pylint` / `radon`
   / `vulture` per `AGENTS.md`.
 

--- a/qa.py
+++ b/qa.py
@@ -35,6 +35,11 @@ from pathlib import Path
 
 NGRAM = 5
 CHAPTER_MIN_WORDS = 80
+# Target word band for a chapter. Below the hard floor (CHAPTER_MIN_WORDS) a
+# chapter FAILs as broken/truncated; within the floor but outside this band it
+# WARNs as thin/bloated. This is the single source of truth for the length
+# thresholds — see docs/07-acceptance-and-quality.md and bench/eval-spec.md.
+CHAPTER_TARGET_BAND = (300, 2500)
 WORD_RE = re.compile(r"[A-Za-z']+")
 # Proper-noun matcher: 1–3 capitalised tokens joined by spaces/tabs only.
 # Newlines are excluded so a paragraph break can't merge two separate names
@@ -312,6 +317,133 @@ def check_chapter_length(text: str, min_words: int = CHAPTER_MIN_WORDS) -> list[
             check="chapter_length",
             severity="info",
             message=f"all {len(chapters)} chapters >= {min_words} words",
+        ))
+    return findings
+
+
+# --- check 5: structural completeness ---------------------------------------
+
+# (level, heading) sections every finished artifact must contain. Missing any
+# of these means the heading-coupled parsers above are mis-reading the file
+# (risk R-8), so the other checks' results can't be trusted.
+REQUIRED_SECTIONS = (
+    (2, "World bible"),
+    (3, "Characters"),
+    (2, "Final Story"),
+)
+
+
+def _heading_present(text: str, level: int, heading: str) -> bool:
+    """True if a ``<level> heading`` line exists in ``text``."""
+    target = f"{'#' * level} {heading}"
+    return any(line.strip() == target for line in text.splitlines())
+
+
+def check_structure(text: str) -> list[Finding]:
+    """Fail when a required artifact section is missing or empty of chapters.
+
+    Guards the heading-coupled parsers: a layout drift (renamed or omitted
+    section) otherwise makes the other checks silently mis-parse."""
+    findings: list[Finding] = []
+    missing = [
+        f"{'#' * level} {heading}"
+        for level, heading in REQUIRED_SECTIONS
+        if not _heading_present(text, level, heading)
+    ]
+    for heading in missing:
+        findings.append(Finding(
+            check="structure",
+            severity="fail",
+            message=f"required section missing: '{heading}'",
+        ))
+    chapters = split_chapters(text)
+    if _heading_present(text, 2, "Final Story") and not chapters:
+        findings.append(Finding(
+            check="structure",
+            severity="fail",
+            message="'## Final Story' present but contains no '### Chapter' sections",
+        ))
+    if not findings and chapters:
+        findings.append(Finding(
+            check="structure",
+            severity="info",
+            message=f"all required sections present ({len(chapters)} chapters)",
+        ))
+    return findings
+
+
+# --- check 6: protagonist placeholder ---------------------------------------
+
+# Only high-precision literals are gated deterministically: the bare word
+# "protagonist" essentially never appears in real narrative prose, so its
+# presence is the unnamed-cold-open defect. Subtler placeholders ("the child",
+# "the boy") are left to the LLM linter (story_linter.py), which can tell a
+# placeholder from a legitimate unnamed minor character.
+_PROTAGONIST_PLACEHOLDERS = ("protagonist",)
+
+
+def check_placeholder_protagonist(
+    text: str,
+    placeholders: tuple[str, ...] = _PROTAGONIST_PLACEHOLDERS,
+) -> list[Finding]:
+    """Fail chapters whose prose uses a placeholder term instead of a name."""
+    chapters = split_chapters(text)
+    patterns = {
+        p: re.compile(rf"\b{re.escape(p)}\b", re.IGNORECASE) for p in placeholders
+    }
+    findings: list[Finding] = []
+    for title, body in chapters.items():
+        hits = sorted(p for p, pat in patterns.items() if pat.search(body))
+        if hits:
+            findings.append(Finding(
+                check="placeholder_protagonist",
+                severity="fail",
+                message=f"chapter '{title}' uses placeholder term(s) {hits} instead of a name",
+            ))
+    if not findings and chapters:
+        findings.append(Finding(
+            check="placeholder_protagonist",
+            severity="info",
+            message="no protagonist-placeholder terms in chapter prose",
+        ))
+    return findings
+
+
+# --- check 7: chapter word band ---------------------------------------------
+
+def check_chapter_band(
+    text: str,
+    lo: int = CHAPTER_TARGET_BAND[0],
+    hi: int = CHAPTER_TARGET_BAND[1],
+) -> list[Finding]:
+    """Warn chapters outside the target word band (thin / bloated).
+
+    Chapters below the hard floor are already a FAIL from
+    :func:`check_chapter_length`, so they're skipped here rather than
+    double-reported as "thin"."""
+    chapters = split_chapters(text)
+    findings: list[Finding] = []
+    for title, body in chapters.items():
+        n = len(_words(body))
+        if n < CHAPTER_MIN_WORDS:
+            continue
+        if n < lo:
+            findings.append(Finding(
+                check="chapter_band",
+                severity="warn",
+                message=f"chapter '{title}' is thin: {n} words (target >= {lo})",
+            ))
+        elif n > hi:
+            findings.append(Finding(
+                check="chapter_band",
+                severity="warn",
+                message=f"chapter '{title}' is bloated: {n} words (target <= {hi})",
+            ))
+    if not findings and chapters:
+        findings.append(Finding(
+            check="chapter_band",
+            severity="info",
+            message=f"all chapters within target band {lo}-{hi} words",
         ))
     return findings
 

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -25,7 +25,7 @@ from dotenv import load_dotenv
 # Add repo root so top-level modules import when run from anywhere.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from bench.evaluate import FullScorecard, evaluate_path  # noqa: E402
+from bench.evaluate import FullScorecard, JudgeInputs, evaluate_path  # noqa: E402
 from logging_config import setup_logging  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -45,7 +45,19 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--with-llm",
         action="store_true",
-        help="Also run the Tier-2 LLM gates (POV consistency + prose lint).",
+        help="Also run the Tier-2/3 LLM gates (POV, prose lint, continuity, "
+        "premise fidelity, rubric).",
+    )
+    parser.add_argument(
+        "--idea",
+        default=None,
+        help="The original story idea — required for the premise-fidelity gate.",
+    )
+    parser.add_argument(
+        "--rubric-samples",
+        type=int,
+        default=1,
+        help="Score the Tier-3 rubric N times and take the per-axis median.",
     )
     parser.add_argument(
         "--no-sidecar",
@@ -118,13 +130,18 @@ def main(argv: list[str] | None = None) -> int:
     if args.with_llm:
         _configure_llm(args)
 
+    judge = JudgeInputs(
+        idea=args.idea,
+        run_llm=args.with_llm,
+        rubric_samples=args.rubric_samples,
+    )
     exit_code = 0
     for path in args.paths:
         if not path.is_file():
             logger.error("not a file: %s", path)
             exit_code = max(exit_code, 1)
             continue
-        card = evaluate_path(path, run_llm=args.with_llm)
+        card = evaluate_path(path, judge)
         print(_render(path, card))
         if not args.no_sidecar:
             _sidecar_path(path).write_text(card.to_json(), encoding="utf-8")

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Score a finished story against the executable Definition of Done.
+
+Runs the unified scorecard (``bench/evaluate.py``): deterministic Tier-1 gates
+always, plus the LLM-backed Tier-2 gates (POV consistency + prose lint) when
+``--with-llm`` is passed. Writes a ``<story>.scorecard.json`` sidecar per file
+and prints a human summary. Exit code is 2 if any gate FAILs.
+
+Without ``--with-llm`` this needs no model and reports ``tier1_clean``; the
+full ``ship`` verdict requires the Tier-2 gates, so run ``--with-llm`` (with a
+configured Ollama/DSPy backend) for a shippable/not-shippable decision.
+
+Mirrors ``scripts/check_pov.py``'s DSPy configuration flags.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+# Add repo root so top-level modules import when run from anywhere.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from bench.evaluate import FullScorecard, evaluate_path  # noqa: E402
+from logging_config import setup_logging  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+_STATUS_TAG = {
+    "pass": "PASS",
+    "fail": "FAIL",
+    "warn": "WARN",
+    "skipped": "skip",
+    "manual": "MANUAL",
+}
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="+", type=Path, help="story markdown file(s)")
+    parser.add_argument(
+        "--with-llm",
+        action="store_true",
+        help="Also run the Tier-2 LLM gates (POV consistency + prose lint).",
+    )
+    parser.add_argument(
+        "--no-sidecar",
+        action="store_true",
+        help="Don't write the <story>.scorecard.json sidecar.",
+    )
+
+    parser.add_argument("--model", default="qwen3")
+    parser.add_argument("--provider", default="ollama")
+    parser.add_argument("--api-key")
+    parser.add_argument("--max-tokens", type=int, default=8192)
+    parser.add_argument("--num-ctx", type=int, default=16384)
+    parser.add_argument("--cache", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--memory-cache", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument(
+        "--cache-dir",
+        type=str,
+        default=os.environ.get("DSPY_CACHE_DIR", ".cache/dspy"),
+    )
+    parser.add_argument("--log-level", default="INFO")
+    parser.add_argument("--log-file", default=".tmp/evaluate.log")
+    parser.add_argument("-v", "--verbose", action="count", default=0)
+    return parser.parse_args(argv)
+
+
+def _configure_llm(args: argparse.Namespace) -> None:
+    """Configure the DSPy backend (only needed for the Tier-2 gates)."""
+    from dspy_runtime import DSPyConfig, configure_dspy
+
+    model_name = args.model if "/" in args.model else f"{args.provider}/{args.model}"
+    configure_dspy(
+        DSPyConfig(
+            model_name=model_name,
+            api_key=args.api_key,
+            max_tokens=args.max_tokens,
+            num_ctx=args.num_ctx,
+            cache=args.cache,
+            memory_cache=args.memory_cache,
+            cache_dir=args.cache_dir,
+        )
+    )
+
+
+def _render(path: Path, card: FullScorecard) -> str:
+    """Render a human-readable summary of one scorecard."""
+    lines = [f"\n=== {path} ==="]
+    verdict = "SHIP" if card.ship else ("tier-1 clean" if card.tier1_clean else "DO NOT SHIP")
+    suffix = "" if card.complete else "  (Tier-2 not run — provisional)"
+    lines.append(f"verdict: {verdict}{suffix}")
+    for gate in card.gates:
+        tag = _STATUS_TAG.get(gate.status, gate.status)
+        detail = f": {'; '.join(gate.messages)}" if gate.messages else ""
+        lines.append(f"  [{tag}] T{gate.tier} {gate.gate}{detail}")
+    for budget, info in card.budgets.items():
+        flag = " OVER" if info["over"] else ""
+        lines.append(f"  budget {budget}: {info['count']}/{info['budget']}{flag}")
+    for item in card.manual_checks:
+        lines.append(f"  [MANUAL] {item}")
+    return "\n".join(lines)
+
+
+def _sidecar_path(story_path: Path) -> Path:
+    return story_path.with_suffix(story_path.suffix + ".scorecard.json")
+
+
+def main(argv: list[str] | None = None) -> int:
+    load_dotenv()
+    args = parse_args(argv)
+    setup_logging(verbosity=args.verbose, log_level=args.log_level, log_file=args.log_file)
+    if args.with_llm:
+        _configure_llm(args)
+
+    exit_code = 0
+    for path in args.paths:
+        if not path.is_file():
+            logger.error("not a file: %s", path)
+            exit_code = max(exit_code, 1)
+            continue
+        card = evaluate_path(path, run_llm=args.with_llm)
+        print(_render(path, card))
+        if not args.no_sidecar:
+            _sidecar_path(path).write_text(card.to_json(), encoding="utf-8")
+        if card.fails:
+            exit_code = 2
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test_qa.py
+++ b/test_qa.py
@@ -2,9 +2,12 @@ from qa import (
     PROPER_NOUN_RE,
     canonical_name,
     character_bullets,
+    check_chapter_band,
     check_chapter_length,
     check_character_presence,
     check_name_drift,
+    check_placeholder_protagonist,
+    check_structure,
     split_chapters,
 )
 
@@ -205,3 +208,82 @@ def test_split_chapters_round_trip():
     chapters = split_chapters(story)
     assert list(chapters.keys()) == ["Chapter 1: Open", "Chapter 2: Mid"]
     assert chapters["Chapter 1: Open"].startswith("alpha")
+
+
+# --- check_structure --------------------------------------------------------
+
+def test_structure_passes_complete_story():
+    story = _story({"Chapter 1": _make_prose(120)})
+    findings = check_structure(story)
+    assert [f.severity for f in findings] == ["info"]
+
+
+def test_structure_fails_missing_final_story():
+    story = "\n".join([
+        "# Story",
+        "",
+        "## World bible",
+        "",
+        "### Characters",
+        "",
+        "1. Cinder, the protagonist",
+    ])
+    findings = check_structure(story)
+    fails = [f for f in findings if f.severity == "fail"]
+    assert len(fails) == 1
+    assert "Final Story" in fails[0].message
+
+
+def test_structure_fails_final_story_without_chapters():
+    story = _story({})  # has the headings but no '### Chapter' bodies
+    findings = check_structure(story)
+    fails = [f for f in findings if f.severity == "fail"]
+    assert any("no '### Chapter'" in f.message for f in fails)
+
+
+# --- check_placeholder_protagonist ------------------------------------------
+
+def test_placeholder_protagonist_fails_on_literal():
+    story = _story({"Chapter 1": "The protagonist drew a blade. " + _make_prose(80)})
+    findings = check_placeholder_protagonist(story)
+    fails = [f for f in findings if f.severity == "fail"]
+    assert len(fails) == 1
+    assert "Chapter 1" in fails[0].message
+
+
+def test_placeholder_protagonist_passes_clean_prose():
+    story = _story({"Chapter 1": "Cinder drew a blade. " + _make_prose(80)})
+    findings = check_placeholder_protagonist(story)
+    assert [f.severity for f in findings] == ["info"]
+
+
+# --- check_chapter_band -----------------------------------------------------
+
+def test_chapter_band_warns_thin_chapter():
+    story = _story({"Chapter 1": _make_prose(120)})  # >= 80 floor, < 300 band
+    findings = check_chapter_band(story)
+    warns = [f for f in findings if f.severity == "warn"]
+    assert len(warns) == 1
+    assert "thin" in warns[0].message
+
+
+def test_chapter_band_warns_bloated_chapter():
+    story = _story({"Chapter 1": _make_prose(2600)})
+    findings = check_chapter_band(story)
+    warns = [f for f in findings if f.severity == "warn"]
+    assert len(warns) == 1
+    assert "bloated" in warns[0].message
+
+
+def test_chapter_band_passes_in_band():
+    story = _story({"Chapter 1": _make_prose(400), "Chapter 2": _make_prose(900)})
+    findings = check_chapter_band(story)
+    assert [f.severity for f in findings] == ["info"]
+
+
+def test_chapter_band_skips_below_hard_floor():
+    # A 40-word chapter is a hard FAIL elsewhere; the band must not also warn
+    # it as "thin" (no double-reporting).
+    story = _story({"Chapter 1": _make_prose(40)})
+    findings = check_chapter_band(story)
+    assert [f.severity for f in findings] == ["info"]

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -12,9 +12,19 @@ from pathlib import Path
 import pytest
 
 import generators  # noqa: F401 — populates REGISTRY for select_generators()
-from bench.criteria import Scorecard
+from bench.criteria import Scorecard, score
 from bench.run import Fixture, load_fixtures, select_generators
 from bench.score import render_fixture_table, walk_run_root
+
+
+def _write_story(tmp_path: Path, chapters: dict[str, str]) -> Path:
+    parts = ["# Story", "", "## World bible", "", "### Characters", "",
+             "", "## Final Story", ""]
+    for title, body in chapters.items():
+        parts += [f"### {title}", "", body, ""]
+    path = tmp_path / "story.md"
+    path.write_text("\n".join(parts), encoding="utf-8")
+    return path
 
 
 def test_load_fixtures_returns_all_three():
@@ -101,3 +111,25 @@ def test_scorecard_to_json_roundtrips():
     assert parsed["ship"] is False
     assert parsed["fails"][0]["check"] == "x"
     assert parsed["budgets"]["a"]["count"] == 1
+
+
+# --- reconciled chapter floor (80 hard fail; 300-2500 warn band) ------------
+
+def test_criteria_thin_chapter_warns_but_ships(tmp_path: Path):
+    # A 250-word chapter is "thin", not "broken": it must WARN, not FAIL, and
+    # the draft still ships (this is the supported fast-model output band).
+    path = _write_story(tmp_path, {"Chapter 1: A": " ".join(["alpha"] * 250) + "."})
+    sc = score(path)
+    assert sc.fails == []
+    assert sc.ship is True
+    assert any("thin" in w["message"] for w in sc.warns)
+
+
+def test_criteria_empty_chapter_fails(tmp_path: Path):
+    path = _write_story(tmp_path, {
+        "Chapter 1: A": " ".join(["alpha"] * 400) + ".",
+        "Chapter 2: B": "",
+    })
+    sc = score(path)
+    assert sc.ship is False
+    assert any(f["check"] == "chapter_length" for f in sc.fails)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,15 +1,18 @@
 """Tests for the unified scorecard (bench/evaluate.py) — no LLM required.
 
-The Tier-2 gates (POV consistency, prose lint) are exercised by *injecting*
-precomputed results, so these tests stay deterministic and fast while still
-covering the wiring, the ship/complete logic, and the Definition-of-Done map.
+The Tier-2/3 gates (POV, prose lint, continuity, premise, rubric) are exercised
+by *injecting* precomputed results via JudgeInputs, so these tests stay
+deterministic while covering the wiring, ship/complete logic, and the
+Definition-of-Done map.
 """
 from __future__ import annotations
 
 import json
 
-from bench.evaluate import evaluate
+from bench.evaluate import JudgeInputs, evaluate
+from bench.judge import RUBRIC_AXES, AxisScore, Contradiction, PremiseVerdict
 from pov_check import ChapterPOV
+from qa import split_chapters
 from story_linter import Replacement
 
 
@@ -19,16 +22,8 @@ def _prose(word: str, n: int) -> str:
 
 def _story(chapters: dict[str, str], characters_block: str = "") -> str:
     parts = [
-        "# Story",
-        "",
-        "## World bible",
-        "",
-        "### Characters",
-        "",
-        characters_block,
-        "",
-        "## Final Story",
-        "",
+        "# Story", "", "## World bible", "", "### Characters", "",
+        characters_block, "", "## Final Story", "",
     ]
     for title, body in chapters.items():
         parts += [f"### {title}", "", body, ""]
@@ -36,17 +31,27 @@ def _story(chapters: dict[str, str], characters_block: str = "") -> str:
 
 
 def _clean_story() -> str:
-    # Two distinct in-band chapters → no length, band, reuse, or placeholder hits.
     return _story({
         "Chapter 1: Open": _prose("alpha", 400),
         "Chapter 2: Turn": _prose("bravo", 400),
     })
 
 
-def _third_person(story: str) -> list[ChapterPOV]:
-    from qa import split_chapters
+def _good_rubric() -> list[AxisScore]:
+    return [AxisScore(axis, 5) for axis in RUBRIC_AXES]
 
-    return [ChapterPOV(title, "third_person") for title in split_chapters(story)]
+
+def _clean_judge(story: str, **overrides) -> JudgeInputs:
+    """JudgeInputs with every Tier-2/3 result injected clean; override per test."""
+    base = dict(
+        pov_classifications=[ChapterPOV(t, "third_person") for t in split_chapters(story)],
+        linter_replacements=[],
+        contradictions=[],
+        premise_verdict=PremiseVerdict(dramatizes=True, score=5, note="on premise"),
+        rubric_scores=_good_rubric(),
+    )
+    base.update(overrides)
+    return JudgeInputs(**base)
 
 
 # --- deterministic-only path ------------------------------------------------
@@ -54,54 +59,55 @@ def _third_person(story: str) -> list[ChapterPOV]:
 def test_deterministic_only_is_tier1_clean_but_not_shippable():
     card = evaluate(_clean_story())
     assert card.tier1_clean is True
-    assert card.complete is False  # Tier-2 not run
+    assert card.complete is False  # every judge skipped
     assert card.ship is False
-    assert set(card.not_evaluated) == {"pov_consistency", "prose_linter"}
+    assert set(card.not_evaluated) == {
+        "pov_consistency", "prose_linter", "continuity", "premise_fidelity", "rubric",
+    }
 
 
-def test_dod_marks_unrun_pov_as_skipped_and_ending_as_manual():
+def test_dod_marks_unrun_judges_as_skipped_and_ending_as_manual():
     card = evaluate(_clean_story())
     by_item = {d["item"]: d["status"] for d in card.definition_of_done}
     assert by_item["POV consistent across chapters"] == "skipped"
+    assert by_item["Story dramatizes the premise"] == "skipped"
     assert by_item["Real ending dramatizes the spine's final beats"] == "manual"
-    assert card.manual_checks  # the real-ending check is always surfaced
+    assert card.manual_checks  # the real-ending check is surfaced when rubric is off
 
 
-# --- full path (Tier-2 injected) --------------------------------------------
+# --- full path (judges injected) --------------------------------------------
 
 def test_full_clean_run_ships():
     story = _clean_story()
-    card = evaluate(
-        story,
-        pov_classifications=_third_person(story),
-        linter_replacements=[],
-    )
+    card = evaluate(story, _clean_judge(story))
     assert card.complete is True
     assert card.ship is True
     assert card.fails == []
     by_item = {d["item"]: d["status"] for d in card.definition_of_done}
     assert by_item["POV consistent across chapters"] == "pass"
+    assert by_item["Story dramatizes the premise"] == "pass"
+    # When the rubric runs, "real ending" is judged by it, not manual.
+    assert by_item["Real ending dramatizes the spine's final beats"] == "pass"
+    assert card.manual_checks == []
 
 
 def test_pov_outlier_blocks_ship():
     story = _clean_story()
-    classifications = [
+    judge = _clean_judge(story, pov_classifications=[
         ChapterPOV("Chapter 1: Open", "third_person"),
         ChapterPOV("Chapter 2: Turn", "first_person", "narrator says 'I'"),
-    ]
-    card = evaluate(story, pov_classifications=classifications, linter_replacements=[])
+    ])
+    card = evaluate(story, judge)
     assert card.ship is False
-    pov_gate = next(g for g in card.gates if g.gate == "pov_consistency")
-    assert pov_gate.status == "fail"
+    assert next(g for g in card.gates if g.gate == "pov_consistency").status == "fail"
 
 
 def test_linter_findings_are_advisory_not_blocking():
     story = _clean_story()
-    card = evaluate(
-        story,
-        pov_classifications=_third_person(story),
-        linter_replacements=[Replacement("the child", "Cinder", "placeholder")],
+    judge = _clean_judge(
+        story, linter_replacements=[Replacement("the child", "Cinder", "placeholder")]
     )
+    card = evaluate(story, judge)
     assert card.complete is True
     assert card.ship is True  # a proposed lint is a warn, not a fail
     linter_gate = next(g for g in card.gates if g.gate == "prose_linter")
@@ -109,20 +115,65 @@ def test_linter_findings_are_advisory_not_blocking():
     assert linter_gate.messages
 
 
-# --- Tier-1 failures --------------------------------------------------------
+# --- Tier-2/3 judge gates ---------------------------------------------------
+
+def test_hard_contradiction_blocks_ship():
+    story = _clean_story()
+    judge = _clean_judge(story, contradictions=[
+        Contradiction("name_collision", "hard", "two distinct characters named Elara"),
+    ])
+    card = evaluate(story, judge)
+    assert card.ship is False
+    assert next(g for g in card.gates if g.gate == "continuity").status == "fail"
+
+
+def test_minor_contradiction_warns_but_ships():
+    story = _clean_story()
+    judge = _clean_judge(story, contradictions=[
+        Contradiction("trait", "minor", "cloak is grey in ch1, brown in ch4"),
+    ])
+    card = evaluate(story, judge)
+    assert card.ship is True
+    assert next(g for g in card.gates if g.gate == "continuity").status == "warn"
+
+
+def test_off_premise_blocks_ship():
+    story = _clean_story()
+    judge = _clean_judge(
+        story, premise_verdict=PremiseVerdict(dramatizes=False, score=2, note="generic tale")
+    )
+    card = evaluate(story, judge)
+    assert card.ship is False
+    assert next(g for g in card.gates if g.gate == "premise_fidelity").status == "fail"
+
+
+def test_weak_rubric_blocks_ship_and_fails_ending_dod():
+    story = _clean_story()
+    weak = [AxisScore(a, 4) for a in RUBRIC_AXES if a != "ending"] + [AxisScore("ending", 2)]
+    card = evaluate(story, _clean_judge(story, rubric_scores=weak))
+    assert card.ship is False
+    assert next(g for g in card.gates if g.gate == "rubric").status == "fail"
+    by_item = {d["item"]: d["status"] for d in card.definition_of_done}
+    assert by_item["Real ending dramatizes the spine's final beats"] == "fail"
+
+
+def test_premise_skipped_when_no_idea_and_no_injection():
+    # run_llm on, but no idea and no injected verdict -> premise can't be judged.
+    story = _clean_story()
+    judge = JudgeInputs(run_llm=False, premise_verdict=None)
+    card = evaluate(story, judge)
+    premise_gate = next(g for g in card.gates if g.gate == "premise_fidelity")
+    assert premise_gate.status == "skipped"
+
+
+# --- Tier-1 failures still gate ---------------------------------------------
 
 def test_empty_chapter_fails_and_blocks_ship():
-    story = _story({
-        "Chapter 1: Open": _prose("alpha", 400),
-        "Chapter 2: Gap": "",
-    })
-    card = evaluate(story, pov_classifications=_third_person(story), linter_replacements=[])
+    story = _story({"Chapter 1: Open": _prose("alpha", 400), "Chapter 2: Gap": ""})
+    card = evaluate(story, _clean_judge(story))
     assert card.ship is False
     assert card.tier1_clean is False
-    length_gate = next(g for g in card.gates if g.gate == "chapter_length")
-    assert length_gate.status == "fail"
-    by_item = {d["item"]: d["status"] for d in card.definition_of_done}
-    assert by_item["N non-empty chapters (>= hard floor)"] == "fail"
+    assert next(g for g in card.gates if g.gate == "chapter_length").status == "fail"
 
 
 def test_missing_section_fails_structure():
@@ -131,28 +182,25 @@ def test_missing_section_fails_structure():
         "1. Cinder, the protagonist",
     ])
     card = evaluate(story)
-    structure_gate = next(g for g in card.gates if g.gate == "structure")
-    assert structure_gate.status == "fail"
+    assert next(g for g in card.gates if g.gate == "structure").status == "fail"
     assert card.tier1_clean is False
 
 
 def test_protagonist_placeholder_fails():
     story = _story({"Chapter 1: Open": "The protagonist ran. " + _prose("alpha", 400)})
-    card = evaluate(story, pov_classifications=_third_person(story), linter_replacements=[])
-    gate = next(g for g in card.gates if g.gate == "placeholder_protagonist")
-    assert gate.status == "fail"
+    card = evaluate(story, _clean_judge(story))
+    assert next(g for g in card.gates if g.gate == "placeholder_protagonist").status == "fail"
     assert card.ship is False
 
 
 def test_phrase_reuse_over_budget_blocks_ship():
-    # Two identical in-band chapters share many 5-grams → reuse budget blown.
     distinct = " ".join(
         ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf",
          "hotel", "india", "juliet", "kilo", "lima", "mike", "november"]
     )
-    body = (distinct + " ") * 25  # ~350 words, in band
+    body = (distinct + " ") * 25
     story = _story({"Chapter 1: Open": body, "Chapter 2: Echo": body})
-    card = evaluate(story, pov_classifications=_third_person(story), linter_replacements=[])
+    card = evaluate(story, _clean_judge(story))
     assert card.budgets["phrase_reuse"]["over"] is True
     assert card.ship is False
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,0 +1,168 @@
+"""Tests for the unified scorecard (bench/evaluate.py) — no LLM required.
+
+The Tier-2 gates (POV consistency, prose lint) are exercised by *injecting*
+precomputed results, so these tests stay deterministic and fast while still
+covering the wiring, the ship/complete logic, and the Definition-of-Done map.
+"""
+from __future__ import annotations
+
+import json
+
+from bench.evaluate import evaluate
+from pov_check import ChapterPOV
+from story_linter import Replacement
+
+
+def _prose(word: str, n: int) -> str:
+    return " ".join([word] * n) + "."
+
+
+def _story(chapters: dict[str, str], characters_block: str = "") -> str:
+    parts = [
+        "# Story",
+        "",
+        "## World bible",
+        "",
+        "### Characters",
+        "",
+        characters_block,
+        "",
+        "## Final Story",
+        "",
+    ]
+    for title, body in chapters.items():
+        parts += [f"### {title}", "", body, ""]
+    return "\n".join(parts)
+
+
+def _clean_story() -> str:
+    # Two distinct in-band chapters → no length, band, reuse, or placeholder hits.
+    return _story({
+        "Chapter 1: Open": _prose("alpha", 400),
+        "Chapter 2: Turn": _prose("bravo", 400),
+    })
+
+
+def _third_person(story: str) -> list[ChapterPOV]:
+    from qa import split_chapters
+
+    return [ChapterPOV(title, "third_person") for title in split_chapters(story)]
+
+
+# --- deterministic-only path ------------------------------------------------
+
+def test_deterministic_only_is_tier1_clean_but_not_shippable():
+    card = evaluate(_clean_story())
+    assert card.tier1_clean is True
+    assert card.complete is False  # Tier-2 not run
+    assert card.ship is False
+    assert set(card.not_evaluated) == {"pov_consistency", "prose_linter"}
+
+
+def test_dod_marks_unrun_pov_as_skipped_and_ending_as_manual():
+    card = evaluate(_clean_story())
+    by_item = {d["item"]: d["status"] for d in card.definition_of_done}
+    assert by_item["POV consistent across chapters"] == "skipped"
+    assert by_item["Real ending dramatizes the spine's final beats"] == "manual"
+    assert card.manual_checks  # the real-ending check is always surfaced
+
+
+# --- full path (Tier-2 injected) --------------------------------------------
+
+def test_full_clean_run_ships():
+    story = _clean_story()
+    card = evaluate(
+        story,
+        pov_classifications=_third_person(story),
+        linter_replacements=[],
+    )
+    assert card.complete is True
+    assert card.ship is True
+    assert card.fails == []
+    by_item = {d["item"]: d["status"] for d in card.definition_of_done}
+    assert by_item["POV consistent across chapters"] == "pass"
+
+
+def test_pov_outlier_blocks_ship():
+    story = _clean_story()
+    classifications = [
+        ChapterPOV("Chapter 1: Open", "third_person"),
+        ChapterPOV("Chapter 2: Turn", "first_person", "narrator says 'I'"),
+    ]
+    card = evaluate(story, pov_classifications=classifications, linter_replacements=[])
+    assert card.ship is False
+    pov_gate = next(g for g in card.gates if g.gate == "pov_consistency")
+    assert pov_gate.status == "fail"
+
+
+def test_linter_findings_are_advisory_not_blocking():
+    story = _clean_story()
+    card = evaluate(
+        story,
+        pov_classifications=_third_person(story),
+        linter_replacements=[Replacement("the child", "Cinder", "placeholder")],
+    )
+    assert card.complete is True
+    assert card.ship is True  # a proposed lint is a warn, not a fail
+    linter_gate = next(g for g in card.gates if g.gate == "prose_linter")
+    assert linter_gate.status == "warn"
+    assert linter_gate.messages
+
+
+# --- Tier-1 failures --------------------------------------------------------
+
+def test_empty_chapter_fails_and_blocks_ship():
+    story = _story({
+        "Chapter 1: Open": _prose("alpha", 400),
+        "Chapter 2: Gap": "",
+    })
+    card = evaluate(story, pov_classifications=_third_person(story), linter_replacements=[])
+    assert card.ship is False
+    assert card.tier1_clean is False
+    length_gate = next(g for g in card.gates if g.gate == "chapter_length")
+    assert length_gate.status == "fail"
+    by_item = {d["item"]: d["status"] for d in card.definition_of_done}
+    assert by_item["N non-empty chapters (>= hard floor)"] == "fail"
+
+
+def test_missing_section_fails_structure():
+    story = "\n".join([
+        "# Story", "", "## World bible", "", "### Characters", "",
+        "1. Cinder, the protagonist",
+    ])
+    card = evaluate(story)
+    structure_gate = next(g for g in card.gates if g.gate == "structure")
+    assert structure_gate.status == "fail"
+    assert card.tier1_clean is False
+
+
+def test_protagonist_placeholder_fails():
+    story = _story({"Chapter 1: Open": "The protagonist ran. " + _prose("alpha", 400)})
+    card = evaluate(story, pov_classifications=_third_person(story), linter_replacements=[])
+    gate = next(g for g in card.gates if g.gate == "placeholder_protagonist")
+    assert gate.status == "fail"
+    assert card.ship is False
+
+
+def test_phrase_reuse_over_budget_blocks_ship():
+    # Two identical in-band chapters share many 5-grams → reuse budget blown.
+    distinct = " ".join(
+        ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf",
+         "hotel", "india", "juliet", "kilo", "lima", "mike", "november"]
+    )
+    body = (distinct + " ") * 25  # ~350 words, in band
+    story = _story({"Chapter 1: Open": body, "Chapter 2: Echo": body})
+    card = evaluate(story, pov_classifications=_third_person(story), linter_replacements=[])
+    assert card.budgets["phrase_reuse"]["over"] is True
+    assert card.ship is False
+
+
+# --- serialization ----------------------------------------------------------
+
+def test_scorecard_json_roundtrips():
+    card = evaluate(_clean_story())
+    parsed = json.loads(card.to_json())
+    assert parsed["ship"] is False
+    assert parsed["tier1_clean"] is True
+    assert "definition_of_done" in parsed
+    assert parsed["gates"][0]["gate"] == "structure"

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -1,0 +1,134 @@
+"""Tests for the LLM-judge logic (bench/judge.py) — no model required.
+
+The LM-calling functions (find_contradictions, judge_premise_fidelity,
+score_rubric) are exercised in integration; here we test the deterministic
+parts: the check_* threshold/severity logic with injected results, the
+coercion of messy LM outputs, and the median aggregation.
+"""
+from __future__ import annotations
+
+from bench.judge import (
+    RUBRIC_AXES,
+    AxisScore,
+    Contradiction,
+    PremiseVerdict,
+    _coerce_axis,
+    _coerce_contradiction,
+    _coerce_premise,
+    _median_axes,
+    check_continuity,
+    check_premise_fidelity,
+    check_rubric,
+)
+
+_CHAPTERS = {"Chapter 1": "prose one", "Chapter 2": "prose two"}
+
+
+# --- check_continuity -------------------------------------------------------
+
+def test_continuity_hard_contradiction_fails():
+    findings = check_continuity(
+        _CHAPTERS, "cast",
+        contradictions=[Contradiction("death", "hard", "Soren dies in ch3, speaks in ch5")],
+    )
+    fails = [f for f in findings if f.severity == "fail"]
+    assert len(fails) == 1
+    assert "Soren" in fails[0].message
+
+
+def test_continuity_minor_contradiction_warns():
+    findings = check_continuity(
+        _CHAPTERS, "cast",
+        contradictions=[Contradiction("trait", "minor", "eye colour wobble")],
+    )
+    assert [f.severity for f in findings] == ["warn"]
+
+
+def test_continuity_clean_reports_info():
+    findings = check_continuity(_CHAPTERS, "cast", contradictions=[])
+    assert [f.severity for f in findings] == ["info"]
+
+
+def test_continuity_empty_chapters_no_findings():
+    assert check_continuity({}, "cast", contradictions=[]) == []
+
+
+# --- check_premise_fidelity -------------------------------------------------
+
+def test_premise_dramatized_passes():
+    findings = check_premise_fidelity(
+        "idea", _CHAPTERS, verdict=PremiseVerdict(dramatizes=True, score=5, note="solid")
+    )
+    assert [f.severity for f in findings] == ["info"]
+
+
+def test_premise_off_idea_fails():
+    findings = check_premise_fidelity(
+        "idea", _CHAPTERS, verdict=PremiseVerdict(dramatizes=False, score=2, note="generic")
+    )
+    assert [f.severity for f in findings] == ["fail"]
+
+
+def test_premise_low_score_even_if_dramatizes_fails():
+    findings = check_premise_fidelity(
+        "idea", _CHAPTERS, verdict=PremiseVerdict(dramatizes=True, score=2)
+    )
+    assert [f.severity for f in findings] == ["fail"]
+
+
+# --- check_rubric -----------------------------------------------------------
+
+def _scores(value: int) -> list[AxisScore]:
+    return [AxisScore(axis, value) for axis in RUBRIC_AXES]
+
+
+def test_rubric_all_high_passes():
+    findings = check_rubric(_CHAPTERS, scores=_scores(5))
+    assert [f.severity for f in findings] == ["info"]
+
+
+def test_rubric_low_average_fails():
+    findings = check_rubric(_CHAPTERS, scores=_scores(3))  # avg 3.0 < 4.0
+    assert [f.severity for f in findings] == ["fail"]
+
+
+def test_rubric_one_axis_below_floor_fails_even_with_high_average():
+    scores = [AxisScore(a, 5) for a in RUBRIC_AXES if a != "ending"] + [AxisScore("ending", 2)]
+    findings = check_rubric(_CHAPTERS, scores=scores)
+    assert findings[0].severity == "fail"
+    assert "ending" in findings[0].message
+
+
+def test_rubric_empty_scores_warns():
+    findings = check_rubric(_CHAPTERS, scores=[])
+    assert [f.severity for f in findings] == ["warn"]
+
+
+# --- coercion ---------------------------------------------------------------
+
+def test_coerce_contradiction_from_dict_and_unknown_severity():
+    c = _coerce_contradiction({"kind": "timeline", "severity": "weird", "detail": "x"})
+    assert c.severity == "hard"  # unknown -> surfaced as hard
+    assert _coerce_contradiction({"detail": ""}) is None  # empty detail dropped
+
+
+def test_coerce_axis_normalises_and_clamps():
+    assert _coerce_axis({"axis": "Arc-Structure", "score": 9}).axis == "arc_structure"
+    assert _coerce_axis({"axis": "arc structure", "score": 9}).score == 5  # clamped
+    assert _coerce_axis({"axis": "nonsense", "score": 3}) is None
+    assert _coerce_axis({"axis": "ending", "score": "x"}) is None
+
+
+def test_coerce_premise_defaults_bad_score_to_zero():
+    v = _coerce_premise({"dramatizes": True, "score": "nope"})
+    assert v.dramatizes is True
+    assert v.score == 0
+
+
+# --- median aggregation -----------------------------------------------------
+
+def test_median_axes_takes_per_axis_median():
+    runs = [_scores(2), _scores(4), _scores(5)]  # median per axis = 4
+    merged = _median_axes(runs)
+    assert {a.axis for a in merged} == set(RUBRIC_AXES)
+    assert all(a.score == 4 for a in merged)


### PR DESCRIPTION
Make "did generation succeed?" answerable in one place. Today the evaluation
surface is fragmented (run_qa, check_pov, lint_story, bench/criteria) with no
single verdict, the documented Definition of Done isn't executable (POV is
listed but never run), and the chapter floor disagrees across docs (80 vs 300).

Add bench/evaluate.py: a FullScorecard that composes the deterministic Tier-1
checks with the existing LLM-backed Tier-2 gates (POV via pov_check, prose lint
via story_linter) into one JSON verdict with honest ship/complete/tier1_clean
flags. The Tier-2 gates are opt-in (run_llm / --with-llm) and injectable, so
the orchestrator is fully testable without a model. Each Definition-of-Done
item maps to a gate; "real ending" is surfaced as a manual check until Tier-3.

- qa.py: add check_structure (required sections; also guards the heading-
  coupled parsers), check_placeholder_protagonist (high-precision literal
  "protagonist" in prose -> FAIL), check_chapter_band (thin/bloated -> WARN);
  add CHAPTER_TARGET_BAND. Existing run_all/CHECKS unchanged.
- Reconcile the chapter floor in qa.py as the single source of truth: 80-word
  hard floor (FAIL = broken) + 300-2500 target band (WARN = thin/bloated).
  bench/criteria.py no longer FAILs at 300 (which wrongly failed the supported
  fast model's normal output); also count only warn-level budget hits.
- scripts/evaluate.py: human CLI with --with-llm + scorecard.json sidecar
  (mirrors check_pov.py's DSPy flags). python -m bench.evaluate is the
  dspy-free deterministic entry point.
- Tests: deterministic coverage for the three new qa checks, the orchestrator
  (ship/complete logic, DoD map, injected Tier-2), and the criteria floor.
- Docs: docs/07 DoD->gate mapping + unified command; eval-spec T1.1 floor
  reconciliation + Tier-2 status; AGENTS/bench README updated.

https://claude.ai/code/session_01FS9mWwAojeNAcx3r8gaxtm