### PR TITLE
Add shared canon config + deterministic continuity metrics + post-gen gate

### DIFF
--- a/bench/criteria.py
+++ b/bench/criteria.py
@@ -6,8 +6,12 @@ name drift, cross-chapter phrase reuse, POV classification). This module
 applies the spec's thresholds (hard floor 300 words vs qa.py's runtime
 default 80, 5-gram budget of 5, etc.) and emits a scorecard.
 
-Tier-2/Tier-3 LLM-judge checks are out of scope here — they'll plug in
-later via a `bench/judge.py` once the prompt + judge model are chosen.
+The deterministic canon/continuity metrics in `canon_metrics.py` (scaffolding
+leak, name-arc ordering, locked-appearance contradiction, required-artifact
+placement, timeline/age) are also folded in here as Tier-1 gates: a project's
+`canon` config (loaded by default from `canon/<project>.yaml`) drives them, and
+any canon FAIL blocks shipping. Tier-2/Tier-3 LLM-judge checks plug in via
+`bench/judge.py`.
 """
 from __future__ import annotations
 
@@ -15,6 +19,8 @@ import json
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
+import canon as canon_mod
+import canon_metrics
 import qa
 
 # Thresholds from bench/eval-spec.md
@@ -36,16 +42,23 @@ class Scorecard:
         return json.dumps(asdict(self), indent=2)
 
 
-def score(story_md_path: Path) -> Scorecard:
+def score(story_md_path: Path, canon=None) -> Scorecard:
     """Run all deterministic checks against a story markdown artifact.
 
     Returns a Scorecard with separated FAILs and WARNs plus per-budget
     counts. `ship=True` only if zero Tier-1 FAILs and every budget respected.
+
+    `canon` is a :class:`canon.Canon`; when ``None`` the project default is
+    loaded (an empty canon if none is authored, making the canon metrics no-ops).
     """
+    if canon is None:
+        canon = canon_mod.load_canon()
     findings = qa.run_all(story_md_path)
     # T1.1 in qa.py uses default min_words=80; re-run with spec floor of 300
     text = Path(story_md_path).read_text(encoding="utf-8")
     findings.extend(qa.check_chapter_length(text, min_words=HARD_CHAPTER_FLOOR))
+    # Deterministic canon/continuity gates (no-ops under an empty canon).
+    findings.extend(canon_metrics.run_all(text, canon))
 
     fails: list[dict] = []
     warns: list[dict] = []

--- a/bench/judge.py
+++ b/bench/judge.py
@@ -1,0 +1,185 @@
+"""LM-judge canon/continuity metrics (Tier-2 of bench/eval-spec.md).
+
+These mirror :mod:`pov_check` and :mod:`story_linter`: a ``dspy.ChainOfThought``
+reads the manuscript and the canon, returns a structured verdict, and the verdict
+is coerced into :class:`qa.Finding` records so it folds into the same
+info/warn/fail report.
+
+The heuristics in :mod:`canon_metrics` can't read for sense; these judges can:
+
+* :func:`judge_appearance` — is the POV character physically described at all,
+  and does any description contradict ``locked_appearance``?
+* :func:`judge_invariant`  — a semantic ``canon_invariant`` (Azazel stays in the
+  Maw after Ch.11; the Command-of-the-Void leash frays; Kira is not a strawman).
+* :func:`judge_dangling_payoff` — setups that are never paid off.
+
+Every check takes an optional pre-computed ``verdict``/``verdicts`` argument so it
+can be unit-tested without an LM (exactly as ``pov_check.check_pov_consistency``
+accepts ``classifications``).
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from qa import Finding, split_chapters
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Verdict:
+    """One LM judgement: did the manuscript satisfy the rule?"""
+
+    holds: bool          # True = the canon rule is satisfied
+    evidence: str = ""   # short justification / the offending detail
+
+
+def _manuscript_text(text: str) -> str:
+    chapters = split_chapters(text)
+    return "\n\n".join(f"### {title}\n\n{body}" for title, body in chapters.items())
+
+
+def _coerce(item: object) -> Verdict:
+    """Coerce a DSPy output into a :class:`Verdict`."""
+    if isinstance(item, Verdict):
+        return item
+    if isinstance(item, dict):
+        holds = item.get("holds")
+        evidence = item.get("evidence") or item.get("note") or ""
+    else:
+        holds = getattr(item, "holds", None)
+        evidence = getattr(item, "evidence", "") or ""
+    return Verdict(holds=bool(holds), evidence=str(evidence).strip())
+
+
+def judge_rule(manuscript: str, rule: str) -> Verdict:
+    """Ask the configured DSPy LM whether ``rule`` holds over ``manuscript``.
+
+    Raises whatever the underlying DSPy call raises — failures stay visible.
+    """
+    import dspy
+
+    class JudgeCanonRule(dspy.Signature):
+        """Judge whether a manuscript satisfies a single canon/continuity rule.
+
+        You are given the chapters of one story (each introduced by a
+        ``### Chapter N: ...`` heading) and one rule that the story must satisfy.
+        Read for sense — consider only the narration and events, ignoring what is
+        said inside quoted dialogue when the rule is about facts of the world.
+        Decide whether the rule HOLDS. Set ``holds`` true only if the manuscript
+        clearly satisfies the rule; set it false if the manuscript violates it.
+        ``evidence`` is a short justification naming the chapter and the offending
+        (or confirming) detail.
+        """
+
+        rule: str = dspy.InputField(desc="The canon/continuity rule to check")
+        manuscript: str = dspy.InputField(desc="The story's chapters with headings")
+        holds: bool = dspy.OutputField(desc="True if the rule is satisfied")
+        evidence: str = dspy.OutputField(desc="Short justification (chapter + detail)")
+
+    result = dspy.ChainOfThought(JudgeCanonRule)(rule=rule, manuscript=manuscript)
+    return _coerce(result)
+
+
+def _finding(check: str, verdict: Verdict, fail_severity: str = "fail") -> Finding:
+    if verdict.holds:
+        return Finding(check=check, severity="info",
+                       message=f"{check}: ok" + (f" ({verdict.evidence})" if verdict.evidence else ""))
+    suffix = f" ({verdict.evidence})" if verdict.evidence else ""
+    return Finding(check=check, severity=fail_severity, message=f"{check}: violated{suffix}")
+
+
+# --- appearance --------------------------------------------------------------
+
+def _appearance_spec(canon) -> str:
+    proto = (getattr(canon, "locked_appearance", {}) or {}).get("protagonist", {})
+    parts = [f"{k}: {proto[k]}" for k in ("eyes", "hair", "hair_style", "build") if proto.get(k)]
+    marks = proto.get("permanent_marks") or []
+    if marks:
+        parts.append("permanent mark(s): " + ", ".join(marks))
+    return "; ".join(parts)
+
+
+def judge_appearance(
+    text: str, canon, described: Verdict | None = None, consistent: Verdict | None = None
+) -> list[Finding]:
+    """Two findings: the POV character must be physically described at all, and
+    any description must not contradict ``locked_appearance``."""
+    manuscript = _manuscript_text(text)
+    spec = _appearance_spec(canon)
+
+    if described is None:
+        described = judge_rule(
+            manuscript,
+            "The point-of-view / protagonist character is given concrete physical "
+            "description somewhere in the prose (not left a faceless cipher).",
+        )
+    findings = [_finding("appearance_described", described)]
+
+    if spec:
+        if consistent is None:
+            consistent = judge_rule(
+                manuscript,
+                f"Every physical description of the protagonist is consistent with "
+                f"this locked appearance and never contradicts it: {spec}. "
+                f"Damage may accumulate but there is no transformation.",
+            )
+        findings.append(_finding("appearance_vs_spec", consistent))
+    return findings
+
+
+# --- semantic invariants -----------------------------------------------------
+
+def judge_invariants(text: str, canon, verdicts: dict[str, Verdict] | None = None) -> list[Finding]:
+    """One finding per ``canon_invariant``; ``verdicts`` maps invariant id ->
+    Verdict for testing without an LM."""
+    manuscript = _manuscript_text(text)
+    invariants = getattr(canon, "canon_invariants", []) or []
+    findings: list[Finding] = []
+    for inv in invariants:
+        inv_id = inv.get("id", "invariant")
+        rule = inv.get("rule", "")
+        verdict = (verdicts or {}).get(inv_id)
+        if verdict is None:
+            verdict = judge_rule(manuscript, rule)
+        findings.append(_finding(inv_id, verdict))
+    return findings
+
+
+# --- dangling setup/payoff ---------------------------------------------------
+
+def judge_dangling_payoff(text: str, verdict: Verdict | None = None) -> list[Finding]:
+    """Flag setups introduced and never paid off (a dangling thread)."""
+    manuscript = _manuscript_text(text)
+    if verdict is None:
+        verdict = judge_rule(
+            manuscript,
+            "Every setup or promise the story makes (an introduced object, threat, "
+            "question, or named plan) is paid off or resolved by the end; no major "
+            "thread is left dangling.",
+        )
+    return [_finding("dangling_payoff", verdict, fail_severity="warn")]
+
+
+# --- runner ------------------------------------------------------------------
+
+def run_all(text: str, canon, verdicts: dict[str, Verdict] | None = None) -> list[Finding]:
+    """Run every LM judge. ``verdicts`` (keyed by check/invariant id) short-circuits
+    the LM for any provided verdict — used by tests and to compose cached runs."""
+    verdicts = verdicts or {}
+    out: list[Finding] = []
+    out.extend(judge_appearance(
+        text, canon,
+        described=verdicts.get("appearance_described"),
+        consistent=verdicts.get("appearance_vs_spec"),
+    ))
+    out.extend(judge_invariants(text, canon, verdicts=verdicts))
+    out.extend(judge_dangling_payoff(text, verdict=verdicts.get("dangling_payoff")))
+    return out
+
+
+def run(path: Path, canon) -> list[Finding]:
+    """Run the LM judges on a story markdown file (calls the LM)."""
+    return run_all(Path(path).read_text(encoding="utf-8"), canon)

--- a/bench/metric.py
+++ b/bench/metric.py
@@ -1,0 +1,129 @@
+"""Composite story-quality metric for ``dspy.Evaluate`` and the optimizer.
+
+Folds the deterministic canon metrics (and, optionally, cached LM-judge verdicts)
+into a single score in ``[0, 1]`` so prompts/demos can be tuned to reduce the
+real continuity failures. Higher is better; each failing check subtracts its
+weight.
+
+The metric is deterministic by default (LM judges off), so it runs in CI without
+an API key. ``make_story_metric`` returns a callable with the
+``metric(example, prediction, trace=None) -> float`` shape DSPy optimizers and
+``dspy.Evaluate`` expect.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import canon as canon_mod
+import canon_guard
+import canon_metrics
+
+# Penalty weight per failing check. Hard continuity gates cost the most.
+WEIGHTS: dict[str, float] = {
+    "scaffolding_leak": 0.20,
+    "name_arc": 0.20,
+    "canon_fact": 0.20,
+    "required_artifact": 0.15,
+    "timeline_age": 0.15,
+    # LM-judge checks (only applied when verdicts are supplied).
+    "appearance_described": 0.15,
+    "appearance_vs_spec": 0.15,
+    "azazel_maw": 0.10,
+    "leash_fray": 0.10,
+    "kira_not_strawman": 0.10,
+    "dangling_payoff": 0.05,
+}
+DEFAULT_WEIGHT = 0.10
+
+
+def _prediction_text(prediction) -> str:
+    """Extract the manuscript/prose text from a variety of prediction shapes."""
+    if isinstance(prediction, str):
+        return prediction
+    for attr in ("story", "manuscript", "prose", "text"):
+        value = getattr(prediction, attr, None)
+        if isinstance(value, str) and value:
+            return value
+    return str(prediction)
+
+
+def score_text(text: str, canon, judge_findings=None, weights: dict[str, float] | None = None) -> float:
+    """Score one manuscript: ``1.0`` minus the weight of every failing check.
+
+    ``judge_findings`` is an optional pre-computed list of ``qa.Finding`` from the
+    LM judges (so the LM is never called from inside the metric). Result is
+    clamped to ``[0, 1]``.
+    """
+    weights = weights or WEIGHTS
+    findings = list(canon_metrics.run_all(text, canon))
+    if judge_findings:
+        findings.extend(judge_findings)
+
+    penalty = 0.0
+    for f in findings:
+        if f.severity == "fail":
+            penalty += weights.get(f.check, DEFAULT_WEIGHT)
+        elif f.severity == "warn":
+            penalty += 0.5 * weights.get(f.check, DEFAULT_WEIGHT)
+    return max(0.0, min(1.0, 1.0 - penalty))
+
+
+def make_story_metric(canon=None, *, threshold: float | None = None, weights=None):
+    """Build a DSPy-compatible metric closure bound to a ``canon``.
+
+    When ``threshold`` is given the metric returns a ``bool`` (score >= threshold)
+    — the shape bootstrapping optimizers expect; otherwise it returns the float
+    score for ``dspy.Evaluate``.
+    """
+    canon = canon if canon is not None else canon_mod.load_canon()
+
+    def metric(example, prediction, trace=None) -> float | bool:
+        text = _prediction_text(prediction)
+        # An example may pin its own canon; fall back to the bound one.
+        ex_canon = getattr(example, "canon", None) or canon
+        judge_findings = getattr(example, "judge_findings", None)
+        score = score_text(text, ex_canon, judge_findings=judge_findings, weights=weights)
+        if threshold is not None:
+            return score >= threshold
+        # During optimization (trace is not None) DSPy wants a hard pass/fail.
+        if trace is not None:
+            return score >= 1.0
+        return score
+
+    return metric
+
+
+def make_chapter_metric(canon=None, *, threshold: float | None = None, weights=None):
+    """Build a per-chapter metric for optimizing the chapter drafter.
+
+    Unlike :func:`make_story_metric` (whole manuscript), this scores one chapter's
+    prose against the canon using the same deterministic critic the generation
+    guard uses, so the optimizer is tuned on exactly the constraints the pipeline
+    enforces. The DSPy ``example`` must carry ``chapter_number`` (and optionally
+    ``chapter_title``); it may pin its own ``canon``.
+    """
+    canon = canon if canon is not None else canon_mod.load_canon()
+    weights = weights or WEIGHTS
+
+    def metric(example, prediction, trace=None) -> float | bool:
+        prose = _prediction_text(prediction)
+        number = int(getattr(example, "chapter_number", 1))
+        title = getattr(example, "chapter_title", "Untitled")
+        ex_canon = getattr(example, "canon", None) or canon
+        violations = canon_guard.chapter_violations(prose, ex_canon, number, title)
+        penalty = sum(weights.get(f.check, DEFAULT_WEIGHT) for f in violations)
+        score = max(0.0, min(1.0, 1.0 - penalty))
+        if threshold is not None:
+            return score >= threshold
+        # During optimization (trace is not None) DSPy wants a hard pass/fail.
+        if trace is not None:
+            return score >= 1.0
+        return score
+
+    return metric
+
+
+def score_path(story_md_path: Path, canon=None) -> float:
+    """Convenience: score a story markdown file on disk (deterministic only)."""
+    canon = canon if canon is not None else canon_mod.load_canon()
+    return score_text(Path(story_md_path).read_text(encoding="utf-8"), canon)

--- a/bench/regression.py
+++ b/bench/regression.py
@@ -1,0 +1,139 @@
+"""Regression/eval set seeded with the REAL continuity bugs.
+
+Each gold negative is a minimal manuscript carrying one of the defects found in
+the manual review, labelled with the deterministic metric that MUST flag it. The
+good cases are the matching false-positive traps that must stay clean (a negated
+non-feature, a sanctioned spelled-out alias, a sanctioned meta-narrative device).
+
+This is the deterministic backbone the pipeline must keep passing. It is exercised
+by ``test_regression.py`` and can be run directly::
+
+    python -m bench.regression
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import canon as canon_mod
+import canon_metrics
+import qa
+
+
+@dataclass
+class RegressionCase:
+    """One labelled fixture. A gold negative names the check that must FAIL; a
+    good case asserts the suite stays clean (optionally for a specific check)."""
+
+    id: str
+    text: str
+    must_fail: str | None = None          # gold negative -> this check must FAIL
+    must_not_fail: list[str] = field(default_factory=list)  # good case guards
+
+
+def _story(chapters: dict[str, str], characters: str = "") -> str:
+    parts = ["# Story", "", "## World bible", "", "### Characters", "", characters,
+             "", "## Final Story", ""]
+    for title, body in chapters.items():
+        parts += [f"### {title}", "", body, ""]
+    return "\n".join(parts)
+
+
+# --- gold negatives (the real bugs) -----------------------------------------
+
+GOLD_NEGATIVES = [
+    RegressionCase(
+        id="scaffolding_ch19",
+        text=_story({"Chapter 18: The Break":
+                     "The breaking was Ch.19's. He had no Ch.19."}),
+        must_fail="scaffolding_leak",
+    ),
+    RegressionCase(
+        id="timeline_eight_years",
+        text=_story({"Chapter 9: After":
+                     "Over the next eight years, the city forgot her name."}),
+        must_fail="timeline_age",
+    ),
+    RegressionCase(
+        id="name_reveal_marta_elias",
+        text=_story({"Chapter 10: The Warning":
+                     'Marta caught his sleeve. "Elias," she whispered, "run now."'}),
+        must_fail="name_arc",
+    ),
+    RegressionCase(
+        id="appearance_blue_eyes",
+        text=_story({"Chapter 1: Open":
+                     "She studied his blue eyes for a long, cold moment."}),
+        must_fail="canon_fact",
+    ),
+]
+
+
+# --- good cases (must stay clean) -------------------------------------------
+
+GOOD_CASES = [
+    RegressionCase(
+        id="appearance_no_horns",
+        text=_story({"Chapter 1: Open":
+                     "No horns, no wings — only his grey eyes, the same as ever."}),
+        must_not_fail=["canon_fact"],
+    ),
+    RegressionCase(
+        id="alias_eighty_four",
+        text=_story(
+            {"Chapter 8: The Roll": "They called for Vessel Eighty-Four, and Vessel "
+                                    "Eighty-Four stepped forward."},
+            characters="1. Vessel 84, a vessel of the order",
+        ),
+        must_not_fail=["name_drift"],
+    ),
+    RegressionCase(
+        id="device_reader",
+        text=_story({"Chapter 5: Stand":
+                     "The reader sees her stand. She did not move from the doorway."}),
+        must_not_fail=["scaffolding_leak"],
+    ),
+]
+
+
+def deterministic_findings(text: str, canon) -> list:
+    """The full deterministic suite used for regression: canon metrics plus the
+    alias-aware name-drift check, run on alias-normalized text."""
+    norm = canon_mod.apply_accepted_aliases(text, canon)
+    findings = list(canon_metrics.run_all(norm, canon))
+    findings += qa.check_name_drift(norm)
+    return findings
+
+
+def evaluate_case(case: RegressionCase, canon) -> tuple[bool, str]:
+    """Return (passed, detail) for one case against the deterministic suite."""
+    findings = deterministic_findings(case.text, canon)
+    failed = {f.check for f in findings if f.severity == "fail"}
+
+    if case.must_fail is not None:
+        ok = case.must_fail in failed
+        return ok, (f"expected FAIL[{case.must_fail}]; "
+                    f"got fails={sorted(failed) or '∅'}")
+
+    leaked = [c for c in case.must_not_fail if c in failed]
+    return not leaked, (f"expected clean for {case.must_not_fail}; "
+                        f"got fails={sorted(failed) or '∅'}")
+
+
+def run(canon=None) -> tuple[bool, list[tuple[str, bool, str]]]:
+    """Evaluate every case; return (all_passed, per-case rows)."""
+    canon = canon if canon is not None else canon_mod.load_canon()
+    rows: list[tuple[str, bool, str]] = []
+    for case in (*GOLD_NEGATIVES, *GOOD_CASES):
+        passed, detail = evaluate_case(case, canon)
+        rows.append((case.id, passed, detail))
+    return all(p for _, p, _ in rows), rows
+
+
+if __name__ == "__main__":
+    import sys
+
+    all_passed, rows = run()
+    for case_id, passed, detail in rows:
+        print(f"[{'PASS' if passed else 'FAIL'}] {case_id}: {detail}")
+    print(f"\n{'ALL PASS' if all_passed else 'REGRESSIONS PRESENT'}")
+    sys.exit(0 if all_passed else 1)

--- a/canon.py
+++ b/canon.py
@@ -1,0 +1,215 @@
+"""The shared canon/continuity config — one source of truth for the rules that
+span chapters.
+
+A project's canon lives in a machine-readable file (``canon/<project>.yaml`` or
+``.json``) and is consumed two ways:
+
+* **Generation (prevent):** :func:`render_chapter_slice` turns the slice of the
+  canon relevant to one chapter into a plain-text directive block that is fed
+  into the per-chapter drafting signatures (names allowed this chapter, the
+  locked appearance, the POV rule, "no scaffolding vocabulary", and any required
+  artifact for that chapter).
+* **Evaluation (score/gate):** the deterministic metrics in
+  :mod:`canon_metrics` and the LM judges in :mod:`bench.judge` read the same
+  :class:`Canon` object.
+
+The :class:`Canon` schema is intentionally generic/per-project — the pipeline
+writes other stories from other ideas — so only the *values* in the YAML are
+story-specific. See ``docs/canon-schema.md`` for the schema contract.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Default location used when no explicit path is given. A project ships exactly
+# one canon file; this is the "Nameless Weapon" instance.
+DEFAULT_CANON_PATH = Path(__file__).resolve().parent / "canon" / "nameless_weapon.yaml"
+
+
+@dataclass(frozen=True)
+class Canon:
+    """A parsed canon/continuity config.
+
+    Every field defaults to empty so a partial canon (or no canon at all) is
+    valid: a project that does not pin, say, ``required_artifacts`` simply has
+    none enforced. ``raw`` keeps the untouched mapping for forward-compat.
+    """
+
+    project: str = ""
+    title: str = ""
+    narration: dict[str, Any] = field(default_factory=dict)
+    timeline: dict[str, Any] = field(default_factory=dict)
+    name_arc: dict[str, Any] = field(default_factory=dict)
+    locked_appearance: dict[str, Any] = field(default_factory=dict)
+    required_artifacts: dict[int, dict] = field(default_factory=dict)
+    canon_invariants: list[dict] = field(default_factory=list)
+    accepted_aliases: dict[str, str] = field(default_factory=dict)
+    motif_allowlist: list[str] = field(default_factory=list)
+    scaffolding_blocklist: list[str] = field(default_factory=list)
+    device_allowlist: list[str] = field(default_factory=list)
+    raw: dict = field(default_factory=dict)
+
+    # --- name-arc helpers ----------------------------------------------------
+
+    def names_not_yet_allowed(self, chapter: int) -> list[str]:
+        """Names whose earliest-narration chapter is strictly after ``chapter``."""
+        earliest = self.name_arc.get("earliest_narration", {})
+        return sorted(n for n, ch in earliest.items() if chapter < int(ch))
+
+    def names_allowed(self, chapter: int) -> list[str]:
+        """Restricted names that have become available by ``chapter``."""
+        earliest = self.name_arc.get("earliest_narration", {})
+        return sorted(n for n, ch in earliest.items() if chapter >= int(ch))
+
+    def required_artifact(self, chapter: int) -> dict | None:
+        return self.required_artifacts.get(int(chapter))
+
+    def active_invariants(self, chapter: int) -> list[dict]:
+        """Invariants in force as of ``chapter`` (those with no ``after_chapter``
+        or whose ``after_chapter`` is < ``chapter``)."""
+        out: list[dict] = []
+        for inv in self.canon_invariants:
+            after = inv.get("after_chapter")
+            if after is None or chapter > int(after):
+                out.append(inv)
+        return out
+
+
+def _coerce_int_keys(mapping: Any) -> dict[int, Any]:
+    """Coerce a mapping's keys to ``int`` where possible (YAML/JSON object keys
+    for chapter numbers can arrive as ``str``)."""
+    if not isinstance(mapping, dict):
+        return {}
+    out: dict[int, Any] = {}
+    for key, value in mapping.items():
+        try:
+            out[int(key)] = value
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def from_dict(data: dict) -> Canon:
+    """Build a :class:`Canon` from an already-parsed mapping."""
+    data = data or {}
+    name_arc = dict(data.get("name_arc", {}) or {})
+    if "call_order" in name_arc:
+        name_arc["call_order"] = _coerce_int_keys(name_arc["call_order"])
+    return Canon(
+        project=str(data.get("project", "")),
+        title=str(data.get("title", "")),
+        narration=dict(data.get("narration", {}) or {}),
+        timeline=dict(data.get("timeline", {}) or {}),
+        name_arc=name_arc,
+        locked_appearance=dict(data.get("locked_appearance", {}) or {}),
+        required_artifacts=_coerce_int_keys(data.get("required_artifacts", {})),
+        canon_invariants=list(data.get("canon_invariants", []) or []),
+        accepted_aliases=dict(data.get("accepted_aliases", {}) or {}),
+        motif_allowlist=list(data.get("motif_allowlist", []) or []),
+        scaffolding_blocklist=list(data.get("scaffolding_blocklist", []) or []),
+        device_allowlist=list(data.get("device_allowlist", []) or []),
+        raw=data,
+    )
+
+
+def load_canon(path: str | Path | None = None) -> Canon:
+    """Load a canon config from YAML or JSON.
+
+    ``path=None`` loads :data:`DEFAULT_CANON_PATH` if present, else returns an
+    empty :class:`Canon` (so the pipeline runs canon-free for projects that
+    haven't authored one yet).
+    """
+    if path is None:
+        if not DEFAULT_CANON_PATH.exists():
+            return Canon()
+        path = DEFAULT_CANON_PATH
+    p = Path(path)
+    text = p.read_text(encoding="utf-8")
+    if p.suffix.lower() == ".json":
+        data = json.loads(text)
+    else:
+        data = yaml.safe_load(text)
+    return from_dict(data or {})
+
+
+# --- generation-time rendering ----------------------------------------------
+
+
+def _appearance_lines(locked: dict) -> list[str]:
+    """Render the protagonist's locked physical anchor as instruction lines."""
+    proto = locked.get("protagonist", {}) if locked else {}
+    if not proto:
+        return []
+    traits: list[str] = []
+    for key in ("eyes", "hair", "hair_style", "build"):
+        if proto.get(key):
+            label = key.replace("_", " ")
+            traits.append(f"{label}: {proto[key]}")
+    marks = proto.get("permanent_marks") or []
+    if marks:
+        traits.append("permanent mark(s): " + ", ".join(marks))
+    if not traits:
+        return []
+    lines = [
+        "GROUND THE POV CHARACTER PHYSICALLY. The point-of-view character has a "
+        "fixed appearance — anchor them in the prose with these exact traits, and "
+        "never contradict them:",
+    ]
+    lines += [f"  - {t}" for t in traits]
+    principle = proto.get("principle")
+    if principle:
+        lines.append(f"  - principle: {principle}")
+    return lines
+
+
+def render_chapter_slice(canon: Canon, chapter: int) -> str:
+    """Render the canon directives relevant to ``chapter`` as a plain-text block.
+
+    This is what gets injected into the per-chapter drafting signatures. An empty
+    canon renders to an empty string (no-op injection).
+    """
+    if canon == Canon():
+        return ""
+
+    sections: list[str] = [f"CANON DIRECTIVES FOR CHAPTER {chapter}:"]
+
+    pov_rule = (canon.narration or {}).get("pov_rule")
+    if pov_rule:
+        sections.append(f"POINT OF VIEW: {pov_rule}")
+
+    sections += _appearance_lines(canon.locked_appearance) or []
+
+    not_yet = canon.names_not_yet_allowed(chapter)
+    if not_yet:
+        sections.append(
+            "NAMES NOT YET REVEALED — do not use these names in narration yet: "
+            + ", ".join(not_yet)
+            + "."
+        )
+
+    artifact = canon.required_artifact(chapter)
+    if artifact:
+        sections.append(
+            f"REQUIRED THIS CHAPTER: this chapter must include the "
+            f"{artifact.get('name', 'required artifact')}."
+        )
+
+    invariants = canon.active_invariants(chapter)
+    if invariants:
+        sections.append("CANON INVARIANTS in force:")
+        sections += [f"  - {inv.get('rule', '')}" for inv in invariants]
+
+    if canon.scaffolding_blocklist:
+        sections.append(
+            "NO SCAFFOLDING VOCABULARY: this is finished prose. Never write "
+            "planning/production language such as chapter numbers ('Ch. 4'), "
+            "'Beat 3', 'world bible', 'setup/payoff', 'easter egg', 'POV', or "
+            "address 'the reader'."
+        )
+
+    return "\n".join(sections)

--- a/canon.py
+++ b/canon.py
@@ -20,6 +20,7 @@ story-specific. See ``docs/canon-schema.md`` for the schema contract.
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -135,6 +136,19 @@ def load_canon(path: str | Path | None = None) -> Canon:
     else:
         data = yaml.safe_load(text)
     return from_dict(data or {})
+
+
+def apply_accepted_aliases(text: str, canon: Canon) -> str:
+    """Rewrite each accepted spoken/spelled-out alias to its canonical form.
+
+    Used before name-drift detection so a sanctioned form ("Vessel Eighty-Four")
+    is not mistaken for drift from its canonical ("Vessel 84"). Longer aliases are
+    applied first so a contained alias ("Eighty-Four") doesn't pre-empt the longer
+    match."""
+    for spoken in sorted(canon.accepted_aliases, key=len, reverse=True):
+        canonical = canon.accepted_aliases[spoken]
+        text = re.sub(re.escape(spoken), canonical, text, flags=re.IGNORECASE)
+    return text
 
 
 # --- generation-time rendering ----------------------------------------------

--- a/canon/nameless_weapon.yaml
+++ b/canon/nameless_weapon.yaml
@@ -1,0 +1,131 @@
+# Canon / continuity config — "The Nameless Weapon" instance.
+#
+# This file is DATA, not code. It encodes the "rules that span files" found in a
+# manual chapter-by-chapter continuity review, and is consumed two ways:
+#   (a) rendered into generation context/instructions (see canon.render_chapter_slice)
+#       to PREVENT the failures, and
+#   (b) read by the deterministic metrics in canon_metrics.py and the LM judges in
+#       bench/judge.py to SCORE and GATE them.
+#
+# The schema is generic/per-project (the pipeline writes other stories from other
+# ideas); only the values below are specific to this manuscript. See
+# docs/canon-schema.md for the schema contract.
+
+project: nameless_weapon
+title: The Nameless Weapon
+
+# How the narrative POV must behave (read by the slice renderer; the POV metric
+# itself lives in pov_check.py / bench.judge).
+narration:
+  pov_rule: >-
+    Maintain a single, consistent narrative point of view. Do not shift point of
+    view within a chapter, and do not change the dominant point of view from one
+    chapter to the next.
+
+# year <-> age map + year-codes + key spans.
+# Year 0 = age 16 ... Year 5 = age 21. The whole story spans 5 years.
+timeline:
+  max_total_span_years: 5
+  year_to_age:
+    0: 16
+    1: 17
+    2: 18
+    3: 19
+    4: 20
+    5: 21
+  year_codes:
+    7N-702: { year: 0, note: flight }
+    7N-707: { year: 5, note: death }
+  key_spans:
+    - from_code: 7N-702
+      to_code: 7N-707
+      years: 5
+      note: flight (7N-702) to death (7N-707)
+
+# Earliest chapter each name may appear in narration; when it was learned; and
+# per-speaker reveal rules.
+name_arc:
+  # name -> earliest chapter the name may appear in narration at all.
+  earliest_narration:
+    Elias: 7
+    Severin: 11
+  # name -> chapter in which the protagonist/narrator learns it (context only).
+  learned:
+    Elias: 6
+  # A specific speaker may only utter a name from a given chapter onward.
+  reveal_rules:
+    - speaker: Marta
+      name: Elias
+      from_chapter: 17
+  # Ordering constraints for a specific chapter: the names must first appear in
+  # this relative order within the chapter.
+  call_order:
+    17: [Severin, Vessel 84, Elias]
+
+# The protagonist's locked physical anchor. Damage accumulates; there is NO
+# transformation. `contradictions` lists adjectives that would contradict the
+# locked trait and must therefore be flagged by the canon-fact metric.
+locked_appearance:
+  protagonist:
+    eyes: grey
+    hair: brown
+    hair_style: nape-braid
+    build: average/lean
+    permanent_marks:
+      - right-cheek scar
+    principle: "damage accumulates, NO transformation"
+    contradictions:
+      eyes: [blue, green, hazel, amber, golden, gold, violet, red, black, brown]
+      hair: [blond, blonde, red, ginger, black, white, grey, gray, auburn, silver]
+
+# chapter -> artifact that must appear in that chapter's prose. `patterns` are
+# lowercased substrings; at least one must be present.
+required_artifacts:
+  4: { name: hymn, patterns: [hymn] }
+  12: { name: bard song, patterns: [bard, song] }
+
+# Semantic invariants for the LM judges. `after_chapter` (optional) scopes the
+# rule to chapters strictly after the given number.
+canon_invariants:
+  - id: azazel_maw
+    rule: "Azazel stays in the Maw after Ch.11; he does not appear on the surface again."
+    after_chapter: 11
+  - id: leash_fray
+    rule: >-
+      The Command-of-the-Void leash frays progressively through Acts IV-V and is
+      gone by the time of the Capitol.
+  - id: kira_not_strawman
+    rule: "Kira is a convinced person with a coherent position, not a strawman."
+
+# Spoken / spelled-out forms that are NOT name drift. The deterministic metrics
+# treat these as equivalent to their canonical form so they don't false-positive.
+accepted_aliases:
+  Vessel Eighty-Four: Vessel 84
+  Eighty-Four: Vessel 84
+  One-Twelve: Vessel 112
+
+# Sanctioned refrains — intentional repetition that the phrase-reuse checks
+# should not penalize.
+motif_allowlist:
+  - "he did not look back"
+  - "the body the eye slid past"
+  - "the small wooden soldier"
+
+# Planning / production vocabulary forbidden in finished prose. Each entry is a
+# regular expression matched case-insensitively against chapter prose.
+scaffolding_blocklist:
+  - 'Ch\.?\s*\d+'
+  - 'chapter plan'
+  - 'Beat\s+\d+'
+  - 'enhancers? guide'
+  - 'world bible'
+  - 'setup/payoff'
+  - 'easter egg'
+  - 'in another book'
+  - '\bPOV\b'
+  - '\bthe reader\b'
+
+# Intentional exceptions to the scaffolding blocklist: sanctioned meta-narrative
+# devices. A blocklist hit inside one of these phrases is not a leak.
+device_allowlist:
+  - "The reader sees her stand"

--- a/canon_guard.py
+++ b/canon_guard.py
@@ -1,0 +1,131 @@
+"""Generation-time self-correction for the cheap deterministic canon constraints.
+
+DSPy 3.x removed ``dspy.Assert`` / ``dspy.Suggest``, so this is the brief's
+fallback: a small critic→revise submodule. The **critic**
+(:func:`chapter_violations`) is a pure function — it runs the deterministic
+canon metrics over a single drafted chapter and returns the hard violations
+(scaffolding leak, a not-yet-allowed name, a locked-appearance contradiction, a
+missing required artifact, an impossible year-span). The **revise** step
+(:func:`revise_chapter`) feeds those violations back to the LM as feedback and
+asks for a corrected draft.
+
+:func:`draft_with_canon_guard` ties them together: draft, critique, and if the
+draft violates a constraint, revise with the violation as feedback — up to
+``max_revisions`` times. The critic is fully testable without an LM.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Callable
+
+from canon_metrics import (
+    check_canon_fact,
+    check_name_arc,
+    check_required_artifact,
+    check_scaffolding_leak,
+    check_timeline_age,
+)
+from qa import Finding
+
+logger = logging.getLogger(__name__)
+
+# The subset of canon metrics cheap and deterministic enough to self-correct on.
+_GUARD_CHECKS = (
+    check_scaffolding_leak,
+    check_name_arc,
+    check_canon_fact,
+    check_required_artifact,
+    check_timeline_age,
+)
+
+
+def _wrap_chapter(chapter_number: int, chapter_title: str, prose: str) -> str:
+    """Wrap a single chapter's prose in the minimal markdown the metrics parse."""
+    return f"## Final Story\n\n### Chapter {chapter_number}: {chapter_title}\n\n{prose}\n"
+
+
+def chapter_violations(
+    prose: str, canon, chapter_number: int, chapter_title: str = "Untitled"
+) -> list[Finding]:
+    """Return the hard (severity=fail) canon violations in one chapter's prose."""
+    text = _wrap_chapter(chapter_number, chapter_title, prose)
+    out: list[Finding] = []
+    for check in _GUARD_CHECKS:
+        out.extend(f for f in check(text, canon) if f.severity == "fail")
+    return out
+
+
+def format_feedback(violations: list[Finding]) -> str:
+    """Render violations as revise-step feedback."""
+    lines = ["The draft violates these canon constraints; fix every one:"]
+    lines += [f"- {f.message}" for f in violations]
+    return "\n".join(lines)
+
+
+def revise_chapter(prose: str, feedback: str, canon_directives: str = "") -> str:
+    """Ask the configured LM to rewrite the prose so it satisfies the constraints.
+
+    Kept verbatim where possible: the revise must only fix the listed violations,
+    not rewrite the chapter wholesale.
+    """
+    import dspy
+
+    class ReviseChapterForCanon(dspy.Signature):
+        """Rewrite the chapter prose so it satisfies the canon constraints.
+
+        You are given a drafted chapter, the canon directives in force, and a
+        list of specific constraint violations. Fix every listed violation while
+        preserving the chapter's events, tone, and length as much as possible —
+        change only what is needed (a contradicting detail, a not-yet-allowed
+        name, leaked planning vocabulary, a missing required element). Return the
+        full corrected chapter prose, nothing else.
+        """
+
+        canon_directives: str = dspy.InputField(desc="Canon rules in force this chapter")
+        violations: str = dspy.InputField(desc="The specific violations to fix")
+        prose: str = dspy.InputField(desc="The drafted chapter prose")
+        revised_prose: str = dspy.OutputField(desc="Corrected chapter prose")
+
+    revise = dspy.ChainOfThought(ReviseChapterForCanon)
+    return revise(
+        canon_directives=canon_directives,
+        violations=feedback,
+        prose=prose,
+    ).revised_prose
+
+
+def draft_with_canon_guard(
+    draft_fn: Callable[[], str],
+    canon,
+    chapter_number: int,
+    chapter_title: str = "Untitled",
+    canon_directives: str = "",
+    max_revisions: int = 2,
+) -> str:
+    """Draft a chapter, then critique-and-revise until it satisfies the cheap
+    deterministic canon constraints (or ``max_revisions`` is exhausted).
+
+    ``draft_fn`` is a zero-arg callable returning the initial prose. With an
+    empty canon there are no constraints, so the draft is returned unchanged.
+    """
+    prose = draft_fn()
+    for attempt in range(1, max_revisions + 1):
+        violations = chapter_violations(prose, canon, chapter_number, chapter_title)
+        if not violations:
+            return prose
+        logger.info(
+            "canon_guard ch.%d attempt %d: %d violation(s); revising",
+            chapter_number, attempt, len(violations),
+        )
+        try:
+            prose = revise_chapter(prose, format_feedback(violations), canon_directives)
+        except Exception as exc:  # an LM/revise failure must not kill the run
+            logger.warning("canon_guard ch.%d revise failed: %s", chapter_number, exc)
+            return prose
+    residual = chapter_violations(prose, canon, chapter_number, chapter_title)
+    if residual:
+        logger.warning(
+            "canon_guard ch.%d: %d violation(s) remain after %d revision(s)",
+            chapter_number, len(residual), max_revisions,
+        )
+    return prose

--- a/canon_metrics.py
+++ b/canon_metrics.py
@@ -1,0 +1,336 @@
+"""Deterministic canon/continuity metrics.
+
+Pure functions over a story's markdown text plus a :class:`canon.Canon`. They
+mirror :mod:`qa`'s contract exactly — each returns ``list[qa.Finding]`` with
+``severity`` in ``{"info", "warn", "fail"}`` — so they fold into the same
+info/warn/fail report and the same post-generation gate. Unlike :mod:`qa`'s
+checks (which read the manuscript alone), these are parameterised by the canon
+config, which encodes the rules that span chapters.
+
+Each metric here is the GUARD half of an intervention whose PREVENT half lives in
+:func:`canon.render_chapter_slice` (see ``docs/canon-schema.md``):
+
+* :func:`check_scaffolding_leak`   — planning/production vocab in prose.
+* :func:`check_name_arc`           — a name used before its allowed chapter.
+* :func:`check_canon_fact`         — appearance contradicting locked_appearance.
+* :func:`check_required_artifact`  — a chapter missing its required artifact.
+* :func:`check_timeline_age`       — a year-span that can't fit the timeline.
+"""
+from __future__ import annotations
+
+import re
+
+from qa import Finding, split_chapters
+
+# Number words 0-20 plus the round tens, enough to read narrated year-spans.
+_NUMBER_WORDS: dict[str, int] = {
+    "zero": 0, "one": 1, "two": 2, "three": 3, "four": 4, "five": 5, "six": 6,
+    "seven": 7, "eight": 8, "nine": 9, "ten": 10, "eleven": 11, "twelve": 12,
+    "thirteen": 13, "fourteen": 14, "fifteen": 15, "sixteen": 16,
+    "seventeen": 17, "eighteen": 18, "nineteen": 19, "twenty": 20,
+    "thirty": 30, "forty": 40, "fifty": 50,
+}
+
+_CHAPTER_NUM_RE = re.compile(r"chapter\s+(\d+)", re.IGNORECASE)
+# A year-span phrase: "<number> years" optionally lead by next/another/over/etc.
+_SPAN_RE = re.compile(
+    r"\b(\d+|" + "|".join(_NUMBER_WORDS) + r")\s+years\b",
+    re.IGNORECASE,
+)
+
+
+def _chapter_number(title: str) -> int | None:
+    """Extract the integer N from a ``Chapter N: ...`` heading label."""
+    m = _CHAPTER_NUM_RE.search(title)
+    return int(m.group(1)) if m else None
+
+
+def _numbered_chapters(text: str) -> list[tuple[int, str, str]]:
+    """Return ``(number, title, body)`` for chapters with a parseable number."""
+    out: list[tuple[int, str, str]] = []
+    for title, body in split_chapters(text).items():
+        n = _chapter_number(title)
+        if n is not None:
+            out.append((n, title, body))
+    return out
+
+
+def _mask_devices(body: str, device_allowlist: list[str]) -> str:
+    """Blank out any sanctioned device phrase so a blocklist hit inside it is not
+    counted as a scaffolding leak."""
+    masked = body
+    for phrase in device_allowlist:
+        masked = re.sub(re.escape(phrase), " ", masked, flags=re.IGNORECASE)
+    return masked
+
+
+# --- metric 1: scaffolding leak ---------------------------------------------
+
+def check_scaffolding_leak(text: str, canon) -> list[Finding]:
+    """Fail prose that contains planning/production vocabulary.
+
+    Device-allowlist phrases are masked first, so an intentional meta-narrative
+    device ("The reader sees her stand.") is not flagged even though it contains
+    a blocked token.
+    """
+    patterns = [re.compile(p, re.IGNORECASE) for p in canon.scaffolding_blocklist]
+    if not patterns:
+        return []
+
+    findings: list[Finding] = []
+    leaks = 0
+    for title, body in split_chapters(text).items():
+        masked = _mask_devices(body, canon.device_allowlist)
+        for pat in patterns:
+            for m in pat.finditer(masked):
+                leaks += 1
+                findings.append(Finding(
+                    check="scaffolding_leak",
+                    severity="fail",
+                    message=f"chapter '{title}' leaks scaffolding vocabulary: {m.group(0)!r}",
+                ))
+    if leaks == 0:
+        findings.append(Finding(
+            check="scaffolding_leak",
+            severity="info",
+            message="no scaffolding vocabulary in chapter prose",
+        ))
+    return findings
+
+
+# --- metric 2: name-arc ordering --------------------------------------------
+
+def _quoted_spans(body: str) -> list[str]:
+    """Return the contents of quoted spans (straight or curly double quotes)."""
+    return re.findall(r"[\"“]([^\"”]+)[\"”]", body)
+
+
+def check_name_arc(text: str, canon) -> list[Finding]:
+    """Fail a name that appears before the chapter it is allowed in.
+
+    Two rules, both from ``canon.name_arc``:
+
+    * ``earliest_narration``: a name may not appear anywhere in a chapter whose
+      number is below its earliest chapter.
+    * ``reveal_rules``: a specific speaker may only utter a name from a given
+      chapter onward (detected as the name inside a quoted span in a chapter
+      where that speaker is present).
+    """
+    arc = canon.name_arc or {}
+    earliest = arc.get("earliest_narration", {})
+    reveal_rules = arc.get("reveal_rules", [])
+    if not earliest and not reveal_rules:
+        return []
+
+    chapters = _numbered_chapters(text)
+    findings: list[Finding] = []
+
+    for number, title, body in chapters:
+        for name, first_ch in earliest.items():
+            if number >= int(first_ch):
+                continue
+            if re.search(rf"\b{re.escape(name)}\b", body):
+                findings.append(Finding(
+                    check="name_arc",
+                    severity="fail",
+                    message=(
+                        f"chapter '{title}' uses the name '{name}' but it is not "
+                        f"allowed until chapter {first_ch}"
+                    ),
+                ))
+
+    for rule in reveal_rules:
+        speaker = rule.get("speaker", "")
+        name = rule.get("name", "")
+        from_ch = int(rule.get("from_chapter", 0))
+        if not speaker or not name:
+            continue
+        for number, title, body in chapters:
+            if number >= from_ch:
+                continue
+            if not re.search(rf"\b{re.escape(speaker)}\b", body):
+                continue
+            said = any(re.search(rf"\b{re.escape(name)}\b", q) for q in _quoted_spans(body))
+            if said:
+                findings.append(Finding(
+                    check="name_arc",
+                    severity="fail",
+                    message=(
+                        f"chapter '{title}': {speaker} says '{name}' but may not "
+                        f"until chapter {from_ch}"
+                    ),
+                ))
+
+    if not findings:
+        findings.append(Finding(
+            check="name_arc",
+            severity="info",
+            message="name-arc ordering respected",
+        ))
+    return findings
+
+
+# --- metric 3: canon-fact contradiction (locked appearance) -----------------
+
+_NEGATION_RE = re.compile(r"\b(no|not|never|n't|without)\b", re.IGNORECASE)
+
+
+def check_canon_fact(text: str, canon) -> list[Finding]:
+    """Fail prose whose protagonist appearance contradicts ``locked_appearance``.
+
+    For each locked feature (e.g. eyes=grey) the canon lists contradicting
+    adjectives (blue, green, ...). A contradiction within a single clause of the
+    feature word ("his blue eyes", "eyes were blue") is a FAIL — unless negated
+    ("not blue eyes"), which is consistent.
+    """
+    proto = (canon.locked_appearance or {}).get("protagonist", {})
+    contradictions = proto.get("contradictions", {}) if proto else {}
+    if not contradictions:
+        return []
+
+    prose = "\n\n".join(split_chapters(text).values())
+    findings: list[Finding] = []
+    seen: set[tuple[str, str]] = set()
+
+    for feature, bad_values in contradictions.items():
+        correct = proto.get(feature, "")
+        for bad in bad_values:
+            # Two unambiguous shapes, both kept inside a single clause so an
+            # adjacent feature doesn't borrow another feature's colour
+            # ("grey eyes ... brown hair"):
+            #   - attributive: "blue eyes", "blue glittering eyes"
+            #   - predicate:   "eyes were (a deep) green"
+            patterns = [
+                rf"\b{re.escape(bad)}\b(?:\s+\w+){{0,2}}\s+\b{re.escape(feature)}\b",
+                rf"\b{re.escape(feature)}\b\s+"
+                rf"(?:were|was|are|is|looked|seemed|appeared|turned|shone|"
+                rf"gleamed|glowed|remained|stayed|gone)\b"
+                rf"[^.;,\n]{{0,15}}\b{re.escape(bad)}\b",
+            ]
+            for pat in patterns:
+                for m in re.finditer(pat, prose, re.IGNORECASE):
+                    window = prose[max(0, m.start() - 12): m.start()]
+                    if _NEGATION_RE.search(window):
+                        continue
+                    key = (feature, bad)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    findings.append(Finding(
+                        check="canon_fact",
+                        severity="fail",
+                        message=(
+                            f"appearance contradicts locked {feature}='{correct}': "
+                            f"prose says {feature} are/were '{bad}' ({m.group(0).strip()!r})"
+                        ),
+                    ))
+
+    if not findings:
+        findings.append(Finding(
+            check="canon_fact",
+            severity="info",
+            message="no locked-appearance contradictions detected",
+        ))
+    return findings
+
+
+# --- metric 4: required-artifact placement ----------------------------------
+
+def check_required_artifact(text: str, canon) -> list[Finding]:
+    """Fail a chapter that is missing its required artifact.
+
+    Only chapters that are present in the manuscript are checked (a not-yet-drafted
+    chapter is not a failure here)."""
+    required = canon.required_artifacts or {}
+    if not required:
+        return []
+
+    by_number = {n: (title, body) for n, title, body in _numbered_chapters(text)}
+    findings: list[Finding] = []
+    checked = 0
+    for chapter_n, spec in required.items():
+        if chapter_n not in by_number:
+            continue
+        checked += 1
+        title, body = by_number[chapter_n]
+        patterns = spec.get("patterns", []) or [spec.get("name", "")]
+        if any(re.search(re.escape(p), body, re.IGNORECASE) for p in patterns if p):
+            continue
+        findings.append(Finding(
+            check="required_artifact",
+            severity="fail",
+            message=(
+                f"chapter '{title}' is missing its required artifact: "
+                f"{spec.get('name', 'artifact')}"
+            ),
+        ))
+    if not findings and checked:
+        findings.append(Finding(
+            check="required_artifact",
+            severity="info",
+            message=f"all {checked} present required artifacts found",
+        ))
+    return findings
+
+
+# --- metric 5: timeline / age span ------------------------------------------
+
+def _word_to_int(token: str) -> int | None:
+    token = token.lower()
+    if token.isdigit():
+        return int(token)
+    return _NUMBER_WORDS.get(token)
+
+
+def check_timeline_age(text: str, canon) -> list[Finding]:
+    """Fail a narrated year-span that cannot fit the canonical timeline.
+
+    The canon's ``timeline.max_total_span_years`` is the longest span the story
+    can express (age 16 -> 21 = 5 years). Any "<N> years" phrase with N greater
+    than that is impossible (e.g. "the next eight years" in a 5-year story)."""
+    timeline = canon.timeline or {}
+    max_span = timeline.get("max_total_span_years")
+    if max_span is None:
+        return []
+    max_span = int(max_span)
+
+    prose = "\n\n".join(split_chapters(text).values())
+    findings: list[Finding] = []
+    for m in _SPAN_RE.finditer(prose):
+        value = _word_to_int(m.group(1))
+        if value is None or value <= max_span:
+            continue
+        findings.append(Finding(
+            check="timeline_age",
+            severity="fail",
+            message=(
+                f"timeline: prose says '{m.group(0)}' but the story spans at most "
+                f"{max_span} years"
+            ),
+        ))
+    if not findings:
+        findings.append(Finding(
+            check="timeline_age",
+            severity="info",
+            message=f"no year-span exceeds the {max_span}-year timeline",
+        ))
+    return findings
+
+
+# --- runner ------------------------------------------------------------------
+
+CHECKS = [
+    check_scaffolding_leak,
+    check_name_arc,
+    check_canon_fact,
+    check_required_artifact,
+    check_timeline_age,
+]
+
+
+def run_all(text: str, canon) -> list[Finding]:
+    """Run every deterministic canon metric and concatenate the findings."""
+    out: list[Finding] = []
+    for check in CHECKS:
+        out.extend(check(text, canon))
+    return out

--- a/core/types.py
+++ b/core/types.py
@@ -83,6 +83,10 @@ class DraftingInput:
     chapters_plan: list[PlanEntry]
     output_file: str
     number_of_chapters: int
+    # The shared canon/continuity config (canon.Canon). Optional and typed as
+    # `object` to keep core dependency-free; generators that use it import the
+    # concrete type. `None` -> generators run canon-free.
+    canon: object | None = None
 
 
 @dataclass

--- a/docs/canon-schema.md
+++ b/docs/canon-schema.md
@@ -1,0 +1,84 @@
+# Canon / continuity config — schema & intervention map
+
+`story_writer` turns a story idea into a multi-chapter manuscript. A manual,
+chapter-by-chapter continuity review of one generated manuscript surfaced a set
+of recurring failure modes — names appearing before they should, the
+protagonist's eye colour flipping, planning vocabulary leaking into prose,
+timeline spans that don't add up, required artifacts going missing. This config
+encodes the **rules that span chapters** as DATA so that *one* source of truth
+both PREVENTS those failures at generation time and SCORES/GATES them at
+evaluation time.
+
+* **The schema is generic/per-project.** The pipeline writes other stories from
+  other ideas; only the *values* are story-specific.
+* **The instance** lives in `canon/<project>.yaml` (e.g.
+  `canon/nameless_weapon.yaml`). YAML or JSON are both accepted.
+* **The loader** is `canon.load_canon(path)` → `canon.Canon`.
+* **Generation reads** `canon.render_chapter_slice(canon, chapter_number)`.
+* **Evaluation reads** the `Canon` object directly:
+  - deterministic metrics: `canon_metrics.py`
+  - LM-judge metrics: `bench/judge.py`
+
+## Schema
+
+| Key | Shape | Consumed by |
+|---|---|---|
+| `project`, `title` | str | metadata |
+| `narration.pov_rule` | str | slice (POV instruction) |
+| `timeline.max_total_span_years` | int | `check_timeline_age` |
+| `timeline.year_to_age` | {year_code:int → age:int} | slice / reference |
+| `timeline.year_codes` | {code → {year, note}} | reference |
+| `timeline.key_spans` | list of {from_code, to_code, years, note} | reference |
+| `name_arc.earliest_narration` | {name → earliest chapter int} | slice + `check_name_arc` |
+| `name_arc.learned` | {name → chapter int} | reference |
+| `name_arc.reveal_rules` | list of {speaker, name, from_chapter} | `check_name_arc` |
+| `name_arc.call_order` | {chapter int → [name, …]} | reference / judge |
+| `locked_appearance.protagonist` | {eyes, hair, hair_style, build, permanent_marks, principle, contradictions} | slice + `check_canon_fact` + judge |
+| `required_artifacts` | {chapter int → {name, patterns:[…]}} | slice + `check_required_artifact` |
+| `canon_invariants` | list of {id, rule, after_chapter?} | slice + judge |
+| `accepted_aliases` | {spoken form → canonical} | name-drift metrics |
+| `motif_allowlist` | list of sanctioned refrains | phrase-reuse metrics |
+| `scaffolding_blocklist` | list of regex (case-insensitive) | slice + `check_scaffolding_leak` |
+| `device_allowlist` | list of sanctioned meta-narrative phrases | `check_scaffolding_leak` |
+
+`locked_appearance.protagonist.contradictions` maps each locked feature to the
+adjectives that would contradict it (e.g. `eyes: [blue, green, …]`), which is
+what the canon-fact metric scans for.
+
+## Intervention map (finding → PREVENT → GUARD)
+
+Every finding is wired both ways: a generation-time injection that prevents it,
+and a metric that guards it in eval.
+
+| Finding (from the review) | PREVENT — injected into | GUARD — metric | Kind |
+|---|---|---|---|
+| Scaffolding vocab in prose ("Ch.19", "Beat 3", "POV", "the reader") | per-chapter draft slice + critic→revise (`canon_guard`) | `check_scaffolding_leak` | deterministic |
+| A name used before its allowed chapter (Elias ≥ Ch.7, Severin ≥ Ch.11; Marta says "Elias" only from Ch.17) | slice "names not yet revealed" + revise | `check_name_arc` | deterministic |
+| Appearance contradicts locked anchor ("blue eyes" vs grey) | slice locked-appearance + revise | `check_canon_fact` | deterministic |
+| Required artifact missing (hymn Ch.4, bard song Ch.12) | slice "required this chapter" + revise | `check_required_artifact` | deterministic |
+| Timeline/age span impossible ("the next eight years", span 5) | slice timeline facts | `check_timeline_age` | deterministic |
+| Protagonist barely physically described | slice "ground the POV character physically" step | `judge.appearance_described` + `appearance_vs_spec` | LM |
+| Azazel on the surface after Ch.11 | slice canon invariant | `judge.azazel_maw` | LM |
+| Command-of-the-Void leash not fraying through Acts IV–V | slice canon invariant | `judge.leash_fray` | LM |
+| Kira reduced to a strawman | slice canon invariant | `judge.kira_not_strawman` | LM |
+| POV discipline | slice POV rule | `pov_check` / `judge.pov` | LM |
+| Dangling setup/payoff | — | `judge.dangling_payoff` | LM |
+
+`accepted_aliases`, `motif_allowlist`, and `device_allowlist` are *anti–false-positive*
+data: the metrics read them so that a spelled-out "Vessel Eighty-Four", a
+sanctioned refrain, or the device "The reader sees her stand." is not mistaken
+for drift / reuse / a scaffolding leak.
+
+## Layers
+
+* **Layer A — PREVENT (generation):** `canon.render_chapter_slice` is injected
+  into the per-chapter drafting signatures; `canon_guard` rejects drafts that
+  violate the cheap deterministic constraints and revises with the violation as
+  feedback.
+* **Layer B — OPTIMIZE (eval/optimizer):** `canon_metrics` + `bench/judge` are
+  composed into a weighted metric (`bench/metric.py`) used by `dspy.Evaluate`
+  and an optimizer over a regression set seeded with the real bugs as gold
+  negatives.
+* **Layer C — CATCH (post-gen gate):** the same `canon_metrics` code runs in
+  `bench/criteria.score` and reports through `qa.py`'s info/warn/fail buckets
+  with thresholds.

--- a/generators/baseline.py
+++ b/generators/baseline.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 
+import canon as canon_mod
 from core.artifact import update_artifact
 from core.types import DraftedChapter, DraftingInput, DraftingOutput
 from generators import register
@@ -32,6 +33,7 @@ class Baseline:
         chapters: list[DraftedChapter] = []
         story_so_far = ""
         total = len(inp.chapters_plan)
+        canon = inp.canon if inp.canon is not None else canon_mod.Canon()
         for i, ch in enumerate(inp.chapters_plan, 1):
             chapter_plan_str = f"{ch.chapter_title}\n{ch.chapter_beats}"
             prose = run_enhance_chapter(
@@ -43,6 +45,9 @@ class Baseline:
                 story_so_far,
                 chapter_index=i,
                 total_chapters=total,
+                canon=canon,
+                canon_directives=canon_mod.render_chapter_slice(canon, i),
+                chapter_title=ch.chapter_title,
             )
             update_artifact(
                 inp.output_file, f"Chapter {i}: {ch.chapter_title}", prose, level=3,

--- a/generators/dspy_module.py
+++ b/generators/dspy_module.py
@@ -19,7 +19,9 @@ import logging
 
 import dspy
 
+import canon as canon_mod
 from _compat import observe
+from canon_guard import draft_with_canon_guard
 from core.artifact import update_artifact
 from core.foundation import act_hint_for_chapter
 from core.types import DraftedChapter, DraftingInput, DraftingOutput
@@ -47,22 +49,31 @@ class DspyModuleGenerator:
         update_artifact(inp.output_file, "Final Story", "", level=2)
         chapters: list[DraftedChapter] = []
         total = len(inp.chapters_plan)
+        canon = inp.canon if inp.canon is not None else canon_mod.Canon()
         for i, ch in enumerate(inp.chapters_plan, 1):
             hint = act_hint_for_chapter(i, total, inp.spine)
+            directives = canon_mod.render_chapter_slice(canon, i)
             logger.info("draft_chapter[%d/%d] | %s", i, total, ch.chapter_title)
-            result = self._draft(
-                story_idea=inp.idea,
-                story_title=inp.title,
-                story_spine=hint["spine_through_act"],
-                act_hint=hint["label"],
-                world_bible=inp.world_bible,
-                chapter=f"{ch.chapter_title}\n{ch.chapter_beats}",
+
+            def _draft(_i=i, _ch=ch, _hint=hint, _directives=directives) -> str:
+                return self._draft(
+                    story_idea=inp.idea,
+                    story_title=inp.title,
+                    story_spine=_hint["spine_through_act"],
+                    act_hint=_hint["label"],
+                    world_bible=inp.world_bible,
+                    chapter=f"{_ch.chapter_title}\n{_ch.chapter_beats}",
+                    canon_directives=_directives,
+                ).prose
+
+            prose = draft_with_canon_guard(
+                _draft, canon, i, ch.chapter_title, directives,
             )
             update_artifact(
-                inp.output_file, f"Chapter {i}: {ch.chapter_title}", result.prose, level=3,
+                inp.output_file, f"Chapter {i}: {ch.chapter_title}", prose, level=3,
             )
             chapters.append(
-                DraftedChapter(chapter_title=ch.chapter_title, prose=result.prose),
+                DraftedChapter(chapter_title=ch.chapter_title, prose=prose),
             )
 
         return DraftingOutput(chapters=chapters, continuity_artifact=None)

--- a/generators/world_state.py
+++ b/generators/world_state.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 
+import canon as canon_mod
 from core.artifact import update_artifact
 from core.types import DraftedChapter, DraftingInput, DraftingOutput, render_world_state
 from generators import register
@@ -41,6 +42,7 @@ class WorldStateGenerator:
         chapters: list[DraftedChapter] = []
         per_chapter_states = []
         total = len(inp.chapters_plan)
+        canon = inp.canon if inp.canon is not None else canon_mod.Canon()
         for i, ch in enumerate(inp.chapters_plan, 1):
             chapter_plan_str = f"{ch.chapter_title}\n{ch.chapter_beats}"
             prose = run_draft_chapter_with_state(
@@ -52,6 +54,9 @@ class WorldStateGenerator:
                 world_state,
                 chapter_index=i,
                 total_chapters=total,
+                canon=canon,
+                canon_directives=canon_mod.render_chapter_slice(canon, i),
+                chapter_title=ch.chapter_title,
             )
             update_artifact(
                 inp.output_file, f"Chapter {i}: {ch.chapter_title}", prose, level=3,

--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ import os
 
 from dotenv import load_dotenv
 
+import canon as canon_mod
 import generators  # auto-discovers and registers every variant in generators/
 from core.artifact import initialize_artifact, update_artifact
 from core.foundation import (
@@ -83,6 +84,17 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--title", type=str)
     parser.add_argument("--number-of-chapters", type=int, default=7)
     parser.add_argument("--output-file", default=".tmp/story.md")
+    parser.add_argument(
+        "--canon",
+        default=None,
+        help="Path to a canon/continuity config (YAML/JSON). Defaults to the "
+        "project canon if present; omit with --no-canon.",
+    )
+    parser.add_argument(
+        "--no-canon",
+        action="store_true",
+        help="Disable canon injection/guards even if a default canon exists.",
+    )
     return parser
 
 
@@ -165,6 +177,8 @@ def run_pipeline(args: argparse.Namespace) -> None:
             args.strategy,
         )
 
+    canon = None if args.no_canon else canon_mod.load_canon(args.canon)
+
     output = entry.cls().draft(
         DraftingInput(
             idea=updated_idea,
@@ -174,6 +188,7 @@ def run_pipeline(args: argparse.Namespace) -> None:
             chapters_plan=chapters_plan,
             output_file=args.output_file,
             number_of_chapters=args.number_of_chapters,
+            canon=canon,
         )
     )
     logger.info(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ dspy-ai
 rich
 python-dotenv
 langfuse
+pyyaml

--- a/scripts/optimize_canon_pipeline.py
+++ b/scripts/optimize_canon_pipeline.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Optimize the chapter drafter against the canon/continuity metric.
+
+Wires the composite per-chapter metric (`bench.metric.make_chapter_metric`) into
+`dspy.Evaluate` and a `BootstrapFewShot` optimizer so prompts/demos are tuned to
+reduce the real continuity failures. The optimizer COMPILE step needs a
+configured LM (an API key / endpoint); the trainset, program, metric, and
+evaluator are all built without one, so the wiring is unit-testable in CI and
+the live run is invoked explicitly by the user::
+
+    python scripts/optimize_canon_pipeline.py --model openai/gpt-4o-mini \\
+        --output .tmp/dspy_optimized/chapter_drafter.json
+
+Without ``--model``/credentials the script builds everything and reports that no
+LM is configured rather than attempting a (failing) compile.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+from pathlib import Path
+
+import dspy
+from dotenv import load_dotenv
+
+import canon as canon_mod
+from bench.metric import make_chapter_metric
+from core.foundation import act_hint_for_chapter
+from core.types import WorldBible
+from dspy_runtime import DSPyConfig, configure_dspy
+from story_module import DraftChapter
+
+logger = logging.getLogger(__name__)
+
+_DRAFT_INPUTS = (
+    "story_idea", "story_title", "story_spine", "act_hint",
+    "world_bible", "chapter", "canon_directives",
+)
+
+
+class ChapterDrafter(dspy.Module):
+    """Single-stage program: draft one chapter from its plan + canon directives."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.draft = dspy.ChainOfThought(DraftChapter)
+
+    def forward(self, **kwargs):
+        return self.draft(**kwargs)
+
+
+def _stub_world_bible(canon: canon_mod.Canon) -> WorldBible:
+    return WorldBible(
+        story_title=canon.title or "Untitled",
+        rules_of_the_world=["Power has a physical cost."],
+        characters=["The protagonist — grey eyes, brown nape-braid, a right-cheek scar."],
+        locations=["The Maw — a sealed pit below the city."],
+        timeline=["Year 0: flight. Year 5: the end."],
+    )
+
+
+def build_trainset(canon: canon_mod.Canon, total_chapters: int = 15) -> list[dspy.Example]:
+    """Build a small trainset of per-chapter drafting tasks seeded from the canon.
+
+    Each example carries the DraftChapter inputs plus the ``chapter_number`` /
+    ``chapter_title`` / ``canon`` the per-chapter metric needs. Chapters with a
+    required artifact or a name-arc boundary are favoured so the optimizer is
+    pushed on the constraints that actually fail.
+    """
+    world_bible = _stub_world_bible(canon)
+    spine = "Once upon a time...\nUntil one day...\nUntil finally..."
+    focus_chapters = sorted({4, 7, 11, 12, 17, *canon.required_artifacts})
+    examples: list[dspy.Example] = []
+    for number in focus_chapters:
+        if number > total_chapters:
+            continue
+        hint = act_hint_for_chapter(number, total_chapters, spine)
+        directives = canon_mod.render_chapter_slice(canon, number)
+        ex = dspy.Example(
+            story_idea="A weapon raised as a person learns its own name.",
+            story_title=canon.title or "Untitled",
+            story_spine=hint["spine_through_act"],
+            act_hint=hint["label"],
+            world_bible=world_bible,
+            chapter=f"Chapter {number}\nA pivotal scene unfolds.",
+            canon_directives=directives,
+            chapter_number=number,
+            chapter_title=f"Chapter {number}",
+            canon=canon,
+        ).with_inputs(*_DRAFT_INPUTS)
+        examples.append(ex)
+    return examples
+
+
+def build_optimizer(canon: canon_mod.Canon, threshold: float = 1.0):
+    """Construct the BootstrapFewShot optimizer bound to the per-chapter metric."""
+    from dspy.teleprompt import BootstrapFewShot
+
+    metric = make_chapter_metric(canon, threshold=threshold)
+    return BootstrapFewShot(metric=metric, max_bootstrapped_demos=4, max_labeled_demos=0)
+
+
+def build_evaluator(trainset, canon: canon_mod.Canon):
+    """A dspy.Evaluate over the trainset using the (float) per-chapter metric."""
+    return dspy.Evaluate(
+        devset=trainset,
+        metric=make_chapter_metric(canon),
+        num_threads=1,
+        display_progress=True,
+    )
+
+
+def parse_args(argv=None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--canon", default=None, help="Canon config path (YAML/JSON).")
+    parser.add_argument("--model", default=os.environ.get("MODEL"))
+    parser.add_argument("--provider", default="ollama")
+    parser.add_argument("--api-key", default=os.environ.get("API_KEY"))
+    parser.add_argument("--max-tokens", type=int, default=4096)
+    parser.add_argument("--num-ctx", type=int, default=16384)
+    parser.add_argument("--threshold", type=float, default=1.0)
+    parser.add_argument("--output", type=Path, default=Path(".tmp/dspy_optimized/chapter_drafter.json"))
+    parser.add_argument("-v", "--verbose", action="count", default=0)
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    load_dotenv()
+    args = parse_args(argv)
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
+
+    canon = canon_mod.load_canon(args.canon)
+    trainset = build_trainset(canon)
+    program = ChapterDrafter()
+    logger.info("built program + trainset (%d examples)", len(trainset))
+
+    if not args.model:
+        logger.warning(
+            "no --model/MODEL configured; built the optimizer wiring but skipping "
+            "the live compile. Re-run with a model to optimize."
+        )
+        return 0
+
+    model_name = args.model if "/" in args.model else f"{args.provider}/{args.model}"
+    configure_dspy(DSPyConfig(
+        model_name=model_name, api_key=args.api_key,
+        max_tokens=args.max_tokens, num_ctx=args.num_ctx,
+    ))
+
+    evaluator = build_evaluator(trainset, canon)
+    logger.info("baseline score: %s", evaluator(program))
+
+    optimizer = build_optimizer(canon, threshold=args.threshold)
+    compiled = optimizer.compile(program, trainset=trainset)
+    logger.info("optimized score: %s", evaluator(compiled))
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    compiled.save(str(args.output))
+    logger.info("saved optimized chapter drafter -> %s", args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/story.py
+++ b/story.py
@@ -20,6 +20,8 @@ import dspy
 
 import ui
 from _compat import observe
+from canon import Canon
+from canon_guard import draft_with_canon_guard
 from core.foundation import act_hint_for_chapter
 from core.types import WorldBible
 
@@ -34,6 +36,9 @@ def run_enhance_chapter(
     story_so_far: str,
     chapter_index: int = 1,
     total_chapters: int = 1,
+    canon=None,
+    canon_directives: str = "",
+    chapter_title: str = "",
 ):
     class DraftChapter(dspy.Signature):
         """Write the chapter prose.
@@ -50,6 +55,11 @@ than restating it.
 Write this chapter in a tone appropriate to {act_hint}; do not foreshadow
 events from later acts. The story_spine you receive only covers beats up to
 and including the current act — treat anything beyond it as not yet decided.
+
+Obey canon_directives exactly: ground the point-of-view character physically in
+the locked appearance, keep a single consistent narrative POV, do not use a name
+that is not yet allowed this chapter, include any element required this chapter,
+and never leak planning/production vocabulary into the prose.
 """
         story_idea: str = dspy.InputField()
         story_title: str = dspy.InputField()
@@ -67,6 +77,9 @@ and including the current act — treat anything beyond it as not yet decided.
             desc="Feedback from the user for the chapter",
         )
         story_so_far: str = dspy.InputField(desc="Story so far")
+        canon_directives: str = dspy.InputField(
+            default="", desc="Canon/continuity rules in force for this chapter",
+        )
         prose: str = dspy.OutputField(desc="Chapter prose")
 
     class GenerateRandomDetail(dspy.Signature):
@@ -86,6 +99,7 @@ and including the current act — treat anything beyond it as not yet decided.
 
     hint = act_hint_for_chapter(chapter_index, total_chapters, story_spine)
     spine_for_draft = hint["spine_through_act"]
+    canon = canon if canon is not None else Canon()
 
     random_detail = ""
     random_gen = dspy.ChainOfThought(GenerateRandomDetail)
@@ -104,27 +118,32 @@ and including the current act — treat anything beyond it as not yet decided.
     feedback = ""
     draft_chapter_func = dspy.ChainOfThought(DraftChapter)
     while True:
-        result = draft_chapter_func(
-            story_idea=story_idea,
-            story_title=story_title,
-            story_spine=spine_for_draft,
-            act_hint=hint["label"],
-            rules_of_the_world=world_bible.rules_of_the_world,
-            characters=world_bible.characters,
-            locations=world_bible.locations,
-            timeline=world_bible.timeline,
-            additional_detail_to_include=random_detail,
-            chapter=chapter,
-            feedback=feedback,
-            story_so_far=story_so_far,
-        )
+        def _draft(_feedback=feedback) -> str:
+            return draft_chapter_func(
+                story_idea=story_idea,
+                story_title=story_title,
+                story_spine=spine_for_draft,
+                act_hint=hint["label"],
+                rules_of_the_world=world_bible.rules_of_the_world,
+                characters=world_bible.characters,
+                locations=world_bible.locations,
+                timeline=world_bible.timeline,
+                additional_detail_to_include=random_detail,
+                chapter=chapter,
+                feedback=_feedback,
+                story_so_far=story_so_far,
+                canon_directives=canon_directives,
+            ).prose
 
+        prose = draft_with_canon_guard(
+            _draft, canon, chapter_index, chapter_title or chapter, canon_directives,
+        )
         feedback, is_correct = ui.review_answer(
             "Drafted Chapter:",
-            result.prose,
+            prose,
         )
         if is_correct:
-            return result.prose
+            return prose
 
 
 @observe()

--- a/story_module.py
+++ b/story_module.py
@@ -62,6 +62,11 @@ class DraftChapter(dspy.Signature):
     Write in a tone appropriate to act_hint and do not foreshadow events from
     later acts — the story_spine you receive only covers beats up to and
     including the current act, so treat anything beyond it as not yet decided.
+
+    Obey canon_directives exactly: ground the point-of-view character physically
+    in the locked appearance, keep a single consistent narrative POV, do not use
+    a name that is not yet allowed this chapter, include any element required
+    this chapter, and never leak planning/production vocabulary into the prose.
     """
 
     story_idea: str = dspy.InputField()
@@ -74,6 +79,9 @@ class DraftChapter(dspy.Signature):
     )
     world_bible: WorldBible = dspy.InputField(desc="Reference canon, not to be quoted")
     chapter: str = dspy.InputField(desc="This chapter's title and beats")
+    canon_directives: str = dspy.InputField(
+        default="", desc="Canon/continuity rules in force for this chapter",
+    )
     prose: str = dspy.OutputField(desc="Chapter prose")
 
 

--- a/test_canon_guard.py
+++ b/test_canon_guard.py
@@ -1,0 +1,93 @@
+"""Tests for the generation-time canon injection + self-correction.
+
+The critic (chapter_violations) and the slice renderer are deterministic and
+tested without an LM. The revise step (revise_chapter) needs an LM and is
+exercised only indirectly via draft_with_canon_guard's no-violation short
+circuit and its non-LM failure handling.
+"""
+import canon as canon_mod
+import canon_guard as cg
+
+CANON = canon_mod.load_canon(canon_mod.DEFAULT_CANON_PATH)
+
+
+# --- critic ------------------------------------------------------------------
+
+def test_chapter_violations_flags_scaffolding_and_appearance():
+    prose = "His blue eyes opened. He had no Ch.19 left in him."
+    viols = cg.chapter_violations(prose, CANON, chapter_number=18, chapter_title="Break")
+    checks = {f.check for f in viols}
+    assert "scaffolding_leak" in checks
+    assert "canon_fact" in checks
+
+
+def test_chapter_violations_flags_name_before_allowed():
+    prose = "Severin crossed the courtyard."
+    viols = cg.chapter_violations(prose, CANON, chapter_number=3, chapter_title="Early")
+    assert any(f.check == "name_arc" for f in viols)
+
+
+def test_chapter_violations_clean_chapter_has_none():
+    prose = "Snow fell on the courtyard. His grey eyes watched the gate, and he waited."
+    viols = cg.chapter_violations(prose, CANON, chapter_number=2, chapter_title="Wait")
+    assert viols == []
+
+
+def test_chapter_violations_required_artifact_missing():
+    prose = "They gathered in silence and then dispersed without a sound."
+    viols = cg.chapter_violations(prose, CANON, chapter_number=4, chapter_title="Rite")
+    assert any(f.check == "required_artifact" for f in viols)
+
+
+# --- guard loop --------------------------------------------------------------
+
+def test_guard_returns_draft_unchanged_when_clean():
+    clean = "Snow fell. His grey eyes watched the gate; brown hair at his nape."
+    out = cg.draft_with_canon_guard(
+        lambda: clean, CANON, chapter_number=2, chapter_title="Wait",
+    )
+    assert out == clean
+
+
+def test_guard_noop_under_empty_canon():
+    # Empty canon -> no constraints -> draft returned verbatim even if "dirty".
+    dirty = "His blue eyes. Ch.19. The next eight years."
+    out = cg.draft_with_canon_guard(
+        lambda: dirty, canon_mod.Canon(), chapter_number=1, chapter_title="X",
+    )
+    assert out == dirty
+
+
+def test_guard_returns_original_when_revise_unavailable():
+    # No LM configured here, so revise_chapter raises; the guard must swallow it
+    # and return the (still-violating) draft rather than crash the run.
+    dirty = "His blue eyes opened."
+    out = cg.draft_with_canon_guard(
+        lambda: dirty, CANON, chapter_number=1, chapter_title="X", max_revisions=1,
+    )
+    assert out == dirty
+
+
+# --- slice renderer ----------------------------------------------------------
+
+def test_render_slice_includes_appearance_pov_and_blocked_names():
+    slice_text = canon_mod.render_chapter_slice(CANON, chapter=3)
+    assert "grey" in slice_text                  # locked appearance
+    assert "POINT OF VIEW" in slice_text         # pov rule
+    assert "Severin" in slice_text               # not yet allowed by ch.3
+    assert "SCAFFOLDING" in slice_text
+
+
+def test_render_slice_lists_required_artifact_for_its_chapter():
+    assert "hymn" in canon_mod.render_chapter_slice(CANON, chapter=4)
+    assert "hymn" not in canon_mod.render_chapter_slice(CANON, chapter=5)
+
+
+def test_render_slice_empty_canon_is_blank():
+    assert canon_mod.render_chapter_slice(canon_mod.Canon(), chapter=1) == ""
+
+
+def test_names_allowed_helpers():
+    assert "Severin" in CANON.names_not_yet_allowed(10)
+    assert "Severin" in CANON.names_allowed(11)
+    assert CANON.required_artifact(12)["name"] == "bard song"

--- a/test_canon_metrics.py
+++ b/test_canon_metrics.py
@@ -1,0 +1,154 @@
+"""Unit tests for the deterministic canon metrics.
+
+Seeded with the REAL bugs found in the manual continuity review as gold
+negatives (each must be flagged by exactly the metric named in the brief), plus
+good cases that must stay clean.
+"""
+import canon as canon_mod
+import canon_metrics as cm
+
+CANON = canon_mod.load_canon(canon_mod.DEFAULT_CANON_PATH)
+
+
+def _story(chapters: dict[str, str]) -> str:
+    """Build a minimal story.md fixture with the chapters under ## Final Story."""
+    parts = ["# Story", "", "## World bible", "", "### Characters", "", "## Final Story", ""]
+    for title, body in chapters.items():
+        parts += [f"### {title}", "", body, ""]
+    return "\n".join(parts)
+
+
+def _fails(findings, check):
+    return [f for f in findings if f.check == check and f.severity == "fail"]
+
+
+# --- scaffolding leak --------------------------------------------------------
+
+def test_scaffolding_leak_flags_chapter_reference():
+    # "The breaking was Ch.19's. He had no Ch.19." -> scaffolding-leak FAIL
+    story = _story({"Chapter 18: The Break": "The breaking was Ch.19's. He had no Ch.19."})
+    findings = cm.check_scaffolding_leak(story, CANON)
+    assert _fails(findings, "scaffolding_leak")
+
+
+def test_scaffolding_leak_flags_pov_and_beat():
+    story = _story({"Chapter 2: Plan": "She kept a clear POV. Beat 3 arrived early."})
+    assert _fails(cm.check_scaffolding_leak(story, CANON), "scaffolding_leak")
+
+
+def test_scaffolding_leak_allows_device_phrase():
+    # GOOD: "The reader sees her stand." is sanctioned via device_allowlist
+    story = _story({"Chapter 5: Stand": "The reader sees her stand. She did not move."})
+    findings = cm.check_scaffolding_leak(story, CANON)
+    assert not _fails(findings, "scaffolding_leak")
+    assert any(f.severity == "info" for f in findings)
+
+
+def test_scaffolding_leak_clean_prose_is_info():
+    story = _story({"Chapter 1: Open": "Snow fell on the quiet courtyard and she waited."})
+    findings = cm.check_scaffolding_leak(story, CANON)
+    assert not _fails(findings, "scaffolding_leak")
+
+
+# --- name-arc ----------------------------------------------------------------
+
+def test_name_arc_flags_marta_saying_elias_before_ch17():
+    # Marta says "Elias" in a pre-Ch.17 fixture -> name-arc FAIL
+    story = _story({
+        "Chapter 10: The Warning": 'Marta caught his sleeve. "Elias," she whispered, "run."',
+    })
+    assert _fails(cm.check_name_arc(story, CANON), "name_arc")
+
+
+def test_name_arc_flags_name_before_earliest_narration():
+    # Severin may not appear until ch.11
+    story = _story({"Chapter 3: Early": "Severin walked the long hall alone."})
+    assert _fails(cm.check_name_arc(story, CANON), "name_arc")
+
+
+def test_name_arc_allows_name_after_earliest():
+    story = _story({"Chapter 11: Named": "Severin walked the long hall alone."})
+    assert not _fails(cm.check_name_arc(story, CANON), "name_arc")
+
+
+def test_name_arc_allows_elias_in_narration_after_ch7_when_marta_silent():
+    story = _story({"Chapter 8: After": "Elias crossed the bridge. No one spoke his name."})
+    assert not _fails(cm.check_name_arc(story, CANON), "name_arc")
+
+
+# --- canon-fact (locked appearance) -----------------------------------------
+
+def test_canon_fact_flags_blue_eyes():
+    # "his blue eyes" -> canon-fact FAIL (locked eyes=grey)
+    story = _story({"Chapter 1: Open": "She studied his blue eyes for a long moment."})
+    assert _fails(cm.check_canon_fact(story, CANON), "canon_fact")
+
+
+def test_canon_fact_flags_eyes_were_green():
+    story = _story({"Chapter 2: Look": "His eyes were green in the lamplight."})
+    assert _fails(cm.check_canon_fact(story, CANON), "canon_fact")
+
+
+def test_canon_fact_allows_no_horns_near_protagonist():
+    # GOOD: "No horns" near protagonist -> appearance OK (no transformation)
+    story = _story({"Chapter 1: Open": "No horns, no wings — his grey eyes, the same as ever."})
+    findings = cm.check_canon_fact(story, CANON)
+    assert not _fails(findings, "canon_fact")
+
+
+def test_canon_fact_allows_correct_grey_eyes():
+    story = _story({"Chapter 1: Open": "His grey eyes caught the light; brown hair at his nape."})
+    assert not _fails(cm.check_canon_fact(story, CANON), "canon_fact")
+
+
+# --- required artifact -------------------------------------------------------
+
+def test_required_artifact_flags_missing_hymn_in_ch4():
+    story = _story({"Chapter 4: The Rite": "They gathered in silence and then dispersed."})
+    assert _fails(cm.check_required_artifact(story, CANON), "required_artifact")
+
+
+def test_required_artifact_passes_when_hymn_present():
+    story = _story({"Chapter 4: The Rite": "A low hymn rose from the stalls as they gathered."})
+    assert not _fails(cm.check_required_artifact(story, CANON), "required_artifact")
+
+
+def test_required_artifact_ignores_absent_chapter():
+    # Chapter 4 not in the manuscript -> not a failure.
+    story = _story({"Chapter 1: Open": "Nothing required here."})
+    assert not _fails(cm.check_required_artifact(story, CANON), "required_artifact")
+
+
+# --- timeline / age ----------------------------------------------------------
+
+def test_timeline_flags_eight_year_span():
+    # "...the next eight years" (span=5) -> timeline FAIL
+    story = _story({"Chapter 9: After": "Over the next eight years, the city forgot her."})
+    assert _fails(cm.check_timeline_age(story, CANON), "timeline_age")
+
+
+def test_timeline_allows_five_year_span():
+    story = _story({"Chapter 9: After": "Five years from the flight to the end, no longer."})
+    assert not _fails(cm.check_timeline_age(story, CANON), "timeline_age")
+
+
+def test_timeline_allows_digit_span_within_bounds():
+    story = _story({"Chapter 9: After": "It had been 3 years since the flight."})
+    assert not _fails(cm.check_timeline_age(story, CANON), "timeline_age")
+
+
+# --- runner ------------------------------------------------------------------
+
+def test_run_all_aggregates_and_separates_good_from_bad():
+    bad = _story({
+        "Chapter 4: The Rite": "His blue eyes. The next eight years. He had no Ch.19.",
+    })
+    findings = cm.run_all(bad, CANON)
+    flagged = {f.check for f in findings if f.severity == "fail"}
+    assert {"scaffolding_leak", "canon_fact", "required_artifact", "timeline_age"} <= flagged
+
+
+def test_empty_canon_metrics_are_noops():
+    empty = canon_mod.Canon()
+    story = _story({"Chapter 1: Open": "His blue eyes. Ch.19. The next eight years."})
+    assert cm.run_all(story, empty) == []

--- a/test_judge.py
+++ b/test_judge.py
@@ -1,0 +1,70 @@
+"""Tests for the LM-judge canon metrics — no LM is called; verdicts are injected
+(exactly as pov_check tests pass pre-classified ChapterPOV objects)."""
+import canon as canon_mod
+from bench import judge
+from bench.judge import Verdict
+
+CANON = canon_mod.load_canon(canon_mod.DEFAULT_CANON_PATH)
+
+
+def _story(body: str) -> str:
+    return ("# Story\n\n## World bible\n\n### Characters\n\n## Final Story\n\n"
+            f"### Chapter 12: Test\n\n{body}\n")
+
+
+def test_appearance_described_fail_and_consistency_pass():
+    text = _story("He moved through the hall.")
+    findings = judge.judge_appearance(
+        text, CANON,
+        described=Verdict(holds=False, evidence="no physical detail"),
+        consistent=Verdict(holds=True),
+    )
+    by = {f.check: f for f in findings}
+    assert by["appearance_described"].severity == "fail"
+    assert by["appearance_vs_spec"].severity == "info"
+
+
+def test_appearance_vs_spec_fail():
+    text = _story("His blue eyes shone.")
+    findings = judge.judge_appearance(
+        text, CANON,
+        described=Verdict(holds=True),
+        consistent=Verdict(holds=False, evidence="blue eyes contradict grey"),
+    )
+    by = {f.check: f for f in findings}
+    assert by["appearance_vs_spec"].severity == "fail"
+
+
+def test_invariants_produce_one_finding_per_rule():
+    text = _story("Azazel walked the surface market in the noon sun.")
+    verdicts = {
+        "azazel_maw": Verdict(holds=False, evidence="Azazel on the surface in ch.12"),
+        "leash_fray": Verdict(holds=True),
+        "kira_not_strawman": Verdict(holds=True),
+    }
+    findings = judge.judge_invariants(text, CANON, verdicts=verdicts)
+    by = {f.check: f.severity for f in findings}
+    assert by["azazel_maw"] == "fail"
+    assert by["leash_fray"] == "info"
+    assert by["kira_not_strawman"] == "info"
+
+
+def test_dangling_payoff_is_warn():
+    text = _story("A sealed letter appeared and was never opened.")
+    findings = judge.judge_dangling_payoff(text, verdict=Verdict(holds=False))
+    assert findings[0].check == "dangling_payoff"
+    assert findings[0].severity == "warn"
+
+
+def test_run_all_uses_injected_verdicts():
+    text = _story("He moved through the hall.")
+    verdicts = {
+        "appearance_described": Verdict(holds=True),
+        "appearance_vs_spec": Verdict(holds=True),
+        "azazel_maw": Verdict(holds=True),
+        "leash_fray": Verdict(holds=True),
+        "kira_not_strawman": Verdict(holds=True),
+        "dangling_payoff": Verdict(holds=True),
+    }
+    findings = judge.run_all(text, CANON, verdicts=verdicts)
+    assert findings and all(f.severity == "info" for f in findings)

--- a/test_metric.py
+++ b/test_metric.py
@@ -1,0 +1,60 @@
+"""Tests for the composite story-quality metric (deterministic; no LM)."""
+import canon as canon_mod
+from bench import metric
+from bench.judge import Verdict
+from bench import judge
+
+CANON = canon_mod.load_canon(canon_mod.DEFAULT_CANON_PATH)
+
+
+def _story(body: str, title: str = "Chapter 1: Open") -> str:
+    return ("# Story\n\n## World bible\n\n### Characters\n\n## Final Story\n\n"
+            f"### {title}\n\n{body}\n")
+
+
+def test_clean_story_scores_one():
+    text = _story("Snow fell on the courtyard; his grey eyes watched the gate.")
+    assert metric.score_text(text, CANON) == 1.0
+
+
+def test_each_violation_lowers_score():
+    clean = _story("Snow fell; his grey eyes watched the gate quietly.")
+    dirty = _story("His blue eyes. Ch.19. Over the next eight years.")
+    assert metric.score_text(dirty, CANON) < metric.score_text(clean, CANON)
+    assert metric.score_text(dirty, CANON) >= 0.0
+
+
+def test_score_is_clamped_to_zero():
+    # Pile on enough violations that raw penalty would exceed 1.0.
+    text = _story(
+        "His blue eyes. His green eyes. Ch.19. Beat 3. The reader. "
+        "Over the next eight years.",
+        title="Chapter 4: Rite",  # also missing required hymn artifact
+    )
+    assert 0.0 <= metric.score_text(text, CANON) <= 1.0
+
+
+def test_judge_findings_count_against_score():
+    text = _story("He moved through the hall.")
+    bad_judge = judge.judge_appearance(
+        text, CANON,
+        described=Verdict(holds=False),
+        consistent=Verdict(holds=True),
+    )
+    with_judge = metric.score_text(text, CANON, judge_findings=bad_judge)
+    without = metric.score_text(text, CANON)
+    assert with_judge < without
+
+
+def test_make_story_metric_threshold_returns_bool():
+    m = metric.make_story_metric(CANON, threshold=0.9)
+    clean = _story("Snow fell; his grey eyes watched the gate.")
+    dirty = _story("His blue eyes opened on Ch.19.")
+    assert m(object(), clean) is True
+    assert m(object(), dirty) is False
+
+
+def test_make_story_metric_float_default():
+    m = metric.make_story_metric(CANON)
+    val = m(object(), _story("Snow fell; his grey eyes watched."))
+    assert isinstance(val, float) and val == 1.0

--- a/test_optimize_canon.py
+++ b/test_optimize_canon.py
@@ -1,0 +1,61 @@
+"""Wiring tests for the canon optimizer harness — no LM is configured, so we
+verify the trainset/program/metric/optimizer/evaluator all BUILD and the
+per-chapter metric scores deterministically. The live compile is not exercised.
+"""
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import dspy
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "scripts"))
+
+import canon as canon_mod  # noqa: E402
+import optimize_canon_pipeline as opt  # noqa: E402
+from bench import metric  # noqa: E402
+
+CANON = canon_mod.load_canon(canon_mod.DEFAULT_CANON_PATH)
+
+
+def test_build_trainset_has_examples_with_metric_fields():
+    trainset = opt.build_trainset(CANON)
+    assert trainset
+    ex = trainset[0]
+    assert "story_idea" in ex.inputs()
+    assert "canon_directives" in ex.inputs()
+    assert isinstance(ex.chapter_number, int)
+    # The required-artifact chapter (4) should be among the seeded focus chapters.
+    assert any(e.chapter_number == 4 for e in trainset)
+
+
+def test_build_program_is_a_module():
+    program = opt.ChapterDrafter()
+    assert isinstance(program, dspy.Module)
+
+
+def test_build_optimizer_and_evaluator_construct():
+    optimizer = opt.build_optimizer(CANON, threshold=1.0)
+    assert hasattr(optimizer, "compile")
+    evaluator = opt.build_evaluator(opt.build_trainset(CANON), CANON)
+    assert callable(evaluator)
+
+
+def test_chapter_metric_rewards_clean_prose():
+    m = metric.make_chapter_metric(CANON)
+    clean = SimpleNamespace(prose="Snow fell; his grey eyes watched the gate.")
+    dirty = SimpleNamespace(prose="His blue eyes opened. He had no Ch.19.")
+    ex = SimpleNamespace(chapter_number=2, chapter_title="X", canon=CANON)
+    assert m(ex, clean) == 1.0
+    assert m(ex, dirty) < 1.0
+
+
+def test_chapter_metric_threshold_returns_bool():
+    m = metric.make_chapter_metric(CANON, threshold=1.0)
+    ex = SimpleNamespace(chapter_number=4, chapter_title="Rite", canon=CANON)
+    # Chapter 4 requires the hymn; prose without it should fall below threshold.
+    assert m(ex, SimpleNamespace(prose="They gathered and dispersed in silence.")) is False
+
+
+def test_main_without_model_skips_compile(monkeypatch):
+    monkeypatch.delenv("MODEL", raising=False)
+    assert opt.main(["--canon", str(canon_mod.DEFAULT_CANON_PATH)]) == 0

--- a/test_regression.py
+++ b/test_regression.py
@@ -1,0 +1,32 @@
+"""The regression eval the pipeline must pass: every gold negative is caught by
+its labelled metric, and every good case stays clean."""
+import canon as canon_mod
+from bench import regression
+
+CANON = canon_mod.load_canon(canon_mod.DEFAULT_CANON_PATH)
+
+
+def test_every_gold_negative_is_caught():
+    for case in regression.GOLD_NEGATIVES:
+        passed, detail = regression.evaluate_case(case, CANON)
+        assert passed, f"{case.id}: {detail}"
+
+
+def test_every_good_case_stays_clean():
+    for case in regression.GOOD_CASES:
+        passed, detail = regression.evaluate_case(case, CANON)
+        assert passed, f"{case.id}: {detail}"
+
+
+def test_run_reports_all_pass():
+    all_passed, rows = regression.run(CANON)
+    assert all_passed, [r for r in rows if not r[1]]
+
+
+def test_alias_good_case_would_fail_without_normalization():
+    # Sanity: the alias case is only clean BECAUSE accepted_aliases normalizes it;
+    # without normalization the spelled-out form drifts from canonical "Vessel 84".
+    import qa
+    case = next(c for c in regression.GOOD_CASES if c.id == "alias_eighty_four")
+    raw = qa.check_name_drift(case.text)
+    assert any(f.check == "name_drift" and f.severity == "warn" for f in raw)

--- a/world_state.py
+++ b/world_state.py
@@ -18,10 +18,17 @@ import dspy
 
 import ui
 from _compat import observe
+from canon import Canon
+from canon_guard import draft_with_canon_guard
 from core.foundation import act_hint_for_chapter
 from core.types import WorldBible, WorldState, render_world_state
 
 logger = logging.getLogger(__name__)
+
+
+def _empty_canon() -> Canon:
+    """An empty canon — guards/injection become no-ops."""
+    return Canon()
 
 
 @observe()
@@ -133,6 +140,9 @@ def run_draft_chapter_with_state(
     world_state: WorldState,
     chapter_index: int = 1,
     total_chapters: int = 1,
+    canon=None,
+    canon_directives: str = "",
+    chapter_title: str = "",
 ) -> str:
     """Draft chapter prose from the static world bible plus the current state."""
 
@@ -153,6 +163,11 @@ def run_draft_chapter_with_state(
         Write this chapter in a tone appropriate to {act_hint}; do not foreshadow
         events from later acts. The story_spine you receive only covers beats up to
         and including the current act — treat anything beyond it as not yet decided.
+
+        Obey canon_directives exactly: ground the point-of-view character physically
+        in the locked appearance, keep a single consistent narrative POV, do not use
+        a name that is not yet allowed this chapter, include any element required this
+        chapter, and never leak planning/production vocabulary into the prose.
         """
 
         story_idea: str = dspy.InputField()
@@ -167,23 +182,33 @@ def run_draft_chapter_with_state(
         )
         chapter: str = dspy.InputField()
         feedback: str = dspy.InputField(desc="Feedback from the user for the chapter")
+        canon_directives: str = dspy.InputField(
+            default="", desc="Canon/continuity rules in force for this chapter",
+        )
         prose: str = dspy.OutputField(desc="Chapter prose")
 
     hint = act_hint_for_chapter(chapter_index, total_chapters, story_spine)
+    canon = canon if canon is not None else _empty_canon()
 
     feedback = ""
     draft_func = dspy.ChainOfThought(DraftChapterWithState)
     while True:
-        result = draft_func(
-            story_idea=story_idea,
-            story_title=story_title,
-            story_spine=hint["spine_through_act"],
-            act_hint=hint["label"],
-            world_bible=world_bible,
-            world_state=world_state,
-            chapter=chapter,
-            feedback=feedback,
+        def _draft(_feedback=feedback) -> str:
+            return draft_func(
+                story_idea=story_idea,
+                story_title=story_title,
+                story_spine=hint["spine_through_act"],
+                act_hint=hint["label"],
+                world_bible=world_bible,
+                world_state=world_state,
+                chapter=chapter,
+                feedback=_feedback,
+                canon_directives=canon_directives,
+            ).prose
+
+        prose = draft_with_canon_guard(
+            _draft, canon, chapter_index, chapter_title or chapter, canon_directives,
         )
-        feedback, is_correct = ui.review_answer("Drafted Chapter:", result.prose)
+        feedback, is_correct = ui.review_answer("Drafted Chapter:", prose)
         if is_correct:
-            return result.prose
+            return prose


### PR DESCRIPTION
Introduce a single machine-readable canon/continuity config (canon/) consumed
both by generation and evaluation:

- canon.py: generic per-project schema (Canon) + YAML/JSON loader +
  render_chapter_slice() for generation-time injection.
- canon/nameless_weapon.yaml: the instance (timeline, name_arc,
  locked_appearance, required_artifacts, canon_invariants, accepted_aliases,
  motif_allowlist, scaffolding_blocklist, device_allowlist).
- canon_metrics.py: five deterministic metrics returning qa.Finding
  (scaffolding leak, name-arc ordering, locked-appearance contradiction,
  required-artifact placement, timeline/age) honoring the device_allowlist.
- bench/criteria.py: fold the canon metrics into the ship gate (Layer C).
- test_canon_metrics.py: gold-negative/positive fixtures from the real review.
- docs/canon-schema.md: schema + finding->prevent->guard intervention map.